### PR TITLE
Use release versions of `universal-hash` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,8 +433,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/universal-hashes#e3201156024586caec73c9b8df599303c51fd55e"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 dependencies = [
  "polyval",
 ]
@@ -610,16 +611,18 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.6.0-pre"
-source = "git+https://github.com/RustCrypto/universal-hashes#e3201156024586caec73c9b8df599303c51fd55e"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b42192ab143ed7619bf888a7f9c6733a9a2153b218e2cd557cfdb52fbf9bb1"
 dependencies = [
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/universal-hashes#e3201156024586caec73c9b8df599303c51fd55e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
  "cfg-if",
  "universal-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,4 @@ members = [
 [patch.crates-io]
 chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers" }
 ctr = { git = "https://github.com/RustCrypto/stream-ciphers" }
-ghash = { git = "https://github.com/RustCrypto/universal-hashes" }
-poly1305 = { git = "https://github.com/RustCrypto/universal-hashes" }
-polyval = { git = "https://github.com/RustCrypto/universal-hashes" }
 salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers" }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["cryptography", "no-std"]
 aead = { version = "0.3", default-features = false }
 aes = { version = "0.4", optional = true }
 block-cipher = "0.7"
-polyval = { version = "0.4.0-pre", default-features = false }
+polyval = { version = "0.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["cryptography", "no-std"]
 aead = { version = "0.3", default-features = false }
 aes = { version = "0.4", optional = true }
 block-cipher = "0.7"
-ghash = { version = "0.3.0-pre", default-features = false }
+ghash = { version = "0.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 aead = { version = "0.3", default-features = false }
 chacha20 = { version = "= 0.4.0-pre", features = ["zeroize"], optional = true }
-poly1305 = "= 0.6.0-pre"
+poly1305 = "0.6"
 stream-cipher = "0.4"
 zeroize = { version = "1", default-features = false }
 

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 aead = { version = "0.3", default-features = false }
 salsa20 = { version = "= 0.5.0-pre", features = ["xsalsa20", "zeroize"] }
-poly1305 = "= 0.6.0-pre"
+poly1305 = "0.6"
 rand_core = { version = "0.5", optional = true }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }


### PR DESCRIPTION
Updates the following UHF deps to use https://crates.io releases:

- `ghash` v0.3.0
- `polyval` v0.4.0
- `poly1305` v0.6.0