### PR TITLE
aes-gcm v0.3.1

### DIFF
--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2020-02-26)
+### Added
+- Notes about NCC audit to documentation ([#80])
+
+[#80]: https://github.com/RustCrypto/AEADs/pull/80
+
 ## 0.3.0 (2019-11-26)
 ### Added
 - `heapless` feature ([#51])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.3.0"
+version = "0.3.1"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher
@@ -16,7 +16,7 @@ keywords = ["aead", "aes", "encryption", "gcm", "ghash"]
 categories = ["cryptography", "no-std"]
 
 [badges]
-maintenance = { status = "actively-maintained" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 aead = { version = "0.2", default-features = false }

--- a/aes-gcm/README.md
+++ b/aes-gcm/README.md
@@ -16,7 +16,8 @@ x86/x86_64), or using a portable implementation which is only constant time
 on processors which implement constant-time multiplication.
 
 It is not suitable for use on processors with a variable-time multiplication
-operation (e.g. short circuit on multiply-by-zero / multiply-by-one).
+operation (e.g. short circuit on multiply-by-zero / multiply-by-one, such as
+certain 32-bit PowerPC CPUs and some non-ARM microcontrollers).
 
 ## License
 

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -24,7 +24,8 @@
 //! on processors which implement constant-time multiplication.
 //!
 //! It is not suitable for use on processors with a variable-time multiplication
-//! operation (e.g. short circuit on multiply-by-zero / multiply-by-one).
+//! operation (e.g. short circuit on multiply-by-zero / multiply-by-one, such as
+//! certain 32-bit PowerPC CPUs and some non-ARM microcontrollers).
 //!
 //! # Usage
 //!

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
 [badges]
-maintenance = { status = "actively-maintained" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 aead = { version = "0.2", default-features = false }


### PR DESCRIPTION
### Added
- Notes about NCC audit to documentation ([#80])

[#80]: https://github.com/RustCrypto/AEADs/pull/80