### PR TITLE
aes-gcm-siv v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aead",
  "aes",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (2020-03-07)
+## 0.4.1 (2020-03-09)
+### Fixed
+- Off-by-one error in `debug_assert` for `BlockCipher::ParBlocks` ([#104])
+
+[#104]: https://github.com/RustCrypto/AEADs/pull/104
+
+## 0.4.0 (2020-03-07) - YANKED, see [#104]
 ### Added
 - `aes` cargo feature; 3rd-party AES crate support ([#90])
 

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#104]: https://github.com/RustCrypto/AEADs/pull/104
 
-## 0.4.1 (2020-03-07)
+## 0.4.1 (2020-03-07) - YANKED, see [#104]
 ### Added
 - Support instantiation from an existing cipher instance ([#101])
 
 [#101]: https://github.com/RustCrypto/AEADs/pull/101
 
-## 0.4.0 (2020-03-07)
+## 0.4.0 (2020-03-07) - YANKED, see [#104]
 ### Added
 - `aes` cargo feature; 3rd-party AES crate support ([#96])
 


### PR DESCRIPTION
### Fixed
- Off-by-one error in `debug_assert` for `BlockCipher::ParBlocks` ([#104])

[#104]: https://github.com/RustCrypto/AEADs/pull/104