### PR TITLE
aes-siv v0.1.2

### DIFF
--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2019-11-14)
+### Changed
+- Upgrade to `zeroize` 1.0 ([#36])
+
+[#36]: https://github.com/RustCrypto/AEADs/pull/36
+
 ## 0.1.1 (2019-10-06)
 
 - Initial release

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.1.1"
+version = "0.1.2"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific


### PR DESCRIPTION
### Changed
- Upgrade to `zeroize` 1.0 ([#36])

[#36]: https://github.com/RustCrypto/AEADs/pull/36