### PR TITLE
aes-gcm-siv v0.4.0

### DIFF
--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-03-07)
+### Added
+- `aes` cargo feature; 3rd-party AES crate support ([#90])
+
+### Changed
+- Make generic around `BlockCipher::ParBlocks` ([#91], [#93])
+
+[#90]: https://github.com/RustCrypto/AEADs/pull/90
+[#91]: https://github.com/RustCrypto/AEADs/pull/91
+[#93]: https://github.com/RustCrypto/AEADs/pull/93
+
 ## 0.3.0 (2019-11-26)
 ### Added
 - `heapless` feature ([#51])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.3.0"
+version = "0.4.0"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific


### PR DESCRIPTION
### Added
- `aes` cargo feature; 3rd-party AES crate support ([#90])

### Changed
- Make generic around `BlockCipher::ParBlocks` ([#91], [#93])

[#90]: https://github.com/RustCrypto/AEADs/pull/90
[#91]: https://github.com/RustCrypto/AEADs/pull/91
[#93]: https://github.com/RustCrypto/AEADs/pull/93