### PR TITLE
Handles variable-length nonce

### DIFF
--- a/aes-gcm/src/ctr.rs
+++ b/aes-gcm/src/ctr.rs
@@ -35,10 +35,14 @@ where
     B::ParBlocks: ArrayLength<GenericArray<u8, B::BlockSize>>,
 {
     /// Instantiate a new CTR instance
-    pub fn new(nonce: &GenericArray<u8, U12>) -> Self {
+    pub fn new(nonce: &[u8]) -> Self {
         let mut counter_block = GenericArray::default();
-        counter_block[..12].copy_from_slice(nonce.as_slice());
-        counter_block[15] = 1;
+        if nonce.len() == 12 {
+            counter_block[..12].copy_from_slice(nonce);
+            counter_block[15] = 1;
+        } else {
+            counter_block[..].copy_from_slice(nonce);
+        }
 
         Self {
             block_cipher: PhantomData,

--- a/aes-gcm/src/ctr.rs
+++ b/aes-gcm/src/ctr.rs
@@ -1,7 +1,7 @@
 //! Counter mode implementation
 
 use block_cipher_trait::generic_array::{
-    typenum::{Unsigned, U12, U16},
+    typenum::{Unsigned, U16},
     ArrayLength, GenericArray,
 };
 use block_cipher_trait::BlockCipher;


### PR DESCRIPTION
I'm trying to fix #62, but I'm not sure I'm on the right track.
I read source code of other implementations of variable-length nonce GCM. They do it like this:

- if nonce is 12 bytes, copy the nonce in counter and add 1 to the last bit
- else copy GHASH of nonce to counter

I did that here. Maybe it's wrong. I'm not sure.
This will be a breaking change but as mentioned in [here](https://github.com/RustCrypto/traits/issues/43), it is time to introduce breaking changes.