### PR TITLE
aes-gcm v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-06-06)
+### Changed
+- Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#142])
+
+[#142]: https://github.com/RustCrypto/AEADs/pull/126
+
 ## 0.5.0 (2020-03-15)
 ### Added
 - Support for non-96-bit nonces ([#126])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Changed
- Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#142])

[#142]: https://github.com/RustCrypto/AEADs/pull/126