### PR TITLE
aes-gcm-siv: support instantiation from an existing cipher instance

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -20,7 +20,8 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 aead = { version = "0.2", default-features = false }
-aes = "0.3"
+aes = { version = "0.3", optional = true }
+block-cipher-trait = "0.6"
 polyval = { version = "0.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
@@ -30,7 +31,7 @@ criterion = "0.3.0"
 criterion-cycles-per-byte = "0.1.1"
 
 [features]
-default = ["alloc"]
+default = ["aes", "alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
 

--- a/aes-gcm-siv/src/ctr32.rs
+++ b/aes-gcm-siv/src/ctr32.rs
@@ -2,7 +2,7 @@ use aead::generic_array::{
     typenum::{U16, U8},
     GenericArray,
 };
-use aes::block_cipher_trait::BlockCipher;
+use block_cipher_trait::BlockCipher;
 use core::{convert::TryInto, mem};
 
 /// AES blocks

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -120,9 +120,13 @@ use aead::generic_array::{
     GenericArray,
 };
 use aead::{Aead, Error, NewAead};
-use aes::{block_cipher_trait::BlockCipher, Aes128, Aes256};
+use block_cipher_trait::BlockCipher;
 use polyval::{universal_hash::UniversalHash, Polyval};
 use zeroize::Zeroize;
+
+/// AES is optional to allow swapping in hardware-specific backends
+#[cfg(feature = "aes")]
+use aes::{Aes128, Aes256};
 
 /// Maximum length of associated data (from RFC 8452 Section 6)
 pub const A_MAX: u64 = 1 << 36;
@@ -137,9 +141,11 @@ pub const C_MAX: u64 = (1 << 36) + 16;
 pub type Tag = GenericArray<u8, U16>;
 
 /// AES-GCM-SIV with a 128-bit key
+#[cfg(feature = "aes")]
 pub type Aes128GcmSiv = AesGcmSiv<Aes128>;
 
 /// AES-GCM-SIV with a 256-bit key
+#[cfg(feature = "aes")]
 pub type Aes256GcmSiv = AesGcmSiv<Aes256>;
 
 /// AES-GCM-SIV: Misuse-Resistant Authenticated Encryption Cipher (RFC 8452)


### PR DESCRIPTION
The use case is instantiating AES-GCM-SIV using an embedded cryptographic processor (including one where the key is hardware-backed and deliberately inextricable)

See: https://github.com/iqlusioninc/usbarmory.rs/pull/41