### PR TITLE
aes-siv v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#142])
 
-[#142]: https://github.com/RustCrypto/AEADs/pull/126
+[#142]: https://github.com/RustCrypto/AEADs/pull/143
 
 ## 0.4.1 (2020-03-09)
 ### Fixed

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#140])
 
-[#140]: https://github.com/RustCrypto/AEADs/pull/126
+[#140]: https://github.com/RustCrypto/AEADs/pull/140
 
 ## 0.5.0 (2020-03-15)
 ### Added

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2019-11-26)
+## 0.3.0 (2019-06-06)
+### Changed
+- Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#143])
+- Use `copy_within` ([#57])
+
+[#143]: https://github.com/RustCrypto/AEADs/pull/143
+[#57]: https://github.com/RustCrypto/AEADs/pull/57
+
+## 0.2.0 (2019-11-26)
 ### Added
 - `heapless` feature ([#51])
 

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific


### PR DESCRIPTION
### Changed
- Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#143])
- Use `copy_within` ([#57])

[#143]: https://github.com/RustCrypto/AEADs/pull/143
[#57]: https://github.com/RustCrypto/AEADs/pull/57