### PR TITLE
xsalsa20poly1305 v0.2.0

### DIFF
--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2019-10-06)
+### Added
+- Expose "detached" in-place encryption/decryption APIs ([#21])
+
+### Changed
+- Upgrade to `poly1305` crate v0.5 ([#20])
+
+[#21]: https://github.com/RustCrypto/AEADs/pull/21
+[#20]: https://github.com/RustCrypto/AEADs/pull/20
+
 ## 0.1.0 (2019-10-01)
 
 - Initial release

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- Expose "detached" in-place encryption/decryption APIs ([#21])

### Changed
- Upgrade to `poly1305` crate v0.5 ([#20])

[#21]: https://github.com/RustCrypto/AEADs/pull/21
[#20]: https://github.com/RustCrypto/AEADs/pull/20