### PR TITLE
Documentation improvements

### DIFF
--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -53,14 +53,20 @@
 //!
 //! ```
 //! use aes_gcm_siv::Aes256GcmSiv; // Or `Aes128GcmSiv`
-//! use aead::{Aead, NewAead, generic_array::GenericArray};
+//! use aes_gcm_siv::aead::{Aead, NewAead, generic_array::GenericArray};
 //!
 //! let key = GenericArray::from_slice(b"an example very very secret key.");
-//! let aead = Aes256GcmSiv::new(key);
+//! let cipher = Aes256GcmSiv::new(key);
 //!
 //! let nonce = GenericArray::from_slice(b"unique nonce"); // 96-bits; unique per message
-//! let ciphertext = aead.encrypt(nonce, b"plaintext message".as_ref()).expect("encryption failure!");
-//! let plaintext = aead.decrypt(nonce, ciphertext.as_ref()).expect("decryption failure!");
+//!
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())
+//!     .expect("encryption failure!");  // NOTE: handle this error to avoid panics!
+//!
+//!
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
+//!     .expect("decryption failure!");  // NOTE: handle this error to avoid panics!
+//!
 //! assert_eq!(&plaintext, b"plaintext message");
 //! ```
 //!
@@ -69,24 +75,25 @@
 //! This crate has an optional `alloc` feature which can be disabled in e.g.
 //! microcontroller environments that don't have a heap.
 //!
-//! The [`Aead::encrypt_in_place`][8] and [`Aead::decrypt_in_place`][9]
-//! methods accept any type that impls the [`aead::Buffer`][10] trait which
+//! The [`AeadInPlace::encrypt_in_place`] and [`AeadInPlace::decrypt_in_place`]
+//! methods accept any type that impls the [`aead::Buffer`] trait which
 //! contains the plaintext for encryption or ciphertext for decryption.
 //!
 //! Note that if you enable the `heapless` feature of this crate,
-//! you will receive an impl of `aead::Buffer` for [`heapless::Vec`][11]
-//! (re-exported from the `aead` crate as `aead::heapless::Vec`),
+//! you will receive an impl of [`aead::Buffer`] for `heapless::Vec`
+//! (re-exported from the [`aead`] crate as [`aead::heapless::Vec`]),
 //! which can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
 //! ```
+//! # #[cfg(feature = "heapless")]
+//! # {
 //! use aes_gcm_siv::Aes256GcmSiv; // Or `Aes128GcmSiv`
-//! use aead::{AeadInPlace, NewAead};
-//! use aead::generic_array::{GenericArray, typenum::U128};
-//! use aead::heapless::Vec;
+//! use aes_gcm_siv::aead::{AeadInPlace, NewAead, generic_array::GenericArray};
+//! use aes_gcm_siv::aead::heapless::{Vec, consts::U128};
 //!
 //! let key = GenericArray::from_slice(b"an example very very secret key.");
-//! let aead = Aes256GcmSiv::new(key);
+//! let cipher = Aes256GcmSiv::new(key);
 //!
 //! let nonce = GenericArray::from_slice(b"unique nonce"); // 96-bits; unique per message
 //!
@@ -94,14 +101,15 @@
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! aead.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//! cipher.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
 //!
 //! // `buffer` now contains the message ciphertext
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! aead.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! cipher.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
 //! assert_eq!(&buffer, b"plaintext message");
+//! # }
 //! ```
 //!
 //! [1]: https://en.wikipedia.org/wiki/AES-GCM-SIV
@@ -111,10 +119,6 @@
 //! [5]: https://www.imperialviolet.org/2017/05/14/aesgcmsiv.html
 //! [6]: https://codahale.com/towards-a-safer-footgun/
 //! [7]: https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/
-//! [8]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.encrypt_in_place
-//! [9]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.decrypt_in_place
-//! [10]: https://docs.rs/aead/latest/aead/trait.Buffer.html
-//! [11]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -33,14 +33,19 @@
 //!
 //! ```
 //! use aes_gcm::Aes256Gcm; // Or `Aes128Gcm`
-//! use aead::{Aead, NewAead, generic_array::GenericArray};
+//! use aes_gcm::aead::{Aead, NewAead, generic_array::GenericArray};
 //!
 //! let key = GenericArray::from_slice(b"an example very very secret key.");
-//! let aead = Aes256Gcm::new(key);
+//! let cipher = Aes256Gcm::new(key);
 //!
 //! let nonce = GenericArray::from_slice(b"unique nonce"); // 96-bits; unique per message
-//! let ciphertext = aead.encrypt(nonce, b"plaintext message".as_ref()).expect("encryption failure!");
-//! let plaintext = aead.decrypt(nonce, ciphertext.as_ref()).expect("decryption failure!");
+//!
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())
+//!     .expect("encryption failure!"); // NOTE: handle this error to avoid panics!
+//!
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
+//!     .expect("decryption failure!"); // NOTE: handle this error to avoid panics!
+//!
 //! assert_eq!(&plaintext, b"plaintext message");
 //! ```
 //!
@@ -49,24 +54,25 @@
 //! This crate has an optional `alloc` feature which can be disabled in e.g.
 //! microcontroller environments that don't have a heap.
 //!
-//! The [`Aead::encrypt_in_place`][5] and [`Aead::decrypt_in_place`][6]
-//! methods accept any type that impls the [`aead::Buffer`][7] trait which
+//! The [`AeadInPlace::encrypt_in_place`] and [`AeadInPlace::decrypt_in_place`]
+//! methods accept any type that impls the [`aead::Buffer`] trait which
 //! contains the plaintext for encryption or ciphertext for decryption.
 //!
 //! Note that if you enable the `heapless` feature of this crate,
-//! you will receive an impl of `aead::Buffer` for [`heapless::Vec`][8]
-//! (re-exported from the `aead` crate as `aead::heapless::Vec`),
+//! you will receive an impl of [`aead::Buffer`] for `heapless::Vec`
+//! (re-exported from the [`aead`] crate as [`aead::heapless::Vec`]),
 //! which can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
 //! ```
+//! # #[cfg(feature = "heapless")]
+//! # {
 //! use aes_gcm::Aes256Gcm; // Or `Aes128Gcm`
-//! use aead::{AeadInPlace, NewAead};
-//! use aead::generic_array::{GenericArray, typenum::U128};
-//! use aead::heapless::Vec;
+//! use aes_gcm::aead::{AeadInPlace, NewAead, generic_array::GenericArray};
+//! use aes_gcm::aead::heapless::{Vec, consts::U128};
 //!
 //! let key = GenericArray::from_slice(b"an example very very secret key.");
-//! let aead = Aes256Gcm::new(key);
+//! let cipher = Aes256Gcm::new(key);
 //!
 //! let nonce = GenericArray::from_slice(b"unique nonce"); // 96-bits; unique per message
 //!
@@ -74,24 +80,21 @@
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! aead.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//! cipher.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
 //!
 //! // `buffer` now contains the message ciphertext
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! aead.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! cipher.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
 //! assert_eq!(&buffer, b"plaintext message");
+//! # }
 //! ```
 //!
 //! [1]: https://en.wikipedia.org/wiki/Authenticated_encryption
 //! [2]: https://en.wikipedia.org/wiki/Galois/Counter_Mode
 //! [3]: https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/
 //! [4]: https://www.mobilecoin.com/
-//! [5]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.encrypt_in_place
-//! [6]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.decrypt_in_place
-//! [7]: https://docs.rs/aead/latest/aead/trait.Buffer.html
-//! [8]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/aes-siv/src/siv.rs
+++ b/aes-siv/src/siv.rs
@@ -10,17 +10,19 @@ use aead::generic_array::{
 };
 use aead::{Buffer, Error};
 use aes::{Aes128, Aes256};
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 use cmac::Cmac;
 use core::ops::Add;
 use crypto_mac::{Mac, NewMac};
 use ctr::Ctr128;
 use dbl::Dbl;
-#[cfg(feature = "pmac")]
-use pmac::Pmac;
 use stream_cipher::{NewStreamCipher, SyncStreamCipher};
 use zeroize::Zeroize;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[cfg(feature = "pmac")]
+use pmac::Pmac;
 
 /// Size of the (synthetic) initialization vector in bytes
 pub const IV_SIZE: usize = 16;
@@ -92,8 +94,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns `Error` if `plaintext.len()` is less than `M::OutputSize`.
-    /// Returns `Error` if `headers.len()` is greater than `MAX_ASSOCIATED_DATA`.
+    /// Returns [`Error`] if `plaintext.len()` is less than `M::OutputSize`.
+    /// Returns [`Error`] if `headers.len()` is greater than [`MAX_HEADERS`].
     #[cfg(feature = "alloc")]
     pub fn encrypt<I, T>(&mut self, headers: I, plaintext: &[u8]) -> Result<Vec<u8>, Error>
     where
@@ -110,8 +112,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns `Error` if `plaintext.len()` is less than `M::OutputSize`.
-    /// Returns `Error` if `headers.len()` is greater than `MAX_ASSOCIATED_DATA`.
+    /// Returns [`Error`] if `plaintext.len()` is less than `M::OutputSize`.
+    /// Returns [`Error`] if `headers.len()` is greater than [`MAX_HEADERS`].
     pub fn encrypt_in_place<I, T>(
         &mut self,
         headers: I,
@@ -138,8 +140,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns `Error` if `plaintext.len()` is less than `M::OutputSize`.
-    /// Returns `Error` if `headers.len()` is greater than `MAX_ASSOCIATED_DATA`.
+    /// Returns [`Error`] if `plaintext.len()` is less than `M::OutputSize`.
+    /// Returns [`Error`] if `headers.len()` is greater than [`MAX_HEADERS`].
     pub fn encrypt_in_place_detached<I, T>(
         &mut self,
         headers: I,
@@ -201,7 +203,7 @@ where
     ///
     /// # Errors
     ///
-    /// Returns `Error` if the ciphertext is not authentic
+    /// Returns [`Error`] if the ciphertext is not authentic
     pub fn decrypt_in_place_detached<I, T>(
         &mut self,
         headers: I,

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -41,3 +41,4 @@ harness = false
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/chacha20poly1305/src/xchacha20poly1305.rs
+++ b/chacha20poly1305/src/xchacha20poly1305.rs
@@ -11,9 +11,10 @@ use aead::{
 use chacha20::{stream_cipher::NewStreamCipher, XChaCha20};
 use zeroize::Zeroize;
 
-/// **XChaCha20Poly1305** is a ChaCha20Poly1305 variant with an extended
-/// 192-bit (24-byte) nonce. The `xchacha20poly1305` Cargo feature
-/// must be enabled in order to use this (which it is by default).
+/// ChaCha20Poly1305 variant with an extended 192-bit (24-byte) nonce.
+///
+/// The `xchacha20poly1305` Cargo feature must be enabled in order to use this
+/// (which it is by default).
 ///
 /// The construction is an adaptation of the same techniques used by
 /// XSalsa20 as described in the paper "Extending the Salsa20 Nonce"
@@ -53,6 +54,7 @@ use zeroize::Zeroize;
 /// assert_eq!(&plaintext, b"plaintext message");
 /// ```
 #[derive(Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "xchacha20poly1305")))]
 pub struct XChaCha20Poly1305 {
     /// Secret key
     key: GenericArray<u8, U32>,

--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -99,7 +99,7 @@
 //! This crate has an optional `alloc` feature which can be disabled in e.g.
 //! microcontroller environments that don't have a heap.
 //!
-//! The [`Aead::encrypt_in_place`] and [`Aead::decrypt_in_place`]
+//! The [`AeadInPlace::encrypt_in_place`] and [`AeadInPlace::decrypt_in_place`]
 //! methods accept any type that impls the [`aead::Buffer`] trait which
 //! contains the plaintext for encryption or ciphertext for decryption.
 //!
@@ -119,9 +119,6 @@
 //! [X25519]: https://cr.yp.to/ecdh.html
 //! [XSalsa20Poly1305]: https://nacl.cr.yp.to/secretbox.html
 //! [ECIES]: https://en.wikipedia.org/wiki/Integrated_Encryption_Scheme
-//! [`Aead::encrypt_in_place`]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.encrypt_in_place
-//! [`Aead::decrypt_in_place`]: https://docs.rs/aead/latest/aead/trait.Aead.html#method.decrypt_in_place
-//! [`aead::Buffer`]: https://docs.rs/aead/latest/aead/trait.Buffer.html
 //! [`heapless::Vec`]: https://docs.rs/heapless/latest/heapless/struct.Vec.html
 
 #![no_std]
@@ -131,11 +128,11 @@
 pub use x25519_dalek::PublicKey;
 pub use xsalsa20poly1305::{aead, generate_nonce};
 
-use aead::generic_array::{
-    typenum::{U0, U16, U24},
-    GenericArray,
+use aead::{
+    consts::{U0, U16, U24},
+    generic_array::GenericArray,
+    AeadInPlace, Buffer, Error, NewAead,
 };
-use aead::{AeadInPlace, Buffer, Error, NewAead};
 use core::fmt::{self, Debug};
 use rand_core::{CryptoRng, RngCore};
 use salsa20::hsalsa20;


### PR DESCRIPTION
- Fix links to `AeadInPlace` traits
- Leverage `rustdoc` more rather than using absolute URLs
- Access `aead` crate as a re-export in examples
- Note that `expect` panics in examples
- Add `doc(cfg(...))` for features of the `chacha20poly1305` crate