### PR TITLE
chacha20poly1305: Add ChaCha8/ChaCha20 reduced round variants

### DIFF
--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -2,9 +2,11 @@
 name = "chacha20poly1305"
 version = "0.3.0"
 description = """
-Pure Rust implementation of the ChaCha20Poly1305 (and XChaCha20Poly1305)
-Authenticated Encryption with Additional Data Ciphers (RFC 8439) with optional
-architecture-specific hardware acceleration
+Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
+with Additional Data Ciphers (RFC 8439) with optional architecture-specific
+hardware acceleration. Also contains implementations of the XChaCha20Poly1305
+extended nonce variant of ChaCha20Poly1305, and the reduced-round
+ChaCha8Poly1305 and ChaCha12Poly1305 lightweight variants.
 """
 authors = ["RustCrypto Developers"]
 edition = "2018"
@@ -32,6 +34,7 @@ criterion-cycles-per-byte = "0.1.1"
 default = ["alloc", "xchacha20poly1305"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
+reduced-round = []
 xchacha20poly1305 = ["chacha20/xchacha20"]
 
 [[bench]]


### PR DESCRIPTION
Adds `ChaCha8Poly1305` and `ChaCha12Poly1305` AEADs, gated under the (off-by-default) `reduced-round` cargo feature.

See the writeup I've already done for the `rand_chacha` crate for the rationale of including these by default:

https://github.com/rust-random/rand/issues/932

tl;dr: the "Too Much Crypto" paper goes into why ChaCha20 is overkill, ChaCha12 is probably what should've been standardized per the eSTREAM analysis of Salsa20 (but wasn't for cargo cult reasons), and ChaCha8 is still probably safe:

https://eprint.iacr.org/2019/1492