### PR TITLE
Upgrade to `zeroize` 1.0

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "aes-gcm-siv"
 version = "0.2.0"
+description = """
+Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
+Encryption Cipher (RFC 8452) with optional architecture-specific
+hardware acceleration
+"""
 authors = ["RustCrypto Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
-description = "AES-GCM-SIV: Misuse-Resistant Authenticated Encryption Cipher (RFC 8452)"
 readme = "README.md"
 documentation = "https://docs.rs/aes-gcm-siv"
 repository = "https://github.com/RustCrypto/AEADs"
@@ -19,7 +23,7 @@ aead = "0.1"
 aes = "0.3"
 polyval = "0.3"
 subtle = { version = "2", default-features = false }
-zeroize = { version = "1.0.0-pre", default-features = false }
+zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/aes-gcm-siv/README.md
+++ b/aes-gcm-siv/README.md
@@ -7,7 +7,7 @@
 ![Maintenance Status: Experimental][maintenance-image]
 [![Build Status][build-image]][build-link]
 
-[AES-GCM-SIV][1] ([RFC 8452][2]) is a high-performance
+[AES-GCM-SIV][1] ([RFC 8452][2]) is a state-of-the-art high-performance
 [Authenticated Encryption with Associated Data (AEAD)][3] cipher which also
 provides [nonce reuse misuse resistance][4].
 

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "aes-gcm"
 version = "0.1.0"
+description = """
+Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
+Authenticated Encryption with Associated Data (AEAD) Cipher
+with optional architecture-specific hardware acceleration
+"""
 authors = ["RustCrypto Developers"]
 edition = "2018"
-license = "MIT OR Apache-2.0"
-description = "Pure Rust implementation of the AES-GCM Authenticated Encryption with Associated Data (AEAD) cipher"
+license = "Apache-2.0 OR MIT"
 readme = "README.md"
 documentation = "https://docs.rs/aes-gcm"
 repository = "https://github.com/RustCrypto/AEADs"
@@ -19,7 +23,7 @@ aead = "0.1"
 aes = "0.3"
 ghash = "0.2.2"
 subtle = { version = "2", default-features = false }
-zeroize = { version = "1.0.0-pre", default-features = false }
+zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "aes-siv"
 version = "0.1.1"
+description = """
+Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
+Encryption Cipher (RFC 5297) with optional architecture-specific
+hardware acceleration
+"""
 authors = ["RustCrypto Developers"]
 edition = "2018"
-license = "MIT OR Apache-2.0"
-description = "AES-SIV: Misuse-Resistant Authenticated Encryption Cipher (RFC 5297)"
+license = "Apache-2.0 OR MIT"
 readme = "README.md"
 documentation = "https://docs.rs/aes-siv"
 repository = "https://github.com/RustCrypto/AEADs"
@@ -23,7 +27,7 @@ ctr = "0.3"
 dbl = { version = "0.2", default-features = false }
 pmac = { version = "0.2", optional = true }
 stream-cipher = { version = "0.3", default-features = false }
-zeroize = { version = "1.0.0-pre", default-features = false }
+zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "chacha20poly1305"
 version = "0.2.1"
+description = """
+Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
+with Additional Data Cipher (RFC 8439) with optional architecture-specific
+hardware acceleration
+"""
 authors = ["RustCrypto Developers"]
 edition = "2018"
-license = "MIT OR Apache-2.0"
-description = """
-ChaCha20Poly1305 Authenticated Encryption with Additional Data Algorithm (RFC 8439)
-"""
+license = "Apache-2.0 OR MIT"
 readme = "README.md"
 documentation = "https://docs.rs/chacha20poly1305"
 repository = "https://github.com/RustCrypto/AEADs"

--- a/chacha20poly1305/src/xchacha20poly1305.rs
+++ b/chacha20poly1305/src/xchacha20poly1305.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 use chacha20::{stream_cipher::NewStreamCipher, XChaCha20};
 use zeroize::Zeroize;
 
-/// **XChaCha20Poly1305** is a [`ChaCha20Poly1305`] variant with an extended
+/// **XChaCha20Poly1305** is a ChaCha20Poly1305 variant with an extended
 /// 192-bit (24-byte) nonce. The `xchacha20poly1305` Cargo feature
 /// must be enabled in order to use this (which it is by default).
 ///

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "xsalsa20poly1305"
 version = "0.2.0"
+description = """
+Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
+authenticated encryption algorithm
+"""
 authors = ["RustCrypto Developers"]
 edition = "2018"
-license = "MIT OR Apache-2.0"
-description = """
-XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox) authenticated encryption algorithm
-"""
+license = "Apache-2.0 OR MIT"
 readme = "README.md"
 documentation = "https://docs.rs/xsalsa20poly1305"
 repository = "https://github.com/RustCrypto/AEADs"
@@ -20,4 +21,4 @@ maintenance = { status = "experimental" }
 aead = "0.1"
 salsa20 = { version = "0.3.0", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.5"
-zeroize = { version = "1.0.0-pre", default-features = false }
+zeroize = { version = "1", default-features = false }


### PR DESCRIPTION
This removes the `-pre` from the requirements for all crates which are using it. Due to semver all of these crates are already using `zeroize` 1.0 anyway, however this officially codifies it in the `Cargo.toml` files.

(Additionally I included some documentation updates in this PR. Mea culpa for not splitting it out separately, but I hope no one cares)