### PR TITLE
Update `stream-cipher` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,8 +171,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chacha20"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers#c9aaf6e97e60dd7b6bdff8fd6b7cdf2e4b9b6b3c"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6acd88fd85f945e7f2e86830a197b26baa828a623de7cd47a00c10b3a2057d7"
 dependencies = [
  "stream-cipher",
  "zeroize",
@@ -350,8 +351,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers#c9aaf6e97e60dd7b6bdff8fd6b7cdf2e4b9b6b3c"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3592740fd55aaf61dd72df96756bd0d11e6037b89dcf30ae2e1895b267692be"
 dependencies = [
  "stream-cipher",
 ]
@@ -764,8 +766,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "salsa20"
-version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers#c9aaf6e97e60dd7b6bdff8fd6b7cdf2e4b9b6b3c"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9431e496727766824bc7dad53a00326a78bb4b3e92afeaaaafdaaf5dca4053b6"
 dependencies = [
  "stream-cipher",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,3 @@ members = [
     "crypto_box",
     "xsalsa20poly1305"
 ]
-
-[patch.crates-io]
-chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers" }
-ctr = { git = "https://github.com/RustCrypto/stream-ciphers" }
-salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers" }

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -20,7 +20,7 @@ aead = { version = "0.3", default-features = false }
 aes = "0.4"
 cmac = "0.3"
 crypto-mac = { version = "0.8", default-features = false }
-ctr = "= 0.4.0-pre"
+ctr = "0.4"
 dbl = { version = "0.3", default-features = false }
 pmac = { version = "0.3", optional = true }
 stream-cipher = { version = "0.4", default-features = false }

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-chacha20 = { version = "= 0.4.0-pre", features = ["zeroize"], optional = true }
+chacha20 = { version = "0.4", features = ["zeroize"], optional = true }
 poly1305 = "0.6"
 stream-cipher = "0.4"
 zeroize = { version = "1", default-features = false }

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["nacl", "libsodium", "public-key", "x25519", "xsalsa20poly1305"]
 
 [dependencies]
 rand_core = "0.5"
-salsa20 = { version = "= 0.5.0-pre", features = ["hsalsa20"] }
+salsa20 = { version = "0.5", features = ["hsalsa20"] }
 zeroize = { version = "1", default-features = false }
 
 [dependencies.x25519-dalek]
@@ -27,7 +27,7 @@ default-features = false
 features = ["u64_backend"]
 
 [dependencies.xsalsa20poly1305]
-version = "= 0.4.0-pre"
+version = "0.4.0-pre"
 default-features = false
 features = ["rand_core"]
 path = "../xsalsa20poly1305"

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-salsa20 = { version = "= 0.5.0-pre", features = ["xsalsa20", "zeroize"] }
+salsa20 = { version = "0.5", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.6"
 rand_core = { version = "0.5", optional = true }
 subtle = { version = "2", default-features = false }


### PR DESCRIPTION
Updates all dependencies from `RustCrypto/stream-ciphers` to releases published to https://crates.io

This removes the `[patch.crates-io]` section and means we can finally release new versions of all crates in this repo 🎉