### PR TITLE
chacha20poly1305: Use 0.1 release of `aead` crate

### DIFF
--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "cipher", "aead", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "0.1", git = "https://github.com/RustCrypto/traits" }
+aead = "0.1"
 chacha20 = { version = "0.2.1", features = ["zeroize"] }
 poly1305 = "0.2"
 zeroize = { version = "0.9", default-features = false }

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -18,7 +18,7 @@ use aead::generic_array::{
     typenum::{U0, U12, U16, U32},
     GenericArray,
 };
-use aead::{Error, NewAead, StatelessAead};
+use aead::{Aead, Error, NewAead, Payload};
 use alloc::vec::Vec;
 use chacha20::{stream_cipher::NewStreamCipher, ChaCha20};
 use zeroize::Zeroize;
@@ -38,27 +38,25 @@ impl NewAead for ChaCha20Poly1305 {
     }
 }
 
-impl StatelessAead for ChaCha20Poly1305 {
+impl Aead for ChaCha20Poly1305 {
     type NonceSize = U12;
     type TagSize = U16;
     type CiphertextOverhead = U0;
 
-    fn encrypt(
+    fn encrypt<'msg, 'aad>(
         &self,
-        associated_data: &[u8],
         nonce: &GenericArray<u8, Self::NonceSize>,
-        plaintext: &[u8],
+        plaintext: impl Into<Payload<'msg, 'aad>>,
     ) -> Result<Vec<u8>, Error> {
-        Cipher::new(ChaCha20::new(&self.key, nonce)).encrypt(associated_data, plaintext)
+        Cipher::new(ChaCha20::new(&self.key, nonce)).encrypt(plaintext.into())
     }
 
-    fn decrypt(
+    fn decrypt<'msg, 'aad>(
         &self,
-        associated_data: &[u8],
         nonce: &GenericArray<u8, Self::NonceSize>,
-        ciphertext: &[u8],
+        ciphertext: impl Into<Payload<'msg, 'aad>>,
     ) -> Result<Vec<u8>, Error> {
-        Cipher::new(ChaCha20::new(&self.key, nonce)).decrypt(associated_data, ciphertext)
+        Cipher::new(ChaCha20::new(&self.key, nonce)).decrypt(ciphertext.into())
     }
 }
 

--- a/chacha20poly1305/src/xchacha20poly1305.rs
+++ b/chacha20poly1305/src/xchacha20poly1305.rs
@@ -5,7 +5,7 @@ use aead::generic_array::{
     typenum::{U0, U16, U24, U32},
     GenericArray,
 };
-use aead::{Error, NewAead, StatelessAead};
+use aead::{Aead, Error, NewAead, Payload};
 use alloc::vec::Vec;
 use chacha20::{stream_cipher::NewStreamCipher, XChaCha20};
 use zeroize::Zeroize;
@@ -43,27 +43,25 @@ impl NewAead for XChaCha20Poly1305 {
     }
 }
 
-impl StatelessAead for XChaCha20Poly1305 {
+impl Aead for XChaCha20Poly1305 {
     type NonceSize = U24;
     type TagSize = U16;
     type CiphertextOverhead = U0;
 
-    fn encrypt(
+    fn encrypt<'msg, 'aad>(
         &self,
-        associated_data: &[u8],
         nonce: &GenericArray<u8, Self::NonceSize>,
-        plaintext: &[u8],
+        plaintext: impl Into<Payload<'msg, 'aad>>,
     ) -> Result<Vec<u8>, Error> {
-        Cipher::new(XChaCha20::new(&self.key, nonce)).encrypt(associated_data, plaintext)
+        Cipher::new(XChaCha20::new(&self.key, nonce)).encrypt(plaintext.into())
     }
 
-    fn decrypt(
+    fn decrypt<'msg, 'aad>(
         &self,
-        associated_data: &[u8],
         nonce: &GenericArray<u8, Self::NonceSize>,
-        ciphertext: &[u8],
+        ciphertext: impl Into<Payload<'msg, 'aad>>,
     ) -> Result<Vec<u8>, Error> {
-        Cipher::new(XChaCha20::new(&self.key, nonce)).decrypt(associated_data, ciphertext)
+        Cipher::new(XChaCha20::new(&self.key, nonce)).decrypt(ciphertext.into())
     }
 }
 


### PR DESCRIPTION
This updates `chacha20poly1305` to switch to the newly released `aead` crate.