### PR TITLE
chacha20poly1305: documentation improvements

### DIFF
--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -1,11 +1,10 @@
-//! **ChaCha20Poly1305** ([RFC 8439][1]) is an
+//! [`ChaCha20Poly1305`] ([RFC 8439][1]) is an
 //! [Authenticated Encryption with Associated Data (AEAD)][2]
 //! cipher amenable to fast, constant-time implementations in software, based on
 //! the [ChaCha20][3] stream cipher and [Poly1305][4] universal hash function.
 //!
-//! This crate also contains an implementation of **XSalsa20Poly1305**
-//! (a.k.a. NaCl `crypto_secretbox`[4]): a variant of Salsa20Poly1305 with an
-//! extended 192-bit (24-byte) nonce.
+//! This crate also contains an implementation of [`XChaCha20Poly1305`] -
+//! a variant of ChaCha20Poly1305 with an extended 192-bit (24-byte) nonce.
 //!
 //! ## Security Warning
 //!

--- a/chacha20poly1305/src/xchacha20poly1305.rs
+++ b/chacha20poly1305/src/xchacha20poly1305.rs
@@ -13,7 +13,8 @@ use chacha20::{stream_cipher::NewStreamCipher, XChaCha20};
 use zeroize::Zeroize;
 
 /// XChaCha20Poly1305 is a ChaCha20Poly1305 variant with an extended
-/// 192-bit (24-byte) nonce.
+/// 192-bit (24-byte) nonce. The `xchacha20poly1305` Cargo feature
+/// must be enabled in order to use this (which it is by default).
 ///
 /// The construction is an adaptation of the same techniques used by
 /// XSalsa20 as described in the paper "Extending the Salsa20 Nonce"
@@ -29,12 +30,12 @@ use zeroize::Zeroize;
 ///
 /// <https://tools.ietf.org/html/draft-arciszewski-xchacha-03>
 ///
-/// It is worth noting that libsodium's default "secretbox" algorithm is
+/// It is worth noting that NaCl/libsodium's default "secretbox" algorithm is
 /// XSalsa20Poly1305, not XChaCha20Poly1305, and thus not compatible with
-/// this library.
+/// this library. If you are interested in that construction, please see the
+/// `xsalsa20poly1305` crate:
 ///
-/// The `xchacha20poly1305` Cargo feature must be enabled in order to use this
-/// (which it is by default).
+/// <https://docs.rs/xsalsa20poly1305/>
 ///
 /// # Usage
 ///


### PR DESCRIPTION
- Fix reference to XSalsa20Poly1305 instead of XChaCha20Poly1305
- Link to the `xsalsa20poly1305` crate