### PR TITLE
chacha20poly1305: add benchmark

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -34,9 +34,9 @@ default = ["alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
 
-[package.metadata.docs.rs]
-all-features = true
-
 [[bench]]
 name = "aes-gcm-siv"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -35,9 +35,9 @@ default = ["alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
 
-[package.metadata.docs.rs]
-all-features = true
-
 [[bench]]
 name = "aes-gcm"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -24,11 +24,19 @@ chacha20 = { version = "0.2.1", features = ["zeroize"] }
 poly1305 = "0.5"
 zeroize = { version = "1", default-features = false }
 
+[dev-dependencies]
+criterion = "0.3.0"
+criterion-cycles-per-byte = "0.1.1"
+
 [features]
 default = ["alloc", "xchacha20poly1305"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
 xchacha20poly1305 = ["chacha20/xchacha20"]
+
+[[bench]]
+name = "aes-gcm"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/chacha20poly1305/benches/aes-gcm.rs
+++ b/chacha20poly1305/benches/aes-gcm.rs
@@ -1,0 +1,35 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion_cycles_per_byte::CyclesPerByte;
+
+use aead::{Aead, NewAead};
+use chacha20poly1305::ChaCha20Poly1305;
+
+const KB: usize = 1024;
+
+fn bench(c: &mut Criterion<CyclesPerByte>) {
+    let mut group = c.benchmark_group("chacha20poly1305");
+
+    for size in &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
+        let buf = vec![0u8; *size];
+
+        group.throughput(Throughput::Bytes(*size as u64));
+
+        group.bench_function(BenchmarkId::new("encrypt", size), |b| {
+            let cipher = ChaCha20Poly1305::new(Default::default());
+            b.iter(|| cipher.encrypt(&Default::default(), &*buf))
+        });
+        group.bench_function(BenchmarkId::new("decrypt", size), |b| {
+            let cipher = ChaCha20Poly1305::new(Default::default());
+            b.iter(|| cipher.decrypt(&Default::default(), &*buf))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_measurement(CyclesPerByte);
+    targets = bench
+);
+criterion_main!(benches);


### PR DESCRIPTION
Adds a `criterion` benchmark similar to the `aes-gcm` and `aes-gcm-siv` crate, with the cycles-per-byte plugin enabled.