### PR TITLE
chacha20poly1305 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "aead",
  "chacha20",

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-06-06)
+### Changed
+- Bump `aead` crate dependency to v0.3; MSRV 1.41+ ([#144])
+- Bump `chacha20` crate dependency to v0.4 ([#159])
+- Bump `poly1305` crate dependency to v0.6 ([#158])
+
+[#159]: https://github.com/RustCrypto/AEADs/pull/159
+[#158]: https://github.com/RustCrypto/AEADs/pull/158
+[#144]: https://github.com/RustCrypto/AEADs/pull/144
+
 ## 0.4.1 (2020-03-09)
 ### Fixed
 - `Clone` impl on `ChaChaPoly1305` ([#103])

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific


### PR DESCRIPTION
### Changed
- Bump `aead` crate dependency to v0.3; MSRV 1.41+ ([#144])
- Bump `chacha20` crate dependency to v0.4 ([#159])
- Bump `poly1305` crate dependency to v0.6 ([#158])

[#159]: https://github.com/RustCrypto/AEADs/pull/159
[#158]: https://github.com/RustCrypto/AEADs/pull/158
[#144]: https://github.com/RustCrypto/AEADs/pull/144