### PR TITLE
chacha20poly1305 v0.2.0

### DIFF
--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2019-10-06)
+### Added
+- Expose "detached" in-place encryption/decryption APIs ([#21])
+
+### Changed
+- Upgrade to `poly1305` crate v0.5 ([#20])
+
+[#21]: https://github.com/RustCrypto/AEADs/pull/21
+[#20]: https://github.com/RustCrypto/AEADs/pull/20
+
 ## 0.1.2 (2019-10-01)
 ### Changed
 - Update to `zeroize` 1.0.0-pre ([#17])

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -12,6 +12,9 @@ documentation = "https://docs.rs/chacha20poly1305"
 repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 aead = "0.1"

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "salsa20", "poly1305", "xsalsa20"]
 categories = ["cryptography", "no-std"]
 
+[badges]
+maintenance = { status = "experimental" }
+
 [dependencies]
 aead = "0.1"
 salsa20 = { version = "0.3.0", features = ["xsalsa20", "zeroize"] }


### PR DESCRIPTION
### Added
- Expose "detached" in-place encryption/decryption APIs ([#21])

### Changed
- Upgrade to `poly1305` crate v0.5 ([#20])

[#21]: https://github.com/RustCrypto/AEADs/pull/21
[#20]: https://github.com/RustCrypto/AEADs/pull/20