### PR TITLE
xsalsa20poly1305: fix in-place (non-detached) API

### DIFF
--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -18,7 +18,11 @@ categories = ["cryptography", "no-std"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.2"
+aead = { version = "0.2", default-features = false }
 salsa20 = { version = "0.3.0", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.5"
 zeroize = { version = "1", default-features = false }
+
+[features]
+default = ["alloc"]
+alloc = ["aead/alloc"]


### PR DESCRIPTION
These were using the default impls of the non-detached in-place API, which use a postfix (as opposed to prefix tag).

By impling these APIs, we can use the default allocating ones.