### PR TITLE
Upgrade aead to v0.2

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["cryptography", "no-std"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.1"
+aead = "0.2"
 aes = "0.3"
 polyval = "0.3"
 subtle = { version = "2", default-features = false }

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -64,20 +64,17 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms)]
 
-extern crate alloc;
-
 mod ctr32;
 
 pub use aead;
 
 use self::ctr32::{Ctr32, BLOCK8_SIZE};
 use aead::generic_array::{
-    typenum::{Unsigned, U0, U12, U16, U8},
+    typenum::{U0, U12, U16, U8},
     GenericArray,
 };
-use aead::{Aead, Error, NewAead, Payload};
+use aead::{Aead, Error, NewAead};
 use aes::{block_cipher_trait::BlockCipher, Aes128, Aes256};
-use alloc::vec::Vec;
 use polyval::{universal_hash::UniversalHash, Polyval};
 use zeroize::Zeroize;
 
@@ -125,60 +122,18 @@ where
     type TagSize = U16;
     type CiphertextOverhead = U0;
 
-    fn encrypt<'msg, 'aad>(
+    fn encrypt_in_place_detached(
         &self,
         nonce: &GenericArray<u8, Self::NonceSize>,
-        plaintext: impl Into<Payload<'msg, 'aad>>,
-    ) -> Result<Vec<u8>, Error> {
-        let payload = plaintext.into();
-        let mut buffer = Vec::with_capacity(payload.msg.len() + Self::TagSize::to_usize());
-        buffer.extend_from_slice(payload.msg);
-
-        let tag = self.encrypt_in_place_detached(nonce, payload.aad, &mut buffer)?;
-        buffer.extend_from_slice(tag.as_slice());
-        Ok(buffer)
-    }
-
-    fn decrypt<'msg, 'aad>(
-        &self,
-        nonce: &GenericArray<u8, Self::NonceSize>,
-        ciphertext: impl Into<Payload<'msg, 'aad>>,
-    ) -> Result<Vec<u8>, Error> {
-        let payload = ciphertext.into();
-
-        if payload.msg.len() < Self::TagSize::to_usize() {
-            return Err(Error);
-        }
-
-        let tag_start = payload.msg.len() - Self::TagSize::to_usize();
-        let mut buffer = Vec::from(&payload.msg[..tag_start]);
-        let tag = Tag::from_slice(&payload.msg[tag_start..]);
-        self.decrypt_in_place_detached(nonce, payload.aad, &mut buffer, tag)?;
-
-        Ok(buffer)
-    }
-}
-
-impl<C> AesGcmSiv<C>
-where
-    C: BlockCipher<BlockSize = U16, ParBlocks = U8>,
-{
-    /// Encrypt the data in-place, returning the authentication tag
-    pub fn encrypt_in_place_detached(
-        &self,
-        nonce: &GenericArray<u8, <Self as Aead>::NonceSize>,
         associated_data: &[u8],
         buffer: &mut [u8],
     ) -> Result<Tag, Error> {
         Cipher::<C>::new(&self.key, nonce).encrypt_in_place_detached(associated_data, buffer)
     }
 
-    /// Decrypt the data in-place, returning an error in the event the provided
-    /// authentication tag does not match the given ciphertext (i.e. ciphertext
-    /// is modified/unauthentic)
-    pub fn decrypt_in_place_detached(
+    fn decrypt_in_place_detached(
         &self,
-        nonce: &GenericArray<u8, <Self as Aead>::NonceSize>,
+        nonce: &GenericArray<u8, Self::NonceSize>,
         associated_data: &[u8],
         buffer: &mut [u8],
         tag: &Tag,

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["cryptography", "no-std"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.1"
+aead = "0.2"
 aes = "0.3"
 ghash = "0.2.2"
 subtle = { version = "2", default-features = false }

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["cryptography", "no-std"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.1"
+aead = "0.2"
 chacha20 = { version = "0.2.1", features = ["zeroize"] }
 poly1305 = "0.5"
 zeroize = { version = "1", default-features = false }

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["cryptography", "no-std"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.1"
+aead = "0.2"
 salsa20 = { version = "0.3.0", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.5"
 zeroize = { version = "1", default-features = false }

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -84,6 +84,30 @@ impl Aead for XSalsa20Poly1305 {
     type TagSize = U16;
     type CiphertextOverhead = U0;
 
+    fn encrypt_in_place_detached(
+        &self,
+        nonce: &GenericArray<u8, Self::NonceSize>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<Tag, Error> {
+        Cipher::new(XSalsa20::new(&self.key, nonce))
+            .encrypt_in_place_detached(associated_data, buffer)
+    }
+
+    fn decrypt_in_place_detached(
+        &self,
+        nonce: &GenericArray<u8, Self::NonceSize>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &Tag,
+    ) -> Result<(), Error> {
+        Cipher::new(XSalsa20::new(&self.key, nonce)).decrypt_in_place_detached(
+            associated_data,
+            buffer,
+            tag,
+        )
+    }
+
     fn encrypt<'msg, 'aad>(
         &self,
         nonce: &GenericArray<u8, Self::NonceSize>,
@@ -119,36 +143,6 @@ impl Aead for XSalsa20Poly1305 {
         self.decrypt_in_place_detached(nonce, payload.aad, &mut buffer, &tag)?;
 
         Ok(buffer)
-    }
-}
-
-impl XSalsa20Poly1305 {
-    /// Encrypt the data in-place, returning the authentication tag
-    pub fn encrypt_in_place_detached(
-        &self,
-        nonce: &GenericArray<u8, <Self as Aead>::NonceSize>,
-        associated_data: &[u8],
-        buffer: &mut [u8],
-    ) -> Result<Tag, Error> {
-        Cipher::new(XSalsa20::new(&self.key, nonce))
-            .encrypt_in_place_detached(associated_data, buffer)
-    }
-
-    /// Decrypt the data in-place, returning an error in the event the provided
-    /// authentication tag does not match the given ciphertext (i.e. ciphertext
-    /// is modified/unauthentic)
-    pub fn decrypt_in_place_detached(
-        &self,
-        nonce: &GenericArray<u8, <Self as Aead>::NonceSize>,
-        associated_data: &[u8],
-        buffer: &mut [u8],
-        tag: &Tag,
-    ) -> Result<(), Error> {
-        Cipher::new(XSalsa20::new(&self.key, nonce)).decrypt_in_place_detached(
-            associated_data,
-            buffer,
-            tag,
-        )
     }
 }
 


### PR DESCRIPTION
Note: I was not able to upgrade aead for `aes-siv` crate. I'll probably need some help doing it. 

Also, in `xsalsa20poly1305`, I suspect `XSalsa20Poly1305::encrypt()` and `XSalsa20Poly1305::encrypt_in_place()` will give different results because, in `XSalsa20Poly1305::encrypt()`, `tag` is inserted before the encrypted data and `XSalsa20Poly1305::encrypt_in_place()` which is auto-implemented from `Aead` trait appends `tag` at the end of the buffer.