### PR TITLE
Remove 'crate' from GitHub Action names

### DIFF
--- a/.github/workflows/aes-gcm-siv.yml
+++ b/.github/workflows/aes-gcm-siv.yml
@@ -1,4 +1,4 @@
-name: aes-gcm-siv crate
+name: aes-gcm-siv
 on:
   pull_request:
     paths:

--- a/.github/workflows/aes-gcm.yml
+++ b/.github/workflows/aes-gcm.yml
@@ -1,4 +1,4 @@
-name: aes-gcm crate
+name: aes-gcm
 on:
   pull_request:
     paths:

--- a/.github/workflows/aes-siv.yml
+++ b/.github/workflows/aes-siv.yml
@@ -1,4 +1,4 @@
-name: aes-siv crate
+name: aes-siv
 on:
   pull_request:
     paths:

--- a/.github/workflows/chacha20poly1305.yml
+++ b/.github/workflows/chacha20poly1305.yml
@@ -1,4 +1,4 @@
-name: chacha20poly1305 crate
+name: chacha20poly1305
 on:
   pull_request:
     paths:

--- a/.github/workflows/crypto_box.yml
+++ b/.github/workflows/crypto_box.yml
@@ -1,4 +1,4 @@
-name: crypto_box crate
+name: crypto_box
 on:
   pull_request:
     paths:

--- a/.github/workflows/ring-aead.yml
+++ b/.github/workflows/ring-aead.yml
@@ -1,4 +1,4 @@
-name: ring-aead crate
+name: ring-aead
 on:
   pull_request:
     paths:

--- a/.github/workflows/xsalsa20poly1305.yml
+++ b/.github/workflows/xsalsa20poly1305.yml
@@ -1,4 +1,4 @@
-name: xsalsa20poly1305 crate
+name: xsalsa20poly1305
 on:
   pull_request:
     paths:


### PR DESCRIPTION
The build badges are broken because of it, and it just makes things a bit harder than necessary