### PR TITLE
Upgrade to `universal-hash` crate v0.3

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 aead = "0.1"
 aes = "0.3"
 ctr = "0.3"
-polyval = "0.1"
+polyval = "0.2"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -192,7 +192,7 @@ where
 
     /// Encrypt the given message, allocating a vector for the resulting ciphertext
     pub(crate) fn encrypt(self, payload: Payload<'_, '_>) -> Result<Vec<u8>, Error> {
-        let tag_size = <Polyval as UniversalHash>::OutputSize::to_usize();
+        let tag_size = <Polyval as UniversalHash>::BlockSize::to_usize();
 
         let mut buffer = Vec::with_capacity(payload.msg.len() + tag_size);
         buffer.extend_from_slice(payload.msg);
@@ -219,7 +219,7 @@ where
 
     /// Decrypt the given message, allocating a vector for the resulting plaintext
     pub(crate) fn decrypt(self, payload: Payload<'_, '_>) -> Result<Vec<u8>, Error> {
-        let tag_size = <Polyval as UniversalHash>::OutputSize::to_usize();
+        let tag_size = <Polyval as UniversalHash>::BlockSize::to_usize();
 
         if payload.msg.len() < tag_size {
             return Err(Error);

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 aead = "0.1"
 chacha20 = { version = "0.2.1", features = ["zeroize"] }
-poly1305 = "0.4"
+poly1305 = "0.5"
 zeroize = { version = "1.0.0-pre", default-features = false }
 
 [features]

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -16,5 +16,5 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 aead = "0.1"
 salsa20 = { version = "0.3.0", features = ["xsalsa20", "zeroize"] }
-poly1305 = "0.4"
+poly1305 = "0.5"
 zeroize = { version = "1.0.0-pre", default-features = false }


### PR DESCRIPTION
Upgrades `aes-gcm-siv` to use `polyval` crate v0.2, and the `chacha20poly1305` and `xsalsa20poly1305` crates to use `poly1305` v0.5.

The new `polyval` and `poly1305` crates transitively depend on `universal-hash` v0.3.