### PR TITLE
aes-gcm v0.2.0

### DIFF
--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2019-11-26)
+### Changed
+- Upgrade `aead` crate to v0.2; `alloc` now optional ([#43])
+
+[#43]: https://github.com/RustCrypto/AEADs/pull/43
+
 ## 0.1.1 (2019-11-14)
 ### Changed
-- Upgrade to `zeroize` 1.0 ([#36])
+- Upgrade `zeroize` to 1.0 ([#36])
 
 [#36]: https://github.com/RustCrypto/AEADs/pull/36
 

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.1.1"
+version = "0.2.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher
@@ -19,9 +19,9 @@ categories = ["cryptography", "no-std"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.2"
+aead = { version = "0.2", default-features = false }
 aes = "0.3"
-ghash = "0.2.2"
+ghash = { version = "0.2.2", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
@@ -29,6 +29,10 @@ zeroize = { version = "1", default-features = false }
 criterion = "0.3.0"
 criterion-cycles-per-byte = "0.1.1"
 hex-literal = "0.2"
+
+[features]
+default = ["alloc"]
+alloc = ["aead/alloc"]
 
 [[bench]]
 name = "aes-gcm"


### PR DESCRIPTION
### Changed
- Upgrade `aead` crate to v0.2; `alloc` now optional ([#43])

[#43]: https://github.com/RustCrypto/AEADs/pull/43