### PR TITLE
aes-gcm v0.5.0

### DIFF
--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-03-15)
+### Added
+- Support for non-96-bit nonces ([#126])
+
+### Changed
+- `AesGcm` type is now generic around nonce size ([#126])
+
+[#126]:  https://github.com/RustCrypto/AEADs/pull/126
+
 ## 0.4.2 (2020-03-09)
 ### Fixed
 - Off-by-one error in `debug_assert` for `BlockCipher::ParBlocks` ([#104])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.4.2"
+version = "0.5.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Added
- Support for non-96-bit nonces ([#126])

### Changed
- `AesGcm` type is now generic around nonce size ([#126])

[#126]:  https://github.com/RustCrypto/AEADs/pull/126