### PR TITLE
aes-gcm-siv v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-06-06)
+### Changed
+- Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#142])
+
+[#142]: https://github.com/RustCrypto/AEADs/pull/126
+
 ## 0.4.1 (2020-03-09)
 ### Fixed
 - Off-by-one error in `debug_assert` for `BlockCipher::ParBlocks` ([#104])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.6.0 (2020-06-06)
 ### Changed
-- Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#142])
+- Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#140])
 
-[#142]: https://github.com/RustCrypto/AEADs/pull/126
+[#140]: https://github.com/RustCrypto/AEADs/pull/126
 
 ## 0.5.0 (2020-03-15)
 ### Added


### PR DESCRIPTION
### Changed
- Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#142])

[#142]: https://github.com/RustCrypto/AEADs/pull/126