### PR TITLE
chacha20poly1305 v0.1.2

### DIFF
--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.1 (2019-09-19)
+## 0.1.2 (2019-10-01)
+### Changed
+- Update to `zeroize` 1.0.0-pre ([#17])
 
+[#17]: https://github.com/RustCrypto/AEADs/pull/17
+
+## 0.1.1 (2019-09-19)
 ### Changed
 - Update to `poly1305` v0.4 ([#8])
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["RustCrypto Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- Update to `zeroize` 1.0.0-pre ([#17])

[#17]: https://github.com/RustCrypto/AEADs/pull/17