### PR TITLE
aes-gcm v0.4.0

### DIFF
--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-03-07)
+### Added
+- `aes` cargo feature; 3rd-party AES crate support ([#96])
+
+### Changed
+- Make generic around `BlockCipher::ParBlocks` ([#97])
+
+[#96]: https://github.com/RustCrypto/AEADs/pull/96
+[#97]: https://github.com/RustCrypto/AEADs/pull/97
+
 ## 0.3.2 (2020-02-27)
 ### Fixed
 - Wording in documentation about security audit ([#84])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.3.2"
+version = "0.4.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Added
- `aes` cargo feature; 3rd-party AES crate support ([#96])

### Changed
- Make generic around `BlockCipher::ParBlocks` ([#97])

[#96]: https://github.com/RustCrypto/AEADs/pull/96
[#97]: https://github.com/RustCrypto/AEADs/pull/97