### PR TITLE
aes-gcm-siv: bump `aead` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,12 +59,12 @@ dependencies = [
 name = "aes-gcm-siv"
 version = "0.4.1"
 dependencies = [
- "aead 0.2.0",
- "aes 0.3.2",
- "block-cipher-trait",
+ "aead 0.3.0-pre",
+ "aes 0.4.0-pre",
+ "block-cipher",
  "criterion",
  "criterion-cycles-per-byte",
- "polyval 0.3.3",
+ "polyval",
  "subtle 2.2.3",
  "zeroize",
 ]
@@ -490,7 +490,7 @@ name = "ghash"
 version = "0.3.0-pre"
 source = "git+https://github.com/RustCrypto/universal-hashes#ce8281ecfe1aaedf98f1885e7d7174dea9630dae"
 dependencies = [
- "polyval 0.4.0-pre",
+ "polyval",
 ]
 
 [[package]]
@@ -674,16 +674,6 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5829f50f48e9ddb79f3f7c3097029d0caee30f8286accb241416df603b080b8"
 dependencies = [
- "universal-hash 0.3.0",
-]
-
-[[package]]
-name = "polyval"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec3341498978de3bfd12d1b22f1af1de22818f5473a11e8a6ef997989e3a212"
-dependencies = [
- "cfg-if",
  "universal-hash 0.3.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ aes = { git = "https://github.com/RustCrypto/block-ciphers" }
 aead = { git = "https://github.com/RustCrypto/traits" }
 block-cipher = { git = "https://github.com/RustCrypto/traits" }
 ghash = { git = "https://github.com/RustCrypto/universal-hashes" }
+polyval = { git = "https://github.com/RustCrypto/universal-hashes" }
 universal-hash = { git = "https://github.com/RustCrypto/traits" }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -16,10 +16,10 @@ keywords = ["aead", "aes", "aes-gcm", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "0.2", default-features = false }
-aes = { version = "0.3", optional = true }
-block-cipher-trait = "0.6"
-polyval = { version = "0.3", default-features = false }
+aead = { version = "0.3.0-pre", default-features = false }
+aes = { version = "0.4.0-pre", optional = true }
+block-cipher = "0.7.0-pre"
+polyval = { version = "0.4.0-pre", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/aes-gcm-siv/src/ctr.rs
+++ b/aes-gcm-siv/src/ctr.rs
@@ -1,10 +1,10 @@
 //! Counter mode implementation
 
-use block_cipher_trait::generic_array::{
+use block_cipher::generic_array::{
     typenum::{Unsigned, U16},
     ArrayLength, GenericArray,
 };
-use block_cipher_trait::BlockCipher;
+use block_cipher::BlockCipher;
 use core::{convert::TryInto, marker::PhantomData, mem};
 
 /// AES blocks

--- a/aes-gcm-siv/tests/common/mod.rs
+++ b/aes-gcm-siv/tests/common/mod.rs
@@ -23,7 +23,7 @@ macro_rules! tests {
                     aad: vector.aad,
                 };
 
-                let cipher = <$aead>::new(*key);
+                let cipher = <$aead>::new(key);
                 let ciphertext = cipher.encrypt(nonce, payload).unwrap();
 
                 assert_eq!(vector.ciphertext, ciphertext.as_slice());
@@ -41,7 +41,7 @@ macro_rules! tests {
                     aad: vector.aad,
                 };
 
-                let cipher = <$aead>::new(*key);
+                let cipher = <$aead>::new(key);
                 let plaintext = cipher.decrypt(nonce, payload).unwrap();
 
                 assert_eq!(vector.plaintext, plaintext.as_slice());
@@ -64,7 +64,7 @@ macro_rules! tests {
                 aad: vector.aad,
             };
 
-            let cipher = <$aead>::new(*key);
+            let cipher = <$aead>::new(key);
             assert!(cipher.decrypt(nonce, payload).is_err());
 
             // TODO(tarcieri): test ciphertext is unmodified in in-place API


### PR DESCRIPTION
Bumps the `aead` crate to the v0.3.0-pre release