### PR TITLE
aes-gcm: make AesGcm generic around nonce size

### DIFF
--- a/aes-gcm/src/ctr.rs
+++ b/aes-gcm/src/ctr.rs
@@ -1,7 +1,7 @@
 //! Counter mode implementation
 
 use block_cipher_trait::generic_array::{
-    typenum::{Unsigned, U12, U16},
+    typenum::{Unsigned, U16},
     ArrayLength, GenericArray,
 };
 use block_cipher_trait::BlockCipher;
@@ -35,10 +35,14 @@ where
     B::ParBlocks: ArrayLength<GenericArray<u8, B::BlockSize>>,
 {
     /// Instantiate a new CTR instance
-    pub fn new(nonce: &GenericArray<u8, U12>) -> Self {
+    pub fn new(nonce: &[u8]) -> Self {
         let mut counter_block = GenericArray::default();
-        counter_block[..12].copy_from_slice(nonce.as_slice());
-        counter_block[15] = 1;
+        if nonce.len() == 12 {
+            counter_block[..12].copy_from_slice(nonce);
+            counter_block[15] = 1;
+        } else {
+            counter_block[..].copy_from_slice(nonce);
+        }
 
         Self {
             block_cipher: PhantomData,

--- a/aes-gcm/tests/other_ivlen.rs
+++ b/aes-gcm/tests/other_ivlen.rs
@@ -1,0 +1,81 @@
+//! Tests for AES-GCM when used with non-96-bit IVs.
+//!
+//! Vectors taken from NIST CAVS vectors' `gcmEncryptExtIV128.rsp` file
+/// <https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/CAVP-TESTING-BLOCK-CIPHER-MODES>
+
+#[macro_use]
+extern crate hex_literal;
+
+use aes_gcm::{
+    aead::{
+        generic_array::{typenum, GenericArray},
+        Aead, NewAead,
+    },
+    aes::Aes128,
+    AesGcm,
+};
+
+/// Based on the following `gcmEncryptExtIV128.rsp` test vector:
+///
+/// [Keylen = 128]
+/// [IVlen = 8]
+/// [PTlen = 128]
+/// [AADlen = 0]
+/// [Taglen = 128]
+///
+/// Count = 0
+mod ivlen8 {
+    use super::*;
+
+    type Aes128GcmWith8BitNonce = AesGcm<Aes128, typenum::U1>;
+
+    #[test]
+    fn encrypt() {
+        let key = hex!("15b2d414826453f9e1c7dd0b69d8d1eb");
+        let nonce = hex!("b6");
+        let plaintext = hex!("8cfa255530c6fbc19d51bd4aeb39c91b");
+
+        let ciphertext = Aes128GcmWith8BitNonce::new(key.into())
+            .encrypt(GenericArray::from_slice(&nonce), &plaintext[..])
+            .unwrap();
+
+        let (ct, tag) = ciphertext.split_at(ciphertext.len() - 16);
+        assert_eq!(hex!("4822cb98bd5f5d921ee19285c9032375"), ct);
+        assert_eq!(hex!("8a40670ebac98cf4e9cc1bf8f803167d"), tag);
+    }
+}
+
+/// Based on the following `gcmEncryptExtIV128.rsp` test vector:
+///
+/// [Keylen = 128]
+/// [IVlen = 1024]
+/// [PTlen = 128]
+/// [AADlen = 0]
+/// [Taglen = 128]
+///
+/// Count = 0
+mod ivlen1024 {
+    use super::*;
+
+    type Aes128GcmWith1024BitNonce = AesGcm<Aes128, typenum::U128>;
+
+    #[test]
+    fn encrypt() {
+        let key = hex!("71eebc49c8fb773b2224eaff3ad68714");
+        let nonce = hex!(
+            "07e961e67784011f72faafd95b0eb64089c8de15ad685ec57e63d56e679d3e20
+             2b18b75fcbbec3185ffc41653bc2ac4ae6ae8be8c85636f353a9d19a86100d0b
+             d035cc6bdefcab4318ac7b1a08b819427ad8f6abc782466c6ebd4d6a0dd76e78
+             389b0a2a66506bb85f038ffc1da220c24f3817c7b2d02c5e8fc5e7e3be5074bc"
+        );
+        let plaintext = hex!("705da82292143d2c949dc4ba014f6396");
+
+        let ciphertext = Aes128GcmWith1024BitNonce::new(key.into())
+            .encrypt(GenericArray::from_slice(&nonce), &plaintext[..])
+            .unwrap();
+
+        let (ct, tag) = ciphertext.split_at(ciphertext.len() - 16);
+        assert_eq!(hex!("032363cf0828a03553478bec0f51f372"), ct);
+        assert_eq!(hex!("c681b2c568feaa21900bc44b86aeb946"), tag);
+    }
+}


### PR DESCRIPTION
Support for non-96-bit nonces, while still implementing the current `Aead` interface and type safety for nonce lengths.