### PR TITLE
README.md(s): move CodeCov.io badges from Cargo.toml

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -15,10 +15,6 @@ repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "aes", "aes-gcm", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
 
-[badges]
-codecov = { repository = "RustCrypto/AEADs", branch = "master", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [dependencies]
 aead = { version = "0.2", default-features = false }
 aes = { version = "0.3", optional = true }

--- a/aes-gcm-siv/README.md
+++ b/aes-gcm-siv/README.md
@@ -4,6 +4,7 @@
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
+[![CodeCov Status][codecov-image]][codecov-link]
 [![Build Status][build-image]][build-link]
 
 [AES-GCM-SIV][1] ([RFC 8452][2]) is a state-of-the-art high-performance
@@ -68,6 +69,8 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/aes-gcm-siv/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [build-image]: https://github.com/RustCrypto/AEADs/workflows/aes-gcm-siv/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/AEADs/actions
 

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -15,10 +15,6 @@ repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "aes", "encryption", "gcm", "ghash"]
 categories = ["cryptography", "no-std"]
 
-[badges]
-codecov = { repository = "RustCrypto/AEADs", branch = "master", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [dependencies]
 aead = { version = "0.2", default-features = false }
 aes = { version = "0.3", optional = true }

--- a/aes-gcm/README.md
+++ b/aes-gcm/README.md
@@ -1,4 +1,4 @@
- # AES-GCM [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![Build Status][build-image]][build-link]
+ # AES-GCM [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![CodeCov Status][codecov-image]][codecov-link] [![Build Status][build-image]][build-link]
 
 Pure Rust implementation of the AES-GCM
 [Authenticated Encryption with Associated Data (AEAD)][1] cipher.
@@ -42,6 +42,8 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/aes-gcm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [build-image]: https://github.com/RustCrypto/AEADs/workflows/aes-gcm/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/AEADs/actions
 

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -15,10 +15,6 @@ repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "aes", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
 
-[badges]
-codecov = { repository = "RustCrypto/AEADs", branch = "master", service = "github" }
-maintenance = { status = "passively-maintained" }
-
 [dependencies]
 aead = { version = "0.2", default-features = false }
 aes = "0.3"

--- a/aes-siv/README.md
+++ b/aes-siv/README.md
@@ -1,4 +1,4 @@
-# AES-SIV: Misuse-Resistant Authenticated Encryption Cipher [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![Build Status][build-image]][build-link]
+# AES-SIV: Misuse-Resistant Authenticated Encryption Cipher [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![CodeCov Status][codecov-image]][codecov-link] [![Build Status][build-image]][build-link]
 
 [AES-SIV][1] ([RFC 5297][2]) is a high-performance
 [Authenticated Encryption with Associated Data (AEAD)][3] cipher which also
@@ -37,6 +37,8 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/aes-siv/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [build-image]: https://github.com/RustCrypto/AEADs/workflows/aes-siv/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/AEADs/actions
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -17,10 +17,6 @@ repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
-[badges]
-codecov = { repository = "RustCrypto/AEADs", branch = "master", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [dependencies]
 aead = { version = "0.2", default-features = false }
 chacha20 = { version = "0.3", features = ["zeroize"], optional = true }

--- a/chacha20poly1305/README.md
+++ b/chacha20poly1305/README.md
@@ -1,4 +1,4 @@
-# ChaCha20Poly1305 [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![Build Status][build-image]][build-link]
+# ChaCha20Poly1305 [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![CodeCov Status][codecov-image]][codecov-link] [![Build Status][build-image]][build-link]
 
 Pure Rust implementation of **ChaCha20Poly1305** ([RFC 8439][1]): an
 [Authenticated Encryption with Associated Data (AEAD)][2] cipher amenable to
@@ -47,6 +47,8 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/chacha20poly1305/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [build-image]: https://github.com/RustCrypto/AEADs/workflows/chacha20poly1305/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/AEADs/actions
 

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -16,10 +16,6 @@ repository = "https://github.com/RustCrypto/AEADs/tree/master/crypto_box"
 categories = ["cryptography", "no-std"]
 keywords = ["nacl", "libsodium", "public-key", "x25519", "xsalsa20poly1305"]
 
-[badges]
-codecov = { repository = "RustCrypto/AEADs", branch = "master", service = "github" }
-maintenance = { status = "passively-maintained" }
-
 [dependencies]
 rand_core = "0.5"
 salsa20 = { version = "0.4.1", features = ["hsalsa20"] }

--- a/crypto_box/README.md
+++ b/crypto_box/README.md
@@ -1,4 +1,4 @@
-# `crypto_box` [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![Build Status][build-image]][build-link]
+# `crypto_box` [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![CodeCov Status][codecov-image]][codecov-link] [![Build Status][build-image]][build-link]
 
 Pure Rust implementation of [NaCl]'s [`crypto_box`] primitive, providing
 public-key authenticated encryption which combines the [X25519] Diffie-Hellman
@@ -30,6 +30,8 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/crypto_box/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [build-image]: https://github.com/RustCrypto/AEADs/workflows/crypto_box/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/AEADs/actions
 

--- a/ring-aead/Cargo.toml
+++ b/ring-aead/Cargo.toml
@@ -14,10 +14,6 @@ repository = "https://github.com/RustCrypto/AEADs"
 categories = ["cryptography", "no-std"]
 keywords = ["aead", "aes-gcm", "chacha20poly1305", "crypto", "ring"]
 
-[badges]
-codecov = { repository = "RustCrypto/AEADs", branch = "master", service = "github" }
-maintenance = { status = "passively-maintained" }
-
 [dependencies]
 aead = { version = "0.2", default-features = false }
 ring = "0.16"

--- a/ring-aead/README.md
+++ b/ring-aead/README.md
@@ -1,4 +1,4 @@
-# *ring* AEAD [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![Build Status][build-image]][build-link]
+# *ring* AEAD [![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] ![Apache2/MIT licensed][license-image] ![Rust Version][rustc-image] [![CodeCov Status][codecov-image]][codecov-link] [![Build Status][build-image]][build-link]
 
 [`aead::Aead`] wrappers for high-performance implementations of AES-GCM and ChaCha20Poly1305 in the [*ring*] crate.
 
@@ -27,6 +27,8 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/ring-aead/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [build-image]: https://github.com/RustCrypto/AEADs/workflows/ring-aead/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/AEADs/actions
 

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -14,10 +14,6 @@ repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "salsa20", "poly1305", "xsalsa20"]
 categories = ["cryptography", "no-std"]
 
-[badges]
-codecov = { repository = "RustCrypto/AEADs", branch = "master", service = "github" }
-maintenance = { status = "passively-maintained" }
-
 [dependencies]
 aead = { version = "0.2", default-features = false }
 salsa20 = { version = "0.4", features = ["xsalsa20", "zeroize"] }

--- a/xsalsa20poly1305/README.md
+++ b/xsalsa20poly1305/README.md
@@ -4,6 +4,7 @@
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
+[![CodeCov Status][codecov-image]][codecov-link]
 [![Build Status][build-image]][build-link]
 
 **XSalsa20Poly1305** (a.k.a. NaCl [`crypto_secretbox`][1]) is an
@@ -49,6 +50,8 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/xsalsa20poly1305/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
+[codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [build-image]: https://github.com/RustCrypto/AEADs/workflows/xsalsa20poly1305/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/AEADs/actions
 


### PR DESCRIPTION
We previously relied on https://crates.io to display this but they removed all badges recently, so this deletes the `[badge]` section of Cargo.toml(s).

This commit adds the badge to all the README.md(s) as this repo has fairly decent (94% at present) code coverage.