### PR TITLE
aes-gcm-siv: Upgrade to `polyval` v0.3

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "experimental" }
 aead = "0.1"
 aes = "0.3"
 ctr = "0.3"
-polyval = "0.2"
+polyval = "0.3"
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.0.0-pre", default-features = false }
 


### PR DESCRIPTION
https://github.com/RustCrypto/universal-hashes/pull/29