### PR TITLE
aes-gcm v0.4.1

### DIFF
--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2020-03-07)
+### Added
+- Support instantiation from an existing cipher instance ([#101])
+
+[#101]: https://github.com/RustCrypto/AEADs/pull/101
+
 ## 0.4.0 (2020-03-07)
 ### Added
 - `aes` cargo feature; 3rd-party AES crate support ([#96])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Added
- Support instantiation from an existing cipher instance ([#101])

[#101]: https://github.com/RustCrypto/AEADs/pull/101