### PR TITLE
aes-gcm-siv v0.2.1

### DIFF
--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2019-11-14)
+### Changed
+- Upgrade to `zeroize` 1.0 ([#36])
+
+[#36]: https://github.com/RustCrypto/AEADs/pull/36
+
 ## 0.2.0 (2019-10-06)
 ### Added
 - Expose "detached" in-place encryption/decryption APIs ([#21])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.2.0"
+version = "0.2.1"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific


### PR DESCRIPTION
### Changed
- Upgrade to `zeroize` 1.0 ([#36])

[#36]: https://github.com/RustCrypto/AEADs/pull/36