### PR TITLE
xsalsa20poly1305 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aead",
  "poly1305",

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -27,7 +27,7 @@ default-features = false
 features = ["u64_backend"]
 
 [dependencies.xsalsa20poly1305]
-version = "0.4.0-pre"
+version = "0.4"
 default-features = false
 features = ["rand_core"]
 path = "../xsalsa20poly1305"

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-06)
+### Changed
+- Bump `aead` crate dependency to v0.3; MSRV 1.41+ ([#146])
+- Bump `chacha20` crate dependency to v0.4 ([#159])
+- Bump `poly1305` crate dependency to v0.6 ([#158])
+
+[#159]: https://github.com/RustCrypto/AEADs/pull/159
+[#158]: https://github.com/RustCrypto/AEADs/pull/158
+[#146]: https://github.com/RustCrypto/AEADs/pull/146
+
 ## 0.3.1 (2020-01-17)
 ### Changed
 - Upgrade `salsa20` crate to v0.4 ([#71])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
### Changed
- Bump `aead` crate dependency to v0.3; MSRV 1.41+ ([#146])
- Bump `chacha20` crate dependency to v0.4 ([#159])
- Bump `poly1305` crate dependency to v0.6 ([#158])

[#159]: https://github.com/RustCrypto/AEADs/pull/159
[#158]: https://github.com/RustCrypto/AEADs/pull/158
[#146]: https://github.com/RustCrypto/AEADs/pull/146