### PR TITLE
Use release versions of crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/traits#7f2b98d31f704b55c502a685632bd2ea4bd5dd6c"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20e6f2cedd00d6e1d33954c9e4181094b61d87e7e751e5aaed1c249df5ba71ba"
 dependencies = [
  "generic-array 0.14.1",
  "heapless",
@@ -11,8 +12,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers#49f41f6c8f3a1dc711cf22fb5b0faf956a1fd587"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -66,8 +68,9 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers#49f41f6c8f3a1dc711cf22fb5b0faf956a1fd587"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -76,8 +79,9 @@ dependencies = [
 
 [[package]]
 name = "aesni"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers#49f41f6c8f3a1dc711cf22fb5b0faf956a1fd587"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 dependencies = [
  "block-cipher",
  "opaque-debug",
@@ -119,8 +123,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-cipher"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/traits#7f2b98d31f704b55c502a685632bd2ea4bd5dd6c"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f837aab23b44bf3be7e24411b599fda76b1788792e765fa077af268292e156d1"
 dependencies = [
  "generic-array 0.14.1",
 ]
@@ -167,7 +172,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 [[package]]
 name = "chacha20"
 version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers#caccc8ef2c72d061a50e6475322e9e49250519b9"
+source = "git+https://github.com/RustCrypto/stream-ciphers#c9aaf6e97e60dd7b6bdff8fd6b7cdf2e4b9b6b3c"
 dependencies = [
  "stream-cipher",
  "zeroize",
@@ -199,8 +204,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/MACs#408dcda194379f33ed4767c29264a08f4cebacd7"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f8f8ba8b9640e29213f152015694e78208e601adf91c72b698460633b15715"
 dependencies = [
  "block-cipher",
  "crypto-mac",
@@ -300,8 +306,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/traits#7f2b98d31f704b55c502a685632bd2ea4bd5dd6c"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.1",
  "subtle",
@@ -344,7 +351,7 @@ dependencies = [
 [[package]]
 name = "ctr"
 version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers#caccc8ef2c72d061a50e6475322e9e49250519b9"
+source = "git+https://github.com/RustCrypto/stream-ciphers#c9aaf6e97e60dd7b6bdff8fd6b7cdf2e4b9b6b3c"
 dependencies = [
  "stream-cipher",
 ]
@@ -427,7 +434,7 @@ dependencies = [
 [[package]]
 name = "ghash"
 version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/universal-hashes#bf6009a306806fa6c84d3b46d9d0a515564871b4"
+source = "git+https://github.com/RustCrypto/universal-hashes#e3201156024586caec73c9b8df599303c51fd55e"
 dependencies = [
  "polyval",
 ]
@@ -592,8 +599,9 @@ dependencies = [
 
 [[package]]
 name = "pmac"
-version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/MACs#408dcda194379f33ed4767c29264a08f4cebacd7"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "979bdaa73c9597de894baf16305d2b4743b8c43b5511d7e574275eedbf5126bb"
 dependencies = [
  "block-cipher",
  "crypto-mac",
@@ -603,7 +611,7 @@ dependencies = [
 [[package]]
 name = "poly1305"
 version = "0.6.0-pre"
-source = "git+https://github.com/RustCrypto/universal-hashes#bf6009a306806fa6c84d3b46d9d0a515564871b4"
+source = "git+https://github.com/RustCrypto/universal-hashes#e3201156024586caec73c9b8df599303c51fd55e"
 dependencies = [
  "universal-hash",
 ]
@@ -611,7 +619,7 @@ dependencies = [
 [[package]]
 name = "polyval"
 version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/universal-hashes#bf6009a306806fa6c84d3b46d9d0a515564871b4"
+source = "git+https://github.com/RustCrypto/universal-hashes#e3201156024586caec73c9b8df599303c51fd55e"
 dependencies = [
  "cfg-if",
  "universal-hash",
@@ -754,7 +762,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "salsa20"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers#caccc8ef2c72d061a50e6475322e9e49250519b9"
+source = "git+https://github.com/RustCrypto/stream-ciphers#c9aaf6e97e60dd7b6bdff8fd6b7cdf2e4b9b6b3c"
 dependencies = [
  "stream-cipher",
  "zeroize",
@@ -826,8 +834,9 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "stream-cipher"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/traits#7f2b98d31f704b55c502a685632bd2ea4bd5dd6c"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97961116ec5528e0df39aa6e514377cd1572b8b4623576b371da425a87328d16"
 dependencies = [
  "block-cipher",
  "generic-array 0.14.1",
@@ -901,8 +910,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/traits#7f2b98d31f704b55c502a685632bd2ea4bd5dd6c"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array 0.14.1",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,9 @@ members = [
 ]
 
 [patch.crates-io]
-aes = { git = "https://github.com/RustCrypto/block-ciphers" }
-aead = { git = "https://github.com/RustCrypto/traits" }
-block-cipher = { git = "https://github.com/RustCrypto/traits" }
-crypto-mac = { git = "https://github.com/RustCrypto/traits" }
 chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers" }
-cmac = { git = "https://github.com/RustCrypto/MACs" }
 ctr = { git = "https://github.com/RustCrypto/stream-ciphers" }
 ghash = { git = "https://github.com/RustCrypto/universal-hashes" }
-pmac = { git = "https://github.com/RustCrypto/MACs" }
 poly1305 = { git = "https://github.com/RustCrypto/universal-hashes" }
 polyval = { git = "https://github.com/RustCrypto/universal-hashes" }
 salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers" }
-stream-cipher = { git = "https://github.com/RustCrypto/traits" }
-universal-hash = { git = "https://github.com/RustCrypto/traits" }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -16,9 +16,9 @@ keywords = ["aead", "aes", "aes-gcm", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "0.3.0-pre", default-features = false }
-aes = { version = "0.4.0-pre", optional = true }
-block-cipher = "0.7.0-pre"
+aead = { version = "0.3", default-features = false }
+aes = { version = "0.4", optional = true }
+block-cipher = "0.7"
 polyval = { version = "0.4.0-pre", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -16,9 +16,9 @@ keywords = ["aead", "aes", "encryption", "gcm", "ghash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "= 0.3.0-pre", default-features = false }
-aes = { version = "= 0.4.0-pre", optional = true }
-block-cipher = "= 0.7.0-pre"
+aead = { version = "0.3", default-features = false }
+aes = { version = "0.4", optional = true }
+block-cipher = "0.7"
 ghash = { version = "0.3.0-pre", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -16,14 +16,14 @@ keywords = ["aead", "aes", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "= 0.3.0-pre", default-features = false }
-aes = "= 0.4.0-pre"
-cmac = "= 0.3.0-pre"
-crypto-mac = { version = "= 0.8.0-pre", default-features = false }
+aead = { version = "0.3", default-features = false }
+aes = "0.4"
+cmac = "0.3"
+crypto-mac = { version = "0.8", default-features = false }
 ctr = "= 0.4.0-pre"
 dbl = { version = "0.3", default-features = false }
-pmac = { version = "= 0.3.0-pre", optional = true }
-stream-cipher = { version = "= 0.4.0-pre", default-features = false }
+pmac = { version = "0.3", optional = true }
+stream-cipher = { version = "0.4", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -18,10 +18,10 @@ keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "= 0.3.0-pre", default-features = false }
+aead = { version = "0.3", default-features = false }
 chacha20 = { version = "= 0.4.0-pre", features = ["zeroize"], optional = true }
 poly1305 = "= 0.6.0-pre"
-stream-cipher = "= 0.4.0-pre"
+stream-cipher = "0.4"
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["aead", "salsa20", "poly1305", "xsalsa20"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "= 0.3.0-pre", default-features = false }
+aead = { version = "0.3", default-features = false }
 salsa20 = { version = "= 0.5.0-pre", features = ["xsalsa20", "zeroize"] }
 poly1305 = "= 0.6.0-pre"
 rand_core = { version = "0.5", optional = true }


### PR DESCRIPTION
Updates the following dependencies to use crates.io releases:

- `aes` v0.4.0
- `aes-soft` v0.4.0
- `aesni` v0.7.0
- `block-cipher` v0.7.0
- `cmac` v0.3.0
- `pmac` v0.3.0
- `stream-cipher` v0.4.0

TODO: `universal-hash`es