### PR TITLE
Bump all versions to `*-pre`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aead",
  "aes",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "aead",
  "aes",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "aead",
  "aes",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "aead",
  "chacha20",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "rand",
  "rand_core",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.3.1"
+version = "0.4.0-pre"
 dependencies = [
  "aead",
  "poly1305",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.4.1"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.5.0"
+version = "0.6.0-pre"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.4.1"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman
@@ -27,7 +27,7 @@ default-features = false
 features = ["u64_backend"]
 
 [dependencies.xsalsa20poly1305]
-version = "0.3"
+version = "= 0.4.0-pre"
 default-features = false
 features = ["rand_core"]
 path = "../xsalsa20poly1305"

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.3.1"
+version = "0.4.0-pre"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
...to reflect the breaking `aead` crate update