### PR TITLE
ring-aead: `aead` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 name = "ring-aead"
 version = "0.1.0"
 dependencies = [
- "aead 0.2.0",
+ "aead 0.3.0-pre",
  "hex-literal",
  "ring",
  "zeroize",

--- a/ring-aead/Cargo.toml
+++ b/ring-aead/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["aead", "aes-gcm", "chacha20poly1305", "crypto", "ring"]
 
 [dependencies]
-aead = { version = "0.2", default-features = false }
+aead = { version = "= 0.3.0-pre", default-features = false }
 ring = "0.16"
 zeroize = "1"
 

--- a/ring-aead/tests/aes128gcm.rs
+++ b/ring-aead/tests/aes128gcm.rs
@@ -7,7 +7,7 @@ extern crate hex_literal;
 mod common;
 
 use self::common::TestVector;
-use ring_aead::aead::{generic_array::GenericArray, Aead, NewAead, Payload};
+use ring_aead::aead::{generic_array::GenericArray, Aead, AeadInPlace, NewAead, Payload};
 use ring_aead::Aes128Gcm;
 
 /// NIST CAVS vectors

--- a/ring-aead/tests/aes256gcm.rs
+++ b/ring-aead/tests/aes256gcm.rs
@@ -7,7 +7,7 @@ extern crate hex_literal;
 mod common;
 
 use self::common::TestVector;
-use ring_aead::aead::{generic_array::GenericArray, Aead, NewAead, Payload};
+use ring_aead::aead::{generic_array::GenericArray, Aead, AeadInPlace, NewAead, Payload};
 use ring_aead::Aes256Gcm;
 
 /// NIST CAVS vectors

--- a/ring-aead/tests/chacha20poly1305.rs
+++ b/ring-aead/tests/chacha20poly1305.rs
@@ -47,7 +47,7 @@ fn encrypt() {
         aad: AAD,
     };
 
-    let cipher = ChaCha20Poly1305::new(*key);
+    let cipher = ChaCha20Poly1305::new(key);
     let ciphertext = cipher.encrypt(nonce, payload).unwrap();
 
     let tag_begins = ciphertext.len() - 16;
@@ -67,7 +67,7 @@ fn decrypt() {
         aad: AAD,
     };
 
-    let cipher = ChaCha20Poly1305::new(*key);
+    let cipher = ChaCha20Poly1305::new(key);
     let plaintext = cipher.decrypt(nonce, payload).unwrap();
 
     assert_eq!(PLAINTEXT, plaintext.as_slice());
@@ -89,6 +89,6 @@ fn decrypt_modified() {
         aad: AAD,
     };
 
-    let cipher = ChaCha20Poly1305::new(*key);
+    let cipher = ChaCha20Poly1305::new(key);
     assert!(cipher.decrypt(nonce, payload).is_err());
 }

--- a/ring-aead/tests/common/mod.rs
+++ b/ring-aead/tests/common/mod.rs
@@ -24,7 +24,7 @@ macro_rules! tests {
                     aad: vector.aad,
                 };
 
-                let cipher = <$aead>::new(*key);
+                let cipher = <$aead>::new(key);
                 let ciphertext = cipher.encrypt(nonce, payload).unwrap();
                 let (ct, tag) = ciphertext.split_at(ciphertext.len() - 16);
                 assert_eq!(vector.ciphertext, ct);
@@ -39,7 +39,7 @@ macro_rules! tests {
                 let nonce = GenericArray::from_slice(vector.nonce);
                 let mut buffer = vector.plaintext.to_vec();
 
-                let cipher = <$aead>::new(*key);
+                let cipher = <$aead>::new(key);
                 let tag = cipher
                     .encrypt_in_place_detached(nonce, vector.aad, &mut buffer)
                     .unwrap();
@@ -62,7 +62,7 @@ macro_rules! tests {
                     aad: vector.aad,
                 };
 
-                let cipher = <$aead>::new(*key);
+                let cipher = <$aead>::new(key);
                 let plaintext = cipher.decrypt(nonce, payload).unwrap();
 
                 assert_eq!(vector.plaintext, plaintext.as_slice());
@@ -77,7 +77,7 @@ macro_rules! tests {
                 let mut buffer = vector.ciphertext.to_vec();
                 buffer.extend_from_slice(vector.tag);
 
-                <$aead>::new(*key)
+                <$aead>::new(key)
                     .decrypt_in_place(nonce, vector.aad, &mut buffer)
                     .unwrap();
 
@@ -94,7 +94,7 @@ macro_rules! tests {
                 let tag = GenericArray::clone_from_slice(vector.tag);
                 let mut buffer = vector.ciphertext.to_vec();
 
-                <$aead>::new(*key)
+                <$aead>::new(key)
                     .decrypt_in_place_detached(nonce, vector.aad, &mut buffer, &tag)
                     .unwrap();
             }
@@ -117,7 +117,7 @@ macro_rules! tests {
                 aad: vector.aad,
             };
 
-            let cipher = <$aead>::new(*key);
+            let cipher = <$aead>::new(key);
             assert!(cipher.decrypt(nonce, payload).is_err());
 
             // TODO(tarcieri): test ciphertext is unmodified in in-place API


### PR DESCRIPTION
Upgrades to the `aead` v0.3.0-pre crate.