### PR TITLE
Expose "detached" in-place encryption/decryption APIs

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -20,6 +20,7 @@ aes = "0.3"
 ctr = "0.3"
 polyval = "0.2"
 subtle = { version = "2", default-features = false }
+zeroize = { version = "1.0.0-pre", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/aes-gcm-siv/src/ctr32.rs
+++ b/aes-gcm-siv/src/ctr32.rs
@@ -32,7 +32,8 @@ where
     C: BlockCipher<BlockSize = U16, ParBlocks = U8>,
 {
     /// Instantiate a new CTR instance
-    pub fn new(cipher: &'c C, mut counter_block: Block128) -> Self {
+    pub fn new(cipher: &'c C, counter_block: &Block128) -> Self {
+        let mut counter_block = *counter_block;
         counter_block[15] |= 0x80;
 
         Self {


### PR DESCRIPTION
Exposes an `encrypt_in_place_detached()` and `decrypt_in_place_detached()` API on all AEAD implementations in this repository.

Until we figure out what the upstream API looks like, this commit at least makes an in-place mode an option for those who don't want to allocate a buffer for every encryption/decryption operation.