### PR TITLE
document the incompatibility with libsodium 'secretbox'

### DIFF
--- a/chacha20poly1305/src/xchacha20poly1305.rs
+++ b/chacha20poly1305/src/xchacha20poly1305.rs
@@ -27,6 +27,10 @@ use zeroize::Zeroize;
 ///
 /// <https://tools.ietf.org/html/draft-arciszewski-xchacha-03>
 ///
+/// It is worth noting that libsodium's default "secretbox" algorithm is
+/// XSalsa20Poly1305, not XChaCha20Poly1305, and thus not compatible with
+/// this library.
+///
 /// The `xchacha20poly1305` Cargo feature must be enabled in order to use this
 /// (which it is by default).
 #[derive(Clone)]


### PR DESCRIPTION
The docs cite libsodium as another implementor of the somewhat underspecified XChaCha20Poly1305 algorithm, but I overinterpreted that as suggesting that this crate was a suitable replacement for libsodium's `secretbox` functionality.

It turns out that libsodium provides *two* algorithms under the "secretbox" category: XSalsa20Poly1305 (the default), and XChaCha20Poly1305 (a newer addition). This crate might be compatible with XChaCha20Poly1305, but alas it is not compatible with XSalsa20Poly1305. (Apparently the key and nonce sizes are the same, so you might not notice a problem until your test vectors fail to match). My library (magic-wormhole) is using `secretbox`, so for backwards compatibility reasons I have to stick with the salsa variant, thwarting my plans to replace my libsodium dependency with this crate.

This just adds a note to the docs to help folks like me in the future.
