### PR TITLE
Add a `heapless` feature to all crates + docs to use it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - nightly
 
 script:
-  - cargo test --all --release
+  - cargo test --all --release --lib
   - cargo test --all --all-features --release
 
 env:

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -32,6 +32,10 @@ criterion-cycles-per-byte = "0.1.1"
 [features]
 default = ["alloc"]
 alloc = ["aead/alloc"]
+heapless = ["aead/heapless"]
+
+[package.metadata.docs.rs]
+all-features = true
 
 [[bench]]
 name = "aes-gcm-siv"

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -40,6 +40,8 @@
 //!
 //! # Usage
 //!
+//! Simple usage (allocating, no associated data):
+//!
 //! ```
 //! use aes_gcm_siv::Aes256GcmSiv; // Or `Aes128GcmSiv`
 //! use aead::{Aead, NewAead, generic_array::GenericArray};
@@ -62,22 +64,35 @@
 //! methods accept any type that impls the [`aead::Buffer`][9] trait which
 //! contains the plaintext for encryption or ciphertext for decryption.
 //!
-//! Note that if you enable the `heapless` feature of the `aead` crate,
-//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][10]
-//! type, which can then be passed as the `buffer` parameter to the
-//! in-place encrypt and decrypt methods.
+//! Note that if you enable the `heapless` feature of this crate,
+//! you will receive an impl of `aead::Buffer` for [`heapless::Vec`][10]
+//! (re-exported from the `aead` crate as `aead::heapless::Vec`),
+//! which can then be passed as the `buffer` parameter to the in-place encrypt
+//! and decrypt methods:
 //!
-//! In `Cargo.toml`, add:
+//! ```
+//! use aes_gcm_siv::Aes256GcmSiv; // Or `Aes128GcmSiv`
+//! use aead::{Aead, NewAead};
+//! use aead::generic_array::{GenericArray, typenum::U128};
+//! use aead::heapless::Vec;
 //!
-//! ```toml
-//! [dependencies.aead]
-//! version = "0.2"
-//! default-features = false
-//! features = ["heapless"]
+//! let key = GenericArray::clone_from_slice(b"an example very very secret key.");
+//! let aead = Aes256GcmSiv::new(key);
 //!
-//! [dependencies.aes-gcm-siv]
-//! version = "0.2"
-//! default-features = false
+//! let nonce = GenericArray::from_slice(b"unique nonce"); // 96-bits; unique per message
+//!
+//! let mut buffer: Vec<u8, U128> = Vec::new();
+//! buffer.extend_from_slice(b"plaintext message");
+//!
+//! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
+//! aead.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//!
+//! // `buffer` now contains the message ciphertext
+//! assert_ne!(&buffer, b"plaintext message");
+//!
+//! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
+//! aead.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! assert_eq!(&buffer, b"plaintext message");
 //! ```
 //!
 //! [1]: https://en.wikipedia.org/wiki/AES-GCM-SIV

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -33,6 +33,10 @@ hex-literal = "0.2"
 [features]
 default = ["alloc"]
 alloc = ["aead/alloc"]
+heapless = ["aead/heapless"]
+
+[package.metadata.docs.rs]
+all-features = true
 
 [[bench]]
 name = "aes-gcm"

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -26,6 +26,8 @@
 //!
 //! # Usage
 //!
+//! Simple usage (allocating, no associated data):
+//!
 //! ```
 //! use aes_gcm::Aes256Gcm; // Or `Aes128Gcm`
 //! use aead::{Aead, NewAead, generic_array::GenericArray};
@@ -48,22 +50,35 @@
 //! methods accept any type that impls the [`aead::Buffer`][5] trait which
 //! contains the plaintext for encryption or ciphertext for decryption.
 //!
-//! Note that if you enable the `heapless` feature of the `aead` crate,
-//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][6]
-//! type, which can then be passed as the `buffer` parameter to the
-//! in-place encrypt and decrypt methods.
+//! Note that if you enable the `heapless` feature of this crate,
+//! you will receive an impl of `aead::Buffer` for [`heapless::Vec`][6]
+//! (re-exported from the `aead` crate as `aead::heapless::Vec`),
+//! which can then be passed as the `buffer` parameter to the in-place encrypt
+//! and decrypt methods:
 //!
-//! In `Cargo.toml`, add:
+//! ```
+//! use aes_gcm::Aes256Gcm; // Or `Aes128Gcm`
+//! use aead::{Aead, NewAead};
+//! use aead::generic_array::{GenericArray, typenum::U128};
+//! use aead::heapless::Vec;
 //!
-//! ```toml
-//! [dependencies.aead]
-//! version = "0.2"
-//! default-features = false
-//! features = ["heapless"]
+//! let key = GenericArray::clone_from_slice(b"an example very very secret key.");
+//! let aead = Aes256Gcm::new(key);
 //!
-//! [dependencies.aes-gcm]
-//! version = "0.2"
-//! default-features = false
+//! let nonce = GenericArray::from_slice(b"unique nonce"); // 96-bits; unique per message
+//!
+//! let mut buffer: Vec<u8, U128> = Vec::new();
+//! buffer.extend_from_slice(b"plaintext message");
+//!
+//! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
+//! aead.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//!
+//! // `buffer` now contains the message ciphertext
+//! assert_ne!(&buffer, b"plaintext message");
+//!
+//! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
+//! aead.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! assert_eq!(&buffer, b"plaintext message");
 //! ```
 //!
 //! [1]: https://en.wikipedia.org/wiki/Authenticated_encryption

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -35,6 +35,7 @@ hex-literal = "0.2"
 [features]
 default = ["alloc"]
 alloc = ["aead/alloc"]
+heapless = ["aead/heapless"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -27,4 +27,8 @@ zeroize = { version = "1", default-features = false }
 [features]
 default = ["alloc", "xchacha20poly1305"]
 alloc = ["aead/alloc"]
+heapless = ["aead/heapless"]
 xchacha20poly1305 = ["chacha20/xchacha20"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -20,7 +20,7 @@
 //! # Usage
 //!
 //! ```
-//! use chacha20poly1305::ChaCha20Poly1305;
+//! use chacha20poly1305::ChaCha20Poly1305; // Or `XChaCha20Poly1305`
 //! use aead::{Aead, NewAead, generic_array::GenericArray};
 //!
 //! let key = GenericArray::clone_from_slice(b"an example very very secret key."); // 32-bytes
@@ -41,22 +41,35 @@
 //! methods accept any type that impls the [`aead::Buffer`][7] trait which
 //! contains the plaintext for encryption or ciphertext for decryption.
 //!
-//! Note that if you enable the `heapless` feature of the `aead` crate,
-//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][8]
-//! type, which can then be passed as the `buffer` parameter to the
-//! in-place encrypt and decrypt methods.
+//! Note that if you enable the `heapless` feature of this crate,
+//! you will receive an impl of `aead::Buffer` for [`heapless::Vec`][8]
+//! (re-exported from the `aead` crate as `aead::heapless::Vec`),
+//! which can then be passed as the `buffer` parameter to the in-place encrypt
+//! and decrypt methods:
 //!
-//! In `Cargo.toml`, add:
+//! ```
+//! use chacha20poly1305::ChaCha20Poly1305; // Or `XChaCha20Poly1305`
+//! use aead::{Aead, NewAead};
+//! use aead::generic_array::{GenericArray, typenum::U128};
+//! use aead::heapless::Vec;
 //!
-//! ```toml
-//! [dependencies.aead]
-//! version = "0.2"
-//! default-features = false
-//! features = ["heapless"]
+//! let key = GenericArray::clone_from_slice(b"an example very very secret key.");
+//! let aead = ChaCha20Poly1305::new(key);
 //!
-//! [dependencies.chacha20poly1305]
-//! version = "0.2"
-//! default-features = false
+//! let nonce = GenericArray::from_slice(b"unique nonce"); // 128-bits; unique per message
+//!
+//! let mut buffer: Vec<u8, U128> = Vec::new();
+//! buffer.extend_from_slice(b"plaintext message");
+//!
+//! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
+//! aead.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//!
+//! // `buffer` now contains the message ciphertext
+//! assert_ne!(&buffer, b"plaintext message");
+//!
+//! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
+//! aead.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! assert_eq!(&buffer, b"plaintext message");
 //! ```
 //!
 //! [1]: https://tools.ietf.org/html/rfc8439

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -26,3 +26,7 @@ zeroize = { version = "1", default-features = false }
 [features]
 default = ["alloc"]
 alloc = ["aead/alloc"]
+heapless = ["aead/heapless"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -43,22 +43,35 @@
 //! methods accept any type that impls the [`aead::Buffer`][5] trait which
 //! contains the plaintext for encryption or ciphertext for decryption.
 //!
-//! Note that if you enable the `heapless` feature of the `aead` crate,
-//! you will receive an impl of `aead::Buffer` for the [`heapless::Vec`][6]
-//! type, which can then be passed as the `buffer` parameter to the
-//! in-place encrypt and decrypt methods.
+//! Note that if you enable the `heapless` feature of this crate,
+//! you will receive an impl of `aead::Buffer` for [`heapless::Vec`][8]
+//! (re-exported from the `aead` crate as `aead::heapless::Vec`),
+//! which can then be passed as the `buffer` parameter to the in-place encrypt
+//! and decrypt methods:
 //!
-//! In `Cargo.toml`, add:
+//! ```
+//! use xsalsa20poly1305::XSalsa20Poly1305;
+//! use aead::{Aead, NewAead};
+//! use aead::generic_array::{GenericArray, typenum::U128};
+//! use aead::heapless::Vec;
 //!
-//! ```toml
-//! [dependencies.aead]
-//! version = "0.2"
-//! default-features = false
-//! features = ["heapless"]
+//! let key = GenericArray::clone_from_slice(b"an example very very secret key.");
+//! let aead = XSalsa20Poly1305::new(key);
 //!
-//! [dependencies.xsalsa20poly1305]
-//! version = "0.2"
-//! default-features = false
+//! let nonce = GenericArray::from_slice(b"extra long unique nonce!"); // 24-bytes; unique
+//!
+//! let mut buffer: Vec<u8, U128> = Vec::new();
+//! buffer.extend_from_slice(b"plaintext message");
+//!
+//! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
+//! aead.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//!
+//! // `buffer` now contains the message ciphertext
+//! assert_ne!(&buffer, b"plaintext message");
+//!
+//! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
+//! aead.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! assert_eq!(&buffer, b"plaintext message");
 //! ```
 //!
 //! [1]: https://nacl.cr.yp.to/secretbox.html


### PR DESCRIPTION
Makes `heapless` a first-class feature on all crates, to simplify heapless usage (e.g. microcontrollers).

With `heapless` as a first-class feature, it becomes possible to explicitly document heapless usage as well, which this commit also does.