### PR TITLE
xsalsa20poly1305 v0.3.0

### DIFF
--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2019-11-26)
+### Added
+- `heapless` feature ([#51])
+
+### Changed
+- Upgrade `aead` crate to v0.2; `alloc` now optional ([#43])
+
+[#51]: https://github.com/RustCrypto/AEADs/pull/51
+[#43]: https://github.com/RustCrypto/AEADs/pull/43
+
 ## 0.2.1 (2019-11-14)
 ### Changed
 - Upgrade to `zeroize` 1.0 ([#36])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.2.1"
+version = "0.3.0"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
## 0.3.0 (2019-11-26)
### Added
- `heapless` feature ([#51])

### Changed
- Upgrade `aead` crate to v0.2; `alloc` now optional ([#43])

[#51]: https://github.com/RustCrypto/AEADs/pull/51
[#43]: https://github.com/RustCrypto/AEADs/pull/43