### PR TITLE
aes-gcm/chacha20poly1305: add NCC audit notes to doc

### DIFF
--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["aead", "aes", "encryption", "gcm", "ghash"]
 categories = ["cryptography", "no-std"]
 
 [badges]
-maintenance = { status = "experimental" }
+maintenance = { status = "actively-maintained" }
 
 [dependencies]
 aead = { version = "0.2", default-features = false }

--- a/aes-gcm/README.md
+++ b/aes-gcm/README.md
@@ -1,24 +1,22 @@
-# AES-GCM
-
-[![crate][crate-image]][crate-link]
-[![Docs][docs-image]][docs-link]
-![Apache2/MIT licensed][license-image]
-![Rust Version][rustc-image]
-![Maintenance Status: Experimental][maintenance-image]
-[![Build Status][build-image]][build-link]
+# AES-GCM [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![Build Status][build-image]][build-link]
 
 Pure Rust implementation of the AES-GCM
 [Authenticated Encryption with Associated Data (AEAD)][1] cipher.
 
 [Documentation][docs-link]
 
-## Security Warning
+## Security Notes
 
-No security audits of this crate have ever been performed, and it has not been
-thoroughly assessed to ensure its operation is constant-time on common CPU
-architectures.
+This crate has received one [audit security by NCC Group][2], with no significant
+findings. We would like to thank [MobileCoin][3] for funding the audit.
 
-USE AT YOUR OWN RISK!
+All implementations contained in the crate are designed to execute in constant
+time, either by relying on hardware intrinsics (i.e. AES-NI and CLMUL on
+x86/x86_64), or using a portable implementation which is only constant time
+on processors which implement constant-time multiplication.
+
+It is not suitable for use on processors with a variable-time multiplication
+operation (e.g. short circuit on multiply-by-zero / multiply-by-one).
 
 ## License
 
@@ -43,10 +41,11 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/aes-gcm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
-[maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [build-image]: https://travis-ci.com/RustCrypto/AEADs.svg?branch=master
 [build-link]: https://travis-ci.com/RustCrypto/AEADs
 
 [//]: # (general links)
 
 [1]: https://en.wikipedia.org/wiki/Authenticated_encryption
+[2]: https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/
+[3]: https://www.mobilecoin.com/

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
 [badges]
-maintenance = { status = "passively-maintained" }
+maintenance = { status = "actively-maintained" }
 
 [dependencies]
 aead = { version = "0.2", default-features = false }

--- a/chacha20poly1305/README.md
+++ b/chacha20poly1305/README.md
@@ -1,27 +1,27 @@
-# ChaCha20Poly1305: Authenticated Encryption Cipher
+# ChaCha20Poly1305 [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![Build Status][build-image]][build-link]
 
-[![crate][crate-image]][crate-link]
-[![Docs][docs-image]][docs-link]
-![Apache2/MIT licensed][license-image]
-![Rust Version][rustc-image]
-[![Build Status][build-image]][build-link]
-
-**ChaCha20Poly1305** ([RFC 8439][1]) is an [Authenticated Encryption with Associated Data (AEAD)][2]
-cipher amenable to fast, constant-time implementations in software, based on
-the [ChaCha20][3] stream cipher and [Poly1305][4] universal hash function.
+Pure Rust implementation of **ChaCha20Poly1305** ([RFC 8439][1]): an
+[Authenticated Encryption with Associated Data (AEAD)][2] cipher amenable to
+fast, constant-time implementations in software, based on the [ChaCha20][3]
+stream cipher and [Poly1305][4] universal hash function.
 
 This crate also contains an implementation of **XChaCha20Poly1305**: a variant
 of ChaCha20Poly1305 with an extended 192-bit (24-byte) nonce.
 
 [Documentation][docs-link]
 
-## Security Warning
+## Security Notes
 
-No security audits of this crate have ever been performed, and it has not been
-thoroughly assessed to ensure its operation is constant-time on common CPU
-architectures.
+This crate has received one [audit security by NCC Group][5], with no significant
+findings. We would like to thank [MobileCoin][6] for funding the audit.
 
-USE AT YOUR OWN RISK!
+All implementations contained in the crate are designed to execute in constant
+time, either by relying on hardware intrinsics (i.e. AVX2 on x86/x86_64), or
+using a portable implementation which is only constant time on processors which
+implement constant-time multiplication.
+
+It is not suitable for use on processors with a variable-time multiplication
+operation (e.g. short circuit on multiply-by-zero / multiply-by-one).
 
 ## License
 
@@ -55,3 +55,5 @@ dual licensed as above, without any additional terms or conditions.
 [2]: https://en.wikipedia.org/wiki/Authenticated_encryption
 [3]: https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20
 [4]: https://github.com/RustCrypto/universal-hashes/tree/master/poly1305
+[5]: https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/
+[6]: https://www.mobilecoin.com/

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -46,8 +46,12 @@ where
         }
 
         self.mac.update_padded(associated_data);
+
+        // TODO(tarcieri): interleave encryption with Poly1305
+        // See: <https://github.com/RustCrypto/AEADs/issues/74>
         self.cipher.apply_keystream(buffer);
         self.mac.update_padded(buffer);
+
         self.authenticate_lengths(associated_data, buffer)?;
         Ok(self.mac.result().into_bytes())
     }
@@ -70,6 +74,8 @@ where
 
         // This performs a constant-time comparison using the `subtle` crate
         if self.mac.verify(tag).is_ok() {
+            // TODO(tarcieri): interleave decryption with Poly1305
+            // See: <https://github.com/RustCrypto/AEADs/issues/74>
             self.cipher.apply_keystream(buffer);
             Ok(())
         } else {


### PR DESCRIPTION
Updates the README.md files and crate documentation for the `aes-gcm` and `chacha20poly1305` crates to reflect the NCC audit findings:

https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/