### PR TITLE
aes-siv v0.2.0

### DIFF
--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2019-11-26)
+### Added
+- `heapless` feature ([#51])
+
+### Changed
+- Switch from `AeadMut` to `Aead` ([#47])
+- Make `Siv::new` type-safe via `typenum` arithmetic ([#45])
+- Upgrade `aead` crate to v0.2; `alloc` now optional ([#44])
+
+[#51]: https://github.com/RustCrypto/AEADs/pull/51
+[#47]: https://github.com/RustCrypto/AEADs/pull/47
+[#45]: https://github.com/RustCrypto/AEADs/pull/45
+[#44]: https://github.com/RustCrypto/AEADs/pull/44
+
 ## 0.1.2 (2019-11-14)
 ### Changed
 - Upgrade to `zeroize` 1.0 ([#36])

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.1.2"
+version = "0.2.0"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific


### PR DESCRIPTION
### Added
- `heapless` feature ([#51])

### Changed
- Switch from `AeadMut` to `Aead` ([#47])
- Make `Siv::new` type-safe via `typenum` arithmetic ([#45])
- Upgrade `aead` crate to v0.2; `alloc` now optional ([#44])

[#51]: https://github.com/RustCrypto/AEADs/pull/51
[#47]: https://github.com/RustCrypto/AEADs/pull/47
[#45]: https://github.com/RustCrypto/AEADs/pull/45
[#44]: https://github.com/RustCrypto/AEADs/pull/44