### PR TITLE
aes-gcm v0.3.0

### DIFF
--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2019-11-26)
+### Added
+- `heapless` feature ([#51])
+
+[#51]: https://github.com/RustCrypto/AEADs/pull/51
+
 ## 0.2.1 (2019-11-26)
 ### Added
 - Document in-place API ([#49])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.2.1"
+version = "0.3.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Added
- `heapless` feature ([#51])

[#51]: https://github.com/RustCrypto/AEADs/pull/51