### PR TITLE
aes-gcm(-siv): fix off-by-one error in ParBlocks `debug_assert`

### DIFF
--- a/aes-gcm-siv/src/ctr.rs
+++ b/aes-gcm-siv/src/ctr.rs
@@ -57,7 +57,7 @@ where
     fn apply_keystream_blocks(&mut self, block_cipher: &B, msg: &mut [u8]) {
         let mut counter = u32::from_le_bytes(self.counter_block[..4].try_into().unwrap());
         let n_blocks = msg.chunks(BLOCK_SIZE).count();
-        debug_assert!(n_blocks < B::ParBlocks::to_usize());
+        debug_assert!(n_blocks <= B::ParBlocks::to_usize());
 
         for block in self.buffer.iter_mut().take(n_blocks) {
             *block = self.counter_block;

--- a/aes-gcm/src/ctr.rs
+++ b/aes-gcm/src/ctr.rs
@@ -64,7 +64,7 @@ where
     fn apply_keystream_blocks(&mut self, block_cipher: &B, msg: &mut [u8]) {
         let mut counter = u32::from_be_bytes(self.counter_block[12..].try_into().unwrap());
         let n_blocks = msg.chunks(BLOCK_SIZE).count();
-        debug_assert!(n_blocks < B::ParBlocks::to_usize());
+        debug_assert!(n_blocks <= B::ParBlocks::to_usize());
 
         for block in self.buffer.iter_mut().take(n_blocks) {
             *block = self.counter_block;


### PR DESCRIPTION
This was checking that the number of parallel blocks to be computed doesn't exceed what's supported by the underlying cipher, except it failed in the case that the number of blocks to be computed was equal to the total supported.