### PR TITLE
chacha20poly1305: upgrade to `chacha20` v0.3

### DIFF
--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 aead = { version = "0.2", default-features = false }
-chacha20 = { version = "0.2.1", features = ["zeroize"] }
+chacha20 = { version = "0.3", features = ["zeroize"] }
 poly1305 = "0.5"
 zeroize = { version = "1", default-features = false }
 


### PR DESCRIPTION
This results in a ~60% performance boost for encryption when the AVX2 backend is enabled.

Decryption performance is unaffected.

<img width="667" alt="Screen Shot 2020-01-16 at 9 30 44 AM" src="https://user-images.githubusercontent.com/797/72548430-86938300-3843-11ea-9973-a176bba5b3a6.png">
