### PR TITLE
alloc-free usage notes and fixups for all crates

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -19,15 +19,19 @@ categories = ["cryptography", "no-std"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.2"
+aead = { version = "0.2", default-features = false }
 aes = "0.3"
-polyval = "0.3"
+polyval = { version = "0.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.0"
 criterion-cycles-per-byte = "0.1.1"
+
+[features]
+default = ["alloc"]
+alloc = ["aead/alloc"]
 
 [[bench]]
 name = "aes-gcm-siv"

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -53,12 +53,43 @@
 //! assert_eq!(&plaintext, b"plaintext message");
 //! ```
 //!
+//! ## In-place Usage (eliminates `alloc` requirement)
+//!
+//! This crate has an optional `alloc` feature which can be disabled in e.g.
+//! microcontroller environments that don't have a heap.
+//!
+//! The [`Aead::encrypt_in_place`][7] and [`Aead::decrypt_in_place`][8]
+//! methods accept any type that impls the [`aead::Buffer`][9] trait which
+//! contains the plaintext for encryption or ciphertext for decryption.
+//!
+//! Note that if you enable the `heapless` feature of the `aead` crate,
+//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][10]
+//! type, which can then be passed as the `buffer` parameter to the
+//! in-place encrypt and decrypt methods.
+//!
+//! In `Cargo.toml`, add:
+//!
+//! ```toml
+//! [dependencies.aead]
+//! version = "0.2"
+//! default-features = false
+//! features = ["heapless"]
+//!
+//! [dependencies.aes-gcm-siv]
+//! version = "0.2"
+//! default-features = false
+//! ```
+//!
 //! [1]: https://en.wikipedia.org/wiki/AES-GCM-SIV
 //! [2]: https://tools.ietf.org/html/rfc8452
 //! [3]: https://en.wikipedia.org/wiki/Authenticated_encryption
 //! [4]: https://github.com/miscreant/meta/wiki/Nonce-Reuse-Misuse-Resistance
 //! [5]: https://www.imperialviolet.org/2017/05/14/aesgcmsiv.html
 //! [6]: https://codahale.com/towards-a-safer-footgun/
+//! [7]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.encrypt_in_place
+//! [8]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.decrypt_in_place
+//! [9]: https://docs.rs/aead/latest/aead/trait.Buffer.html
+//! [10]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -39,8 +39,39 @@
 //! assert_eq!(&plaintext, b"plaintext message");
 //! ```
 //!
+//! ## In-place Usage (eliminates `alloc` requirement)
+//!
+//! This crate has an optional `alloc` feature which can be disabled in e.g.
+//! microcontroller environments that don't have a heap.
+//!
+//! The [`Aead::encrypt_in_place`][3] and [`Aead::decrypt_in_place`][4]
+//! methods accept any type that impls the [`aead::Buffer`][5] trait which
+//! contains the plaintext for encryption or ciphertext for decryption.
+//!
+//! Note that if you enable the `heapless` feature of the `aead` crate,
+//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][6]
+//! type, which can then be passed as the `buffer` parameter to the
+//! in-place encrypt and decrypt methods.
+//!
+//! In `Cargo.toml`, add:
+//!
+//! ```toml
+//! [dependencies.aead]
+//! version = "0.2"
+//! default-features = false
+//! features = ["heapless"]
+//!
+//! [dependencies.aes-gcm]
+//! version = "0.2"
+//! default-features = false
+//! ```
+//!
 //! [1]: https://en.wikipedia.org/wiki/Authenticated_encryption
 //! [2]: https://en.wikipedia.org/wiki/Galois/Counter_Mode
+//! [3]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.encrypt_in_place
+//! [4]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.decrypt_in_place
+//! [5]: https://docs.rs/aead/latest/aead/trait.Buffer.html
+//! [6]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -2,10 +2,42 @@
 //! [Authenticated Encryption with Associated Data (AEAD)][3] cipher which also
 //! provides [nonce reuse misuse resistance][4].
 //!
+//!
+//! ## In-place Usage (eliminates `alloc` requirement)
+//!
+//! This crate has an optional `alloc` feature which can be disabled in e.g.
+//! microcontroller environments that don't have a heap.
+//!
+//! The [`Aead::encrypt_in_place`][5] and [`Aead::decrypt_in_place`][6]
+//! methods accept any type that impls the [`aead::Buffer`][7] trait which
+//! contains the plaintext for encryption or ciphertext for decryption.
+//!
+//! Note that if you enable the `heapless` feature of the `aead` crate,
+//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][8]
+//! type, which can then be passed as the `buffer` parameter to the
+//! in-place encrypt and decrypt methods.
+//!
+//! In `Cargo.toml`, add:
+//!
+//! ```toml
+//! [dependencies.aead]
+//! version = "0.2"
+//! default-features = false
+//! features = ["heapless"]
+//!
+//! [dependencies.aes-siv]
+//! version = "0.2"
+//! default-features = false
+//! ```
+//!
 //! [1]: https://github.com/miscreant/meta/wiki/AES-SIV
 //! [2]: https://tools.ietf.org/html/rfc5297
 //! [3]: https://en.wikipedia.org/wiki/Authenticated_encryption
 //! [4]: https://github.com/miscreant/meta/wiki/Nonce-Reuse-Misuse-Resistance
+//! [5]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.encrypt_in_place
+//! [6]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.decrypt_in_place
+//! [7]: https://docs.rs/aead/latest/aead/trait.Buffer.html
+//! [8]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -19,11 +19,12 @@ categories = ["cryptography", "no-std"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aead = "0.2"
+aead = { version = "0.2", default-features = false }
 chacha20 = { version = "0.2.1", features = ["zeroize"] }
 poly1305 = "0.5"
 zeroize = { version = "1", default-features = false }
 
 [features]
-default = ["xchacha20poly1305"]
+default = ["alloc", "xchacha20poly1305"]
+alloc = ["aead/alloc"]
 xchacha20poly1305 = ["chacha20/xchacha20"]

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -32,10 +32,41 @@
 //! assert_eq!(&plaintext, b"plaintext message");
 //! ```
 //!
+//! ## In-place Usage (eliminates `alloc` requirement)
+//!
+//! This crate has an optional `alloc` feature which can be disabled in e.g.
+//! microcontroller environments that don't have a heap.
+//!
+//! The [`Aead::encrypt_in_place`][5] and [`Aead::decrypt_in_place`][6]
+//! methods accept any type that impls the [`aead::Buffer`][7] trait which
+//! contains the plaintext for encryption or ciphertext for decryption.
+//!
+//! Note that if you enable the `heapless` feature of the `aead` crate,
+//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][8]
+//! type, which can then be passed as the `buffer` parameter to the
+//! in-place encrypt and decrypt methods.
+//!
+//! In `Cargo.toml`, add:
+//!
+//! ```toml
+//! [dependencies.aead]
+//! version = "0.2"
+//! default-features = false
+//! features = ["heapless"]
+//!
+//! [dependencies.chacha20poly1305]
+//! version = "0.2"
+//! default-features = false
+//! ```
+//!
 //! [1]: https://tools.ietf.org/html/rfc8439
 //! [2]: https://en.wikipedia.org/wiki/Authenticated_encryption
 //! [3]: https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20
 //! [4]: https://github.com/RustCrypto/universal-hashes/tree/master/poly1305
+//! [5]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.encrypt_in_place
+//! [6]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.decrypt_in_place
+//! [7]: https://docs.rs/aead/latest/aead/trait.Buffer.html
+//! [8]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -34,6 +34,33 @@
 //! assert_eq!(&plaintext, b"plaintext message");
 //! ```
 //!
+//! ## In-place Usage (eliminates `alloc` requirement)
+//!
+//! This crate has an optional `alloc` feature which can be disabled in e.g.
+//! microcontroller environments that don't have a heap.
+//!
+//! The [`Aead::encrypt_in_place`][3] and [`Aead::decrypt_in_place`][4]
+//! methods accept any type that impls the [`aead::Buffer`][5] trait which
+//! contains the plaintext for encryption or ciphertext for decryption.
+//!
+//! Note that if you enable the `heapless` feature of the `aead` crate,
+//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][6]
+//! type, which can then be passed as the `buffer` parameter to the
+//! in-place encrypt and decrypt methods.
+//!
+//! In `Cargo.toml`, add:
+//!
+//! ```toml
+//! [dependencies.aead]
+//! version = "0.2"
+//! default-features = false
+//! features = ["heapless"]
+//!
+//! [dependencies.xsalsa20poly1305]
+//! version = "0.2"
+//! default-features = false
+//! ```
+//!
 //! [1]: https://nacl.cr.yp.to/secretbox.html
 //! [2]: https://en.wikipedia.org/wiki/Authenticated_encryption
 //! [3]: https://github.com/RustCrypto/stream-ciphers/tree/master/salsa20


### PR DESCRIPTION
All crates in this repo now have an optional `alloc` feature which can be disabled for use in heapless environments.