### PR TITLE
AES-SIV and AES-PMAC-SIV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "aes-gcm",
     "aes-gcm-siv",
+    "aes-siv",
     "chacha20poly1305",
     "xsalsa20poly1305"
 ]

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "aes-siv"
+version = "0.1.0"
+authors = ["RustCrypto Developers"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+description = "AES-SIV: Misuse-Resistant Authenticated Encryption Cipher (RFC 5297)"
+readme = "README.md"
+documentation = "https://docs.rs/aes-siv"
+repository = "https://github.com/RustCrypto/AEADs"
+keywords = ["aead", "aes", "encryption", "siv"]
+categories = ["cryptography", "no-std"]
+
+[badges]
+maintenance = { status = "passively-maintained" }
+
+[dependencies]
+aead = "0.1"
+aes = "0.3"
+cmac = "0.2"
+crypto-mac = { version = "0.7", default-features = false }
+ctr = "0.3"
+dbl = { version = "0.2", default-features = false }
+pmac = { version = "0.2", optional = true }
+stream-cipher = { version = "0.3", default-features = false }
+zeroize = { version = "1.0.0-pre", default-features = false }
+
+[dev-dependencies]
+subtle-encoding = "0.3"
+serde_json = "1"
+
+[features]
+default = ["alloc"]
+alloc = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/aes-siv/LICENSE-APACHE
+++ b/aes-siv/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/aes-siv/LICENSE-MIT
+++ b/aes-siv/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2019 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/aes-siv/README.md
+++ b/aes-siv/README.md
@@ -1,0 +1,58 @@
+# AES-SIV: Misuse-Resistant Authenticated Encryption Cipher
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+![Maintenance Status: Experimental][maintenance-image]
+[![Build Status][build-image]][build-link]
+
+[AES-SIV][1] ([RFC 5297][2]) is a high-performance
+[Authenticated Encryption with Associated Data (AEAD)][3] cipher which also
+provides [nonce reuse misuse resistance][4].
+
+[Documentation][docs-link]
+
+## Security Warning
+
+No security audits of this crate have ever been performed, and it has not been
+thoroughly assessed to ensure its operation is constant-time on common CPU
+architectures.
+
+USE AT YOUR OWN RISK!
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://decryptsource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/aes-siv.svg
+[crate-link]: https://crates.io/crates/aes-siv
+[docs-image]: https://docs.rs/aes-siv/badge.svg
+[docs-link]: https://docs.rs/aes-siv/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
+[build-image]: https://travis-ci.com/RustCrypto/AEADs.svg?branch=master
+[build-link]: https://travis-ci.com/RustCrypto/AEADs
+
+[//]: # (general links)
+
+[1]: https://github.com/miscreant/meta/wiki/AES-SIV
+[2]: https://tools.ietf.org/html/rfc5297
+[3]: https://en.wikipedia.org/wiki/Authenticated_encryption
+[4]: https://github.com/miscreant/meta/wiki/Nonce-Reuse-Misuse-Resistance
+[5]: https://www.imperialviolet.org/2017/05/14/aesgcmsiv.html
+[6]: https://codahale.com/towards-a-safer-footgun/

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -1,0 +1,168 @@
+//! [AES-SIV][1] ([RFC 5297][2]): high-performance
+//! [Authenticated Encryption with Associated Data (AEAD)][3] cipher which also
+//! provides [nonce reuse misuse resistance][4].
+//!
+//! [1]: https://github.com/miscreant/meta/wiki/AES-SIV
+//! [2]: https://tools.ietf.org/html/rfc5297
+//! [3]: https://en.wikipedia.org/wiki/Authenticated_encryption
+//! [4]: https://github.com/miscreant/meta/wiki/Nonce-Reuse-Misuse-Resistance
+
+#![no_std]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![recursion_limit = "1024"]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
+
+pub use aead;
+
+pub mod siv;
+
+use crate::siv::{Siv, IV_SIZE};
+use aead::generic_array::{
+    typenum::{U0, U16, U32, U64},
+    GenericArray,
+};
+use aead::{AeadMut, Error, NewAead, Payload};
+use aes::{Aes128, Aes256};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+use cmac::Cmac;
+use crypto_mac::Mac;
+use ctr::Ctr128;
+#[cfg(feature = "pmac")]
+use pmac::Pmac;
+use stream_cipher::{NewStreamCipher, SyncStreamCipher};
+
+/// The `SivAead` type wraps the more powerful `Siv` interface in a more
+/// commonly used Authenticated Encryption with Associated Data (AEAD) API,
+/// which accepts a key, nonce, and associated data when encrypting/decrypting.
+pub struct SivAead<C, M>
+where
+    C: NewStreamCipher<NonceSize = U16> + SyncStreamCipher,
+    M: Mac<OutputSize = U16>,
+{
+    siv: Siv<C, M>,
+}
+
+/// SIV AEAD modes based on CMAC
+pub type CmacSivAead<BlockCipher> = SivAead<Ctr128<BlockCipher>, Cmac<BlockCipher>>;
+
+/// SIV AEAD modes based on PMAC
+#[cfg(feature = "pmac")]
+pub type PmacSivAead<BlockCipher> = SivAead<Ctr128<BlockCipher>, Pmac<BlockCipher>>;
+
+/// AES-CMAC-SIV in AEAD mode with 256-bit key size (128-bit security)
+pub type Aes128SivAead = CmacSivAead<Aes128>;
+
+/// AES-CMAC-SIV in AEAD mode with 512-bit key size (256-bit security)
+pub type Aes256SivAead = CmacSivAead<Aes256>;
+
+/// AES-PMAC-SIV in AEAD mode with 256-bit key size (128-bit security)
+#[cfg(feature = "pmac")]
+pub type Aes128PmacSivAead = PmacSivAead<Aes128>;
+
+/// AES-PMAC-SIV in AEAD mode with 512-bit key size (256-bit security)
+#[cfg(feature = "pmac")]
+pub type Aes256PmacSivAead = PmacSivAead<Aes256>;
+
+#[cfg(feature = "alloc")]
+impl<M> NewAead for SivAead<Ctr128<Aes128>, M>
+where
+    M: Mac<OutputSize = U16>,
+{
+    type KeySize = U32;
+
+    fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
+        Self {
+            siv: Siv::new(key.as_slice()),
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<M> NewAead for SivAead<Ctr128<Aes256>, M>
+where
+    M: Mac<OutputSize = U16>,
+{
+    type KeySize = U64;
+
+    fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
+        Self {
+            siv: Siv::new(key.as_slice()),
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<C, M> AeadMut for SivAead<C, M>
+where
+    C: NewStreamCipher<NonceSize = U16> + SyncStreamCipher,
+    M: Mac<OutputSize = U16>,
+{
+    // "If the nonce is random, it SHOULD be at least 128 bits in length"
+    // https://tools.ietf.org/html/rfc5297#section-3
+    type NonceSize = U16;
+    type TagSize = U16;
+    type CiphertextOverhead = U0;
+
+    fn encrypt<'msg, 'aad>(
+        &mut self,
+        nonce: &GenericArray<u8, Self::NonceSize>,
+        plaintext: impl Into<Payload<'msg, 'aad>>,
+    ) -> Result<Vec<u8>, Error> {
+        let payload = plaintext.into();
+        let mut buffer = vec![0; IV_SIZE + payload.msg.len()];
+        buffer[IV_SIZE..].copy_from_slice(payload.msg);
+        self.encrypt_in_place(nonce, payload.aad, &mut buffer);
+        Ok(buffer)
+    }
+
+    fn decrypt<'msg, 'aad>(
+        &mut self,
+        nonce: &GenericArray<u8, Self::NonceSize>,
+        ciphertext: impl Into<Payload<'msg, 'aad>>,
+    ) -> Result<Vec<u8>, Error> {
+        let payload = ciphertext.into();
+        let mut buffer = Vec::from(payload.msg);
+        self.decrypt_in_place(nonce, payload.aad, &mut buffer)?;
+        buffer.drain(..IV_SIZE);
+        Ok(buffer)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<C, M> SivAead<C, M>
+where
+    C: NewStreamCipher<NonceSize = U16> + SyncStreamCipher,
+    M: Mac<OutputSize = U16>,
+{
+    /// Encrypt the given message in-place
+    pub fn encrypt_in_place(
+        &mut self,
+        nonce: &GenericArray<u8, <Self as AeadMut>::NonceSize>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+    ) {
+        // "SIV performs nonce-based authenticated encryption when a component of
+        // the associated data is a nonce.  For purposes of interoperability the
+        // final component -- i.e., the string immediately preceding the
+        // plaintext in the vector input to S2V -- is used for the nonce."
+        // https://tools.ietf.org/html/rfc5297#section-3
+        self.siv
+            .encrypt_in_place(&[associated_data, nonce.as_slice()], buffer)
+    }
+
+    /// Decrypt the given message in-place
+    pub fn decrypt_in_place<'a>(
+        &mut self,
+        nonce: &GenericArray<u8, <Self as AeadMut>::NonceSize>,
+        associated_data: &[u8],
+        buffer: &'a mut [u8],
+    ) -> Result<&'a [u8], Error> {
+        self.siv
+            .decrypt_in_place(&[associated_data, nonce.as_slice()], buffer)
+    }
+}

--- a/aes-siv/src/siv.rs
+++ b/aes-siv/src/siv.rs
@@ -1,0 +1,272 @@
+//! The Synthetic Initialization Vector (SIV) misuse-resistant block cipher
+//! mode of operation ([RFC 5297][1]).
+//!
+//! [1]: https://tools.ietf.org/html/rfc5297
+
+use aead::generic_array::{
+    typenum::{Unsigned, U16},
+    GenericArray,
+};
+use aead::Error;
+use aes::{Aes128, Aes256};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+use cmac::Cmac;
+use crypto_mac::{Mac, MacResult};
+use ctr::Ctr128;
+use dbl::Dbl;
+#[cfg(feature = "pmac")]
+use pmac::Pmac;
+use stream_cipher::{NewStreamCipher, SyncStreamCipher};
+use zeroize::Zeroize;
+
+/// Size of the (synthetic) initialization vector in bytes
+pub const IV_SIZE: usize = 16;
+
+/// Maximum number of header items on the encrypted message
+pub const MAX_HEADERS: usize = 126;
+
+/// GenericArray of bytes which is the size of a synthetic IV
+type SivArray = GenericArray<u8, U16>;
+
+/// Synthetic Initialization Vector (SIV) mode, providing misuse-resistant
+/// authenticated encryption (MRAE).
+pub struct Siv<C, M>
+where
+    C: NewStreamCipher<NonceSize = U16> + SyncStreamCipher,
+    M: Mac<OutputSize = U16>,
+{
+    encryption_key: GenericArray<u8, <C as NewStreamCipher>::KeySize>,
+    mac: M,
+}
+
+/// SIV modes based on CMAC
+pub type CmacSiv<BlockCipher> = Siv<Ctr128<BlockCipher>, Cmac<BlockCipher>>;
+
+/// SIV modes based on PMAC
+#[cfg(feature = "pmac")]
+pub type PmacSiv<BlockCipher> = Siv<Ctr128<BlockCipher>, Pmac<BlockCipher>>;
+
+/// AES-CMAC-SIV with a 128-bit key
+pub type Aes128Siv = CmacSiv<Aes128>;
+
+/// AES-CMAC-SIV with a 256-bit key
+pub type Aes256Siv = CmacSiv<Aes256>;
+
+/// AES-PMAC-SIV with a 128-bit key
+#[cfg(feature = "pmac")]
+pub type Aes128PmacSiv = PmacSiv<Aes128>;
+
+/// AES-PMAC-SIV with a 256-bit key
+#[cfg(feature = "pmac")]
+pub type Aes256PmacSiv = PmacSiv<Aes256>;
+
+impl<C, M> Siv<C, M>
+where
+    C: NewStreamCipher<NonceSize = U16> + SyncStreamCipher,
+    M: Mac<OutputSize = U16>,
+{
+    /// Create a new AES-SIV instance
+    ///
+    /// Panics if the key is the wrong length
+    // TODO(tarcieri): use `GenericArray` to eliminate panic conditions
+    pub fn new(key: &[u8]) -> Self {
+        let key_size = M::KeySize::to_usize() * 2;
+
+        assert_eq!(
+            key.len(),
+            key_size,
+            "expected {}-byte key, got {}",
+            key_size,
+            key.len()
+        );
+
+        // Use the first half of the key as the encryption key
+        let encryption_key = GenericArray::clone_from_slice(&key[(key_size / 2)..]);
+
+        // Use the second half of the key as the MAC key
+        let mac = M::new(GenericArray::from_slice(&key[..(key_size / 2)]));
+
+        Self {
+            encryption_key,
+            mac,
+        }
+    }
+
+    /// Encrypt the given plaintext in-place, replacing it with the SIV tag and
+    /// ciphertext. Requires a buffer with 16-bytes additional space.
+    ///
+    /// # Usage
+    ///
+    /// It's important to note that only the *end* of the buffer will be
+    /// treated as the input plaintext:
+    ///
+    /// ```rust
+    /// let buffer = [0u8; 21];
+    /// let plaintext = &buffer[..buffer.len() - 16];
+    /// ```
+    ///
+    /// In this case, only the *last* 5 bytes are treated as the plaintext,
+    /// since `21 - 16 = 5` (the AES block size is 16-bytes).
+    ///
+    /// The buffer must include an additional 16-bytes of space in which to
+    /// write the SIV tag (at the beginning of the buffer).
+    /// Failure to account for this will leave you with plaintext messages that
+    /// are missing their first 16-bytes!
+    ///
+    /// # Panics
+    ///
+    /// Panics if `plaintext.len()` is less than `M::OutputSize`.
+    /// Panics if `headers.len()` is greater than `MAX_ASSOCIATED_DATA`.
+    pub fn encrypt_in_place<I, T>(&mut self, headers: I, plaintext: &mut [u8])
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        if plaintext.len() < IV_SIZE {
+            panic!("plaintext buffer too small to hold MAC tag!");
+        }
+
+        let (siv_tag, msg) = plaintext.split_at_mut(IV_SIZE);
+
+        // Compute the synthetic IV for this plaintext
+        siv_tag.copy_from_slice(s2v(&mut self.mac, headers, msg).code().as_slice());
+        self.xor_with_keystream(siv_tag, msg);
+    }
+
+    /// Decrypt the given ciphertext in-place, authenticating it against the
+    /// synthetic IV included in the message.
+    ///
+    /// Returns a slice containing a decrypted message on success.
+    pub fn decrypt_in_place<'a, I, T>(
+        &mut self,
+        headers: I,
+        ciphertext: &'a mut [u8],
+    ) -> Result<&'a [u8], Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        if ciphertext.len() < IV_SIZE {
+            return Err(Error);
+        }
+
+        let (siv_tag, msg) = ciphertext.split_at_mut(IV_SIZE);
+        self.xor_with_keystream(siv_tag, msg);
+
+        let computed_siv_tag = s2v(&mut self.mac, headers, msg);
+
+        // Note: constant-time comparison of `MacResult` values
+        if computed_siv_tag == MacResult::new(*GenericArray::from_slice(siv_tag)) {
+            Ok(msg)
+        } else {
+            // Re-encrypt the decrypted plaintext to avoid revealing it
+            self.xor_with_keystream(siv_tag, msg);
+            Err(Error)
+        }
+    }
+
+    /// Encrypt the given plaintext, allocating and returning a Vec<u8> for the ciphertext
+    #[cfg(feature = "alloc")]
+    pub fn encrypt<I, T>(&mut self, associated_data: I, plaintext: &[u8]) -> Vec<u8>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        let mut buffer = vec![0; IV_SIZE + plaintext.len()];
+        buffer[IV_SIZE..].copy_from_slice(plaintext);
+        self.encrypt_in_place(associated_data, &mut buffer);
+        buffer
+    }
+
+    /// Decrypt the given ciphertext, allocating and returning a Vec<u8> for the plaintext
+    #[cfg(feature = "alloc")]
+    pub fn decrypt<I, T>(&mut self, associated_data: I, ciphertext: &[u8]) -> Result<Vec<u8>, Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        let mut buffer = Vec::from(ciphertext);
+        self.decrypt_in_place(associated_data, &mut buffer)?;
+        buffer.drain(..IV_SIZE);
+        Ok(buffer)
+    }
+
+    /// XOR the given buffer with the keystream for the given IV
+    fn xor_with_keystream(&mut self, iv: &[u8], msg: &mut [u8]) {
+        let mut zeroed_iv = SivArray::clone_from_slice(iv);
+
+        // "We zero-out the top bit in each of the last two 32-bit words
+        // of the IV before assigning it to Ctr"
+        //  — http://web.cs.ucdavis.edu/~rogaway/papers/siv.pdf
+        zeroed_iv[8] &= 0x7f;
+        zeroed_iv[12] &= 0x7f;
+
+        C::new(GenericArray::from_slice(&self.encryption_key), &zeroed_iv).apply_keystream(msg);
+    }
+}
+
+impl<C, M> Drop for Siv<C, M>
+where
+    C: NewStreamCipher<NonceSize = U16> + SyncStreamCipher,
+    M: Mac<OutputSize = U16>,
+{
+    fn drop(&mut self) {
+        self.encryption_key.zeroize()
+    }
+}
+
+/// "S2V" is a vectorized pseudorandom function (sometimes referred to as a
+/// vector MAC or "vMAC") which performs a "dbl"-and-xor operation on the
+/// outputs of a pseudo-random function (CMAC or PMAC).
+///
+/// In the RFC 5297 SIV construction (see Section 2.4), message headers
+/// (e.g. nonce, associated data) and the plaintext are used as inputs to
+/// S2V, together with a message authentication key. The output is the
+/// eponymous "synthetic IV" (SIV), which has a dual role as both
+/// initialization vector (for AES-CTR encryption) and MAC.
+fn s2v<M, I, T>(mac: &mut M, headers: I, message: &[u8]) -> MacResult<U16>
+where
+    M: Mac<OutputSize = U16>,
+    I: IntoIterator<Item = T>,
+    T: AsRef<[u8]>,
+{
+    mac.input(&SivArray::default());
+    let mut state = mac.result_reset().code();
+
+    for (i, header) in headers.into_iter().enumerate() {
+        if i >= MAX_HEADERS {
+            panic!("too many associated data items!");
+        }
+
+        state = state.dbl();
+        mac.input(header.as_ref());
+        let code = mac.result_reset().code();
+        xor_in_place(&mut state, &code);
+    }
+
+    if message.len() >= IV_SIZE {
+        let n = message.len().checked_sub(IV_SIZE).unwrap();
+
+        mac.input(&message[..n]);
+        xor_in_place(&mut state, &message[n..]);
+    } else {
+        state = state.dbl();
+        xor_in_place(&mut state, message);
+        state[message.len()] ^= 0x80;
+    };
+
+    mac.input(state.as_ref());
+    mac.result_reset()
+}
+
+/// XOR the second argument into the first in-place. Slices do not have to be
+/// aligned in memory.
+///
+/// Panics if the destination slice is smaller than the source.
+#[inline]
+fn xor_in_place(dst: &mut [u8], src: &[u8]) {
+    for (a, b) in dst[..src.len()].iter_mut().zip(src) {
+        *a ^= *b;
+    }
+}

--- a/aes-siv/tests/aead.rs
+++ b/aes-siv/tests/aead.rs
@@ -1,0 +1,90 @@
+pub mod vectors;
+
+use self::vectors::aead::AesSivAeadExample;
+use aes_siv::{
+    aead::{generic_array::GenericArray, AeadMut, NewAead, Payload},
+    Aes128SivAead, Aes256SivAead,
+};
+#[cfg(feature = "pmac")]
+use aes_siv::{Aes128PmacSivAead, Aes256PmacSivAead};
+
+#[test]
+fn aes_siv_aead_examples_encrypt() {
+    let examples = AesSivAeadExample::load_all();
+
+    for example in examples {
+        let nonce = GenericArray::clone_from_slice(&example.nonce);
+        let payload = Payload {
+            aad: &example.ad,
+            msg: &example.plaintext,
+        };
+
+        let ciphertext = match example.alg.as_ref() {
+            "AES-SIV" => match example.key.len() {
+                32 => Aes128SivAead::new(GenericArray::clone_from_slice(&example.key))
+                    .encrypt(&nonce, payload),
+                64 => Aes256SivAead::new(GenericArray::clone_from_slice(&example.key))
+                    .encrypt(&nonce, payload),
+                _ => panic!("unexpected key size: {}", example.key.len()),
+            },
+            #[cfg(feature = "pmac")]
+            "AES-PMAC-SIV" => match example.key.len() {
+                32 => Aes128PmacSivAead::new(GenericArray::clone_from_slice(&example.key))
+                    .encrypt(&nonce, payload),
+                64 => Aes256PmacSivAead::new(GenericArray::clone_from_slice(&example.key))
+                    .encrypt(&nonce, payload),
+                _ => panic!("unexpected key size: {}", example.key.len()),
+            },
+            _ => {
+                if example.alg == "AES-PMAC-SIV" {
+                    continue;
+                } else {
+                    panic!("unexpected algorithm: {}", example.alg)
+                }
+            }
+        };
+
+        assert_eq!(ciphertext.expect("encryption failure"), example.ciphertext);
+    }
+}
+
+#[test]
+fn aes_siv_aead_examples_decrypt() {
+    let examples = AesSivAeadExample::load_all();
+
+    for example in examples {
+        let nonce = GenericArray::clone_from_slice(&example.nonce);
+        let payload = Payload {
+            aad: &example.ad,
+            msg: &example.ciphertext,
+        };
+
+        let plaintext = match example.alg.as_ref() {
+            "AES-SIV" => match example.key.len() {
+                32 => Aes128SivAead::new(GenericArray::clone_from_slice(&example.key))
+                    .decrypt(&nonce, payload),
+                64 => Aes256SivAead::new(GenericArray::clone_from_slice(&example.key))
+                    .decrypt(&nonce, payload),
+                _ => panic!("unexpected key size: {}", example.key.len()),
+            },
+            #[cfg(feature = "pmac")]
+            "AES-PMAC-SIV" => match example.key.len() {
+                32 => Aes128PmacSivAead::new(GenericArray::clone_from_slice(&example.key))
+                    .decrypt(&nonce, payload),
+                64 => Aes256PmacSivAead::new(GenericArray::clone_from_slice(&example.key))
+                    .decrypt(&nonce, payload),
+                _ => panic!("unexpected key size: {}", example.key.len()),
+            },
+            _ => {
+                if example.alg == "AES-PMAC-SIV" {
+                    continue;
+                } else {
+                    panic!("unexpected algorithm: {}", example.alg)
+                }
+            }
+        }
+        .expect("decrypt failure");
+
+        assert_eq!(plaintext, example.plaintext);
+    }
+}

--- a/aes-siv/tests/siv.rs
+++ b/aes-siv/tests/siv.rs
@@ -1,0 +1,72 @@
+mod vectors;
+
+#[cfg(feature = "pmac")]
+use self::vectors::siv::AesPmacSivExample;
+use self::vectors::siv::AesSivExample;
+#[cfg(feature = "pmac")]
+use aes_siv::siv::{Aes128PmacSiv, Aes256PmacSiv};
+use aes_siv::siv::{Aes128Siv, Aes256Siv};
+
+#[test]
+fn aes_siv_examples_encrypt() {
+    let examples = AesSivExample::load_all();
+
+    for example in examples {
+        let ciphertext = match example.key.len() {
+            32 => Aes128Siv::new(&example.key).encrypt(&example.ad, &example.plaintext),
+            64 => Aes256Siv::new(&example.key).encrypt(&example.ad, &example.plaintext),
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        };
+
+        assert_eq!(ciphertext, example.ciphertext);
+    }
+}
+
+#[test]
+fn aes_siv_examples_decrypt() {
+    let examples = AesSivExample::load_all();
+
+    for example in examples {
+        let plaintext = match example.key.len() {
+            32 => Aes128Siv::new(&example.key).decrypt(&example.ad, &example.ciphertext),
+            64 => Aes256Siv::new(&example.key).decrypt(&example.ad, &example.ciphertext),
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        }
+        .expect("decrypt failure");
+
+        assert_eq!(plaintext, example.plaintext);
+    }
+}
+
+#[test]
+#[cfg(feature = "pmac")]
+fn aes_pmac_siv_examples_encrypt() {
+    let examples = AesPmacSivExample::load_all();
+
+    for example in examples {
+        let ciphertext = match example.key.len() {
+            32 => Aes128PmacSiv::new(&example.key).encrypt(&example.ad, &example.plaintext),
+            64 => Aes256PmacSiv::new(&example.key).encrypt(&example.ad, &example.plaintext),
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        };
+
+        assert_eq!(ciphertext, example.ciphertext);
+    }
+}
+
+#[test]
+#[cfg(feature = "pmac")]
+fn aes_pmac_siv_examples_decrypt() {
+    let examples = AesPmacSivExample::load_all();
+
+    for example in examples {
+        let plaintext = match example.key.len() {
+            32 => Aes128PmacSiv::new(&example.key).decrypt(&example.ad, &example.ciphertext),
+            64 => Aes256PmacSiv::new(&example.key).decrypt(&example.ad, &example.ciphertext),
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        }
+        .expect("decrypt failure");
+
+        assert_eq!(plaintext, example.plaintext);
+    }
+}

--- a/aes-siv/tests/vectors/aead.rs
+++ b/aes-siv/tests/vectors/aead.rs
@@ -1,0 +1,86 @@
+#![allow(dead_code)]
+
+pub use serde_json::Value as JsonValue;
+use subtle_encoding::hex;
+
+/// AES-SIV AEAD test vectors
+// TODO(tarcieri): extract these from JSON format
+const TEST_VECTORS: &str = r#"
+{
+    "examples:A<O>":[
+        {
+            "name:s":"AES-SIV Authenticted Encryption with Associated Data Example",
+            "alg:s":"AES-SIV",
+            "key:d16":"7f7e7d7c7b7a79787776757473727170404142434445464748494a4b4c4d4e4f",
+            "ad:d16":"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+            "nonce:d16":"09f911029d74e35bd84156c5635688c0",
+            "plaintext:d16":"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553",
+            "ciphertext:d16":"85825e22e90cf2ddda2c548dc7c1b6310dcdaca0cebf9dc6cb90583f5bf1506e02cd48832b00e4e598b2b22a53e6199d4df0c1666a35a0433b250dc134d776"
+        },
+        {
+            "name:s":"AES-PMAC-SIV Authenticted Encryption with Associated Data Example",
+            "alg:s":"AES-PMAC-SIV",
+            "key:d16":"7f7e7d7c7b7a79787776757473727170404142434445464748494a4b4c4d4e4f",
+            "ad:d16":"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+            "nonce:d16":"09f911029d74e35bd84156c5635688c0",
+            "plaintext:d16":"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553",
+            "ciphertext:d16":"1463d1119b2a2797241bb1674633dff13b9de11e5e2f526048b36c40c7722667b2957018023bf0e52792b703a01e88aacd49898cecfce943d7f61a2337a097"
+        }
+    ]
+}
+"#;
+
+/// AES-SIV test vectors for AEAD API (CMAC and PMAC)
+#[derive(Debug)]
+pub struct AesSivAeadExample {
+    pub alg: String,
+    pub key: Vec<u8>,
+    pub ad: Vec<u8>,
+    pub nonce: Vec<u8>,
+    pub plaintext: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+impl AesSivAeadExample {
+    /// Load examples from aes_siv_aead.tjson
+    pub fn load_all() -> Vec<Self> {
+        let tjson: serde_json::Value =
+            serde_json::from_str(TEST_VECTORS).expect("aes_siv.tjson parses successfully");
+
+        let examples = &tjson["examples:A<O>"]
+            .as_array()
+            .expect("aes_siv_aead.tjson examples array");
+
+        examples
+            .into_iter()
+            .map(|ex| Self {
+                alg: ex["alg:s"].as_str().expect("algorithm name").to_owned(),
+                key: hex::decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                ad: hex::decode(ex["ad:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                nonce: hex::decode(
+                    ex["nonce:d16"]
+                        .as_str()
+                        .expect("encoded example")
+                        .as_bytes(),
+                )
+                .expect("hex encoded"),
+                plaintext: hex::decode(
+                    ex["plaintext:d16"]
+                        .as_str()
+                        .expect("encoded example")
+                        .as_bytes(),
+                )
+                .expect("hex encoded"),
+                ciphertext: hex::decode(
+                    ex["ciphertext:d16"]
+                        .as_str()
+                        .expect("encoded example")
+                        .as_bytes(),
+                )
+                .expect("hex encoded"),
+            })
+            .collect()
+    }
+}

--- a/aes-siv/tests/vectors/mod.rs
+++ b/aes-siv/tests/vectors/mod.rs
@@ -1,0 +1,4 @@
+//! Test vectors
+
+pub mod aead;
+pub mod siv;

--- a/aes-siv/tests/vectors/siv.rs
+++ b/aes-siv/tests/vectors/siv.rs
@@ -1,0 +1,246 @@
+pub use serde_json::Value as JsonValue;
+use subtle_encoding::hex;
+
+/// AES-CMAC-SIV test vectors
+// TODO(tarcieri): extract these from JSON format
+const AES_CMAC_SIV_TEST_VECTORS: &str = r#"
+{
+    "examples:A<O>":[
+        {
+            "name:s":"Deterministic Authenticated Encryption Example",
+            "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+            "ad:A<d16>":[
+                "101112131415161718191a1b1c1d1e1f2021222324252627"
+            ],
+            "plaintext:d16":"112233445566778899aabbccddee",
+            "ciphertext:d16":"85632d07c6e8f37f950acd320a2ecc9340c02b9690c4dc04daef7f6afe5c"
+        },
+        {
+            "name:s":"Nonce-Based Authenticated Encryption Example",
+            "key:d16":"7f7e7d7c7b7a79787776757473727170404142434445464748494a4b4c4d4e4f",
+            "ad:A<d16>":[
+                "00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+                "102030405060708090a0",
+                "09f911029d74e35bd84156c5635688c0"
+            ],
+            "plaintext:d16":"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553",
+            "ciphertext:d16":"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d"
+        },
+        {
+            "name:s":"Empty Authenticated Data And Plaintext Example",
+            "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+            "ad:A<d16>":[],
+            "plaintext:d16":"",
+            "ciphertext:d16":"f2007a5beb2b8900c588a7adf599f172"
+        },
+        {
+            "name:s":"NIST SIV test vectors (256-bit subkeys #1)",
+            "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f06f6e6d6c6b6a69686766656463626160f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f",
+            "ad:A<d16>":[
+                "101112131415161718191a1b1c1d1e1f2021222324252627"
+            ],
+            "plaintext:d16":"112233445566778899aabbccddee",
+            "ciphertext:d16":"f125274c598065cfc26b0e71575029088b035217e380cac8919ee800c126"
+        },
+        {
+            "name:s":"NIST SIV test vectors (256-bit subkeys #2)",
+            "key:d16":"7f7e7d7c7b7a797877767574737271706f6e6d6c6b6a69686766656463626160404142434445464748494a4b4c4d4e4f505152535455565758595a5b5b5d5e5f",
+            "ad:A<d16>":[
+                "00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+                "102030405060708090a0",
+                "09f911029d74e35bd84156c5635688c0"
+            ],
+            "plaintext:d16":"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553",
+            "ciphertext:d16":"85b8167310038db7dc4692c0281ca35868181b2762f3c24f2efa5fb80cb143516ce6c434b898a6fd8eb98a418842f51f66fc67de43ac185a66dd72475bbb08"
+        },
+        {
+            "name:s":"Empty Authenticated Data And Block-Size Plaintext Example",
+            "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+            "ad:A<d16>":[],
+            "plaintext:d16":"00112233445566778899aabbccddeeff",
+            "ciphertext:d16":"f304f912863e303d5b540e5057c7010c942ffaf45b0e5ca5fb9a56a5263bb065"
+        }
+    ]
+}
+"#;
+
+/// AES-SIV test vectors
+#[derive(Debug)]
+pub struct AesSivExample {
+    pub key: Vec<u8>,
+    pub ad: Vec<Vec<u8>>,
+    pub plaintext: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+impl AesSivExample {
+    /// Load examples from aes_siv.tjson
+    pub fn load_all() -> Vec<Self> {
+        let tjson: serde_json::Value = serde_json::from_str(AES_CMAC_SIV_TEST_VECTORS)
+            .expect("aes_siv.tjson parses successfully");
+
+        let examples = &tjson["examples:A<O>"]
+            .as_array()
+            .expect("aes_siv.tjson examples array");
+
+        examples
+            .into_iter()
+            .map(|ex| Self {
+                key: hex::decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                ad: ex["ad:A<d16>"]
+                    .as_array()
+                    .expect("encoded example")
+                    .iter()
+                    .map(|ex| {
+                        hex::decode(ex.as_str().expect("encoded example").as_bytes())
+                            .expect("hex encoded")
+                    })
+                    .collect(),
+                plaintext: hex::decode(
+                    ex["plaintext:d16"]
+                        .as_str()
+                        .expect("encoded example")
+                        .as_bytes(),
+                )
+                .expect("hex encoded"),
+                ciphertext: hex::decode(
+                    ex["ciphertext:d16"]
+                        .as_str()
+                        .expect("encoded example")
+                        .as_bytes(),
+                )
+                .expect("hex encoded"),
+            })
+            .collect()
+    }
+}
+
+/// AES-PMAC-SIV test vectors
+// TODO(tarcieri): extract these from JSON format
+#[cfg(feature = "pmac")]
+const AES_PMAC_SIV_TEST_VECTORS: &str = r#"
+{
+  "examples:A<O>":[
+    {
+      "name:s":"AES-PMAC-SIV-128-TV1: Deterministic Authenticated Encryption Example",
+      "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "ad:A<d16>":[
+        "101112131415161718191a1b1c1d1e1f2021222324252627"
+      ],
+      "plaintext:d16":"112233445566778899aabbccddee",
+      "ciphertext:d16":"8c4b814216140fc9b34a41716aa61633ea66abe16b2f6e4bceeda6e9077f"
+    },
+    {
+      "name:s":"AES-PMAC-SIV-128-TV2: Nonce-Based Authenticated Encryption Example",
+      "key:d16":"7f7e7d7c7b7a79787776757473727170404142434445464748494a4b4c4d4e4f",
+      "ad:A<d16>":[
+        "00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+        "102030405060708090a0",
+        "09f911029d74e35bd84156c5635688c0"
+      ],
+      "plaintext:d16":"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553",
+      "ciphertext:d16":"acb9cbc95dbed8e766d25ad59deb65bcda7aff9214153273f88e89ebe580c77defc15d28448f420e0a17d42722e6d42776849aa3bec375c5a05e54f519e9fd"
+    },
+    {
+      "name:s":"AES-PMAC-SIV-128-TV3: Empty Authenticated Data And Plaintext Example",
+      "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "ad:A<d16>":[],
+      "plaintext:d16":"",
+      "ciphertext:d16":"19f25e5ea8a96ef27067d4626fdd3677"
+    },
+    {
+      "name:s":"AES-PMAC-SIV-128-TV4: Nonce-Based Authenticated Encryption With Large Message Example",
+      "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "ad:A<d16>":[
+        "101112131415161718191a1b1c1d1e1f2021222324252627"
+      ],
+      "plaintext:d16":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f70",
+      "ciphertext:d16":"34cbb315120924e6ad05240a1582018b3dc965941308e0535680344cf9cf40cb5aa00b449548f9a4d9718fd22057d19f5ea89450d2d3bf905e858aaec4fc594aa27948ea205ca90102fc463f5c1cbbfb171d296d727ec77f892fb192a4eb9897b7d48d50e474a1238f02a82b122a7b16aa5cc1c04b10b839e478662ff1cec7cabc"
+    },
+    {
+      "name:s":"AES-PMAC-SIV-256-TV1: 256-bit key with one associated data field",
+      "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f06f6e6d6c6b6a69686766656463626160f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f",
+      "ad:A<d16>":[
+        "101112131415161718191a1b1c1d1e1f2021222324252627"
+      ],
+      "plaintext:d16":"112233445566778899aabbccddee",
+      "ciphertext:d16":"77097bb3e160988e8b262c1942f983885f826d0d7e047e975e2fc4ea6776"
+    },
+    {
+      "name:s":"AES-PMAC-SIV-256-TV2: 256-bit key with three associated data fields",
+      "key:d16":"7f7e7d7c7b7a797877767574737271706f6e6d6c6b6a69686766656463626160404142434445464748494a4b4c4d4e4f505152535455565758595a5b5b5d5e5f",
+      "ad:A<d16>":[
+        "00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+        "102030405060708090a0",
+        "09f911029d74e35bd84156c5635688c0"
+      ],
+      "plaintext:d16":"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553",
+      "ciphertext:d16":"cd07d56dca0fe1569b8ecb3cf2346604290726e12529fc5948546b6be39fed9cd8652256c594c8f56208c7496789de8dfb4f161627c91482f9ecf809652a9e"
+    },
+    {
+      "name:s":"AES-PMAC-SIV-256-TV3: Nonce-Based Authenticated Encryption With Large Message Example",
+      "key:d16":"7f7e7d7c7b7a797877767574737271706f6e6d6c6b6a69686766656463626160404142434445464748494a4b4c4d4e4f505152535455565758595a5b5b5d5e5f",
+      "ad:A<d16>":[
+        "101112131415161718191a1b1c1d1e1f2021222324252627"
+      ],
+      "plaintext:d16":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f70",
+      "ciphertext:d16":"045ba64522c5c980835674d1c5a9264eca3e9f7aceafe9b5485b33f7d2c9114fe5c4b24f9c814d88e78b6150028d630289d023015b8569af338de0af8534827732b365ace1ac99d278431b22eafe31b94297b1c6a2de41383ed8b39f17e748aea128a8bd7d0ee80ec899f1b940c9c0463f22fc2b5a145cb6e90a32801dd1950f92"
+    }
+  ]
+}
+"#;
+
+/// AES-PMAC-SIV test vectors
+#[derive(Debug)]
+#[cfg(feature = "pmac")]
+pub struct AesPmacSivExample {
+    pub key: Vec<u8>,
+    pub ad: Vec<Vec<u8>>,
+    pub plaintext: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+#[cfg(feature = "pmac")]
+impl AesPmacSivExample {
+    /// Load examples from aes_pmac_siv.tjson
+    pub fn load_all() -> Vec<Self> {
+        let tjson: serde_json::Value = serde_json::from_str(AES_PMAC_SIV_TEST_VECTORS)
+            .expect("aes_pmac_siv.tjson parses successfully");
+
+        let examples = &tjson["examples:A<O>"]
+            .as_array()
+            .expect("aes_pmac_siv.tjson examples array");
+
+        examples
+            .into_iter()
+            .map(|ex| Self {
+                key: hex::decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                ad: ex["ad:A<d16>"]
+                    .as_array()
+                    .expect("encoded example")
+                    .iter()
+                    .map(|ex| {
+                        hex::decode(ex.as_str().expect("encoded example").as_bytes())
+                            .expect("hex encoded")
+                    })
+                    .collect(),
+                plaintext: hex::decode(
+                    ex["plaintext:d16"]
+                        .as_str()
+                        .expect("encoded example")
+                        .as_bytes(),
+                )
+                .expect("hex encoded"),
+                ciphertext: hex::decode(
+                    ex["ciphertext:d16"]
+                        .as_str()
+                        .expect("encoded example")
+                        .as_bytes(),
+                )
+                .expect("hex encoded"),
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
This is largely an import of the AES-(PMAC-)SIV implementation from Miscreant, taken from this commit:

https://github.com/miscreant/miscreant.rs/commit/71aa57519347d0b6a38204f86f2f0335756ae0b8

It uses the `AeadMut` API for now (but would be nice to convert to `Aead` eventually)

Note that the RFC 5297 description of the AEAD interface for AES-SIV cannot presently be expressed in terms of the `Aead`/`AeadMut` traits, since it supports a variable-length nonce (which is what Miscreant's current `Aead` trait also provides):

https://tools.ietf.org/html/rfc5297#section-6.1

> N_MIN  is 1 octet.
> N_MAX  is unlimited.

I have selected a 128-bit `NonceSize` based on the following SHOULD in RFC 5297:

https://tools.ietf.org/html/rfc5297#section-3

> If the nonce is random, it SHOULD be at least 128 bits in length

This is not ideal though, and means I had to delete the test vectors which use a nonce whose length is not 128-bits.