### PR TITLE
Use `copy_within` for `aes-siv`/`xsalsa20poly1305`; MSRV 1.37+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
     - rust: nightly
   fast_finish: true
   include:
-    - name: "Rust: 1.36.0"
-      rust: 1.36.0
+    - name: "Rust: 1.37.0"
+      rust: 1.37.0
       env: {} # clear `-D warnings` above; allow warnings
     - name: "Rust: stable (thumbv7em-none-eabihf)"
       rust: stable

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ security reviews.
 | [XSalsa20Poly1305](https://nacl.cr.yp.to/secretbox.html) | [![crates.io](https://img.shields.io/crates/v/xsalsa20poly1305.svg)](https://crates.io/crates/xsalsa20poly1305) | [![Documentation](https://docs.rs/xsalsa20poly1305/badge.svg)](https://docs.rs/xsalsa20poly1305) |
 
 ### Minimum Supported Rust Version
-All crates in this repository support Rust 1.36 or higher. In future minimum
+All crates in this repository support Rust 1.37 or higher. In future minimum
 supported Rust version can be changed, but it will be done with the minor
 version bump.
 

--- a/aes-gcm-siv/README.md
+++ b/aes-gcm-siv/README.md
@@ -56,7 +56,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes-gcm-siv/badge.svg
 [docs-link]: https://docs.rs/aes-gcm-siv/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [build-image]: https://travis-ci.com/RustCrypto/AEADs.svg?branch=master
 [build-link]: https://travis-ci.com/RustCrypto/AEADs

--- a/aes-gcm/README.md
+++ b/aes-gcm/README.md
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes-gcm/badge.svg
 [docs-link]: https://docs.rs/aes-gcm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [build-image]: https://travis-ci.com/RustCrypto/AEADs.svg?branch=master
 [build-link]: https://travis-ci.com/RustCrypto/AEADs

--- a/aes-siv/README.md
+++ b/aes-siv/README.md
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes-siv/badge.svg
 [docs-link]: https://docs.rs/aes-siv/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [build-image]: https://travis-ci.com/RustCrypto/AEADs.svg?branch=master
 [build-link]: https://travis-ci.com/RustCrypto/AEADs

--- a/aes-siv/src/siv.rs
+++ b/aes-siv/src/siv.rs
@@ -127,10 +127,7 @@ where
         buffer.extend_from_slice(Tag::default().as_slice())?;
 
         // TODO(tarcieri): add offset param to `encrypt_in_place_detached`
-        for i in (0..pt_len).rev() {
-            let byte = buffer.as_ref()[i];
-            buffer.as_mut()[i + IV_SIZE] = byte;
-        }
+        buffer.as_mut().copy_within(..pt_len, IV_SIZE);
 
         let tag = self.encrypt_in_place_detached(headers, &mut buffer.as_mut()[IV_SIZE..])?;
         buffer.as_mut()[..IV_SIZE].copy_from_slice(tag.as_slice());
@@ -194,11 +191,7 @@ where
         let pt_len = buffer.len() - IV_SIZE;
 
         // TODO(tarcieri): add offset param to `encrypt_in_place_detached`
-        for i in 0..pt_len {
-            let byte = buffer.as_ref()[i + IV_SIZE];
-            buffer.as_mut()[i] = byte;
-        }
-
+        buffer.as_mut().copy_within(IV_SIZE.., 0);
         buffer.truncate(pt_len);
         Ok(())
     }

--- a/chacha20poly1305/README.md
+++ b/chacha20poly1305/README.md
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/chacha20poly1305/badge.svg
 [docs-link]: https://docs.rs/chacha20poly1305/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [build-image]: https://travis-ci.com/RustCrypto/AEADs.svg?branch=master
 [build-link]: https://travis-ci.com/RustCrypto/AEADs

--- a/xsalsa20poly1305/README.md
+++ b/xsalsa20poly1305/README.md
@@ -7,7 +7,7 @@
 ![Maintenance Status: Experimental][maintenance-image]
 [![Build Status][build-image]][build-link]
 
-**XSalsa20Poly1305** (a.k.a. NaCl `crypto_secretbox`[1]) is an
+**XSalsa20Poly1305** (a.k.a. NaCl [`crypto_secretbox`][1]) is an
 [authenticated encryption][2] cipher amenable to fast, constant-time
 implementations in software, based on the [Salsa20][3] stream cipher 
 (with [XSalsa20][4] 192-bit nonce extension) and the [Poly1305][5] universal
@@ -49,7 +49,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/xsalsa20poly1305/badge.svg
 [docs-link]: https://docs.rs/xsalsa20poly1305/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [build-image]: https://travis-ci.com/RustCrypto/AEADs.svg?branch=master
 [build-link]: https://travis-ci.com/RustCrypto/AEADs

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -134,10 +134,7 @@ impl Aead for XSalsa20Poly1305 {
         buffer.extend_from_slice(Tag::default().as_slice())?;
 
         // TODO(tarcieri): add offset param to `encrypt_in_place_detached`
-        for i in (0..pt_len).rev() {
-            let byte = buffer.as_ref()[i];
-            buffer.as_mut()[i + tag_len] = byte;
-        }
+        buffer.as_mut().copy_within(..pt_len, tag_len);
 
         let tag = self.encrypt_in_place_detached(
             nonce,
@@ -181,11 +178,7 @@ impl Aead for XSalsa20Poly1305 {
         let pt_len = buffer.len() - tag_len;
 
         // TODO(tarcieri): add offset param to `encrypt_in_place_detached`
-        for i in 0..pt_len {
-            let byte = buffer.as_ref()[i + tag_len];
-            buffer.as_mut()[i] = byte;
-        }
-
+        buffer.as_mut().copy_within(tag_len.., 0);
         buffer.truncate(pt_len);
         Ok(())
     }


### PR DESCRIPTION
`aes-siv` and `xsalsa20poly1305` use a prepended authentication tag, which means during in-place encryption/decryption, they need the message shifted by the tag size.

It would be nice if this could happen during encryption/decryption:

https://github.com/RustCrypto/block-ciphers/issues/59

...but barring that, using `copy_within` (which performs a `memmove` behind the scenes) should be the fastest available option.

This commit replaces a previous `for` loop which performed this copy with `copy_within`.

Note that `copy_within` is MSRV 1.37+, so this bumps the project MSRV up by a single version (from 1.36).