### PR TITLE
chacha20poly1305 v0.3.1

### DIFF
--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2020-01-16)
+### Added
+- `ChaCha8Poly1305`/`ChaCha12Poly1305` reduced round variants ([#69])
+- `criterion`-based benchmark ([#66])
+
+### Changed
+- Upgrade to `chacha20` v0.3; adds AVX2 backend w\ +60% perf ([#67])
+
+[#66]: https://github.com/RustCrypto/AEADs/pull/66
+[#67]: https://github.com/RustCrypto/AEADs/pull/67
+[#69]: https://github.com/RustCrypto/AEADs/pull/69
+
 ## 0.3.0 (2019-11-26)
 ### Added
 - `heapless` feature ([#51])

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.3.0"
+version = "0.3.1"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Ciphers (RFC 8439) with optional architecture-specific
@@ -18,7 +18,7 @@ keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
 [badges]
-maintenance = { status = "experimental" }
+maintenance = { status = "passively-maintained" }
 
 [dependencies]
 aead = { version = "0.2", default-features = false }

--- a/chacha20poly1305/README.md
+++ b/chacha20poly1305/README.md
@@ -4,7 +4,6 @@
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
-![Maintenance Status: Experimental][maintenance-image]
 [![Build Status][build-image]][build-link]
 
 **ChaCha20Poly1305** ([RFC 8439][1]) is an [Authenticated Encryption with Associated Data (AEAD)][2]
@@ -47,7 +46,6 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/chacha20poly1305/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
-[maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [build-image]: https://travis-ci.com/RustCrypto/AEADs.svg?branch=master
 [build-link]: https://travis-ci.com/RustCrypto/AEADs
 


### PR DESCRIPTION
### Added
- `ChaCha8Poly1305`/`ChaCha12Poly1305` reduced round variants ([#69])
- `criterion`-based benchmark ([#66])

### Changed
- Upgrade to `chacha20` v0.3; adds AVX2 backend w\ +60% perf ([#67])

[#66]: https://github.com/RustCrypto/AEADs/pull/66
[#67]: https://github.com/RustCrypto/AEADs/pull/67
[#69]: https://github.com/RustCrypto/AEADs/pull/69