### PR TITLE
crypto_box v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "rand",
  "rand_core",

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,5 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2020-06-06)
+### Changed
+- Bump `aead` crate dependency to v0.3; MSRV 1.41+ ([#146])
+- Bump `xsalsa20poly1305` dependency to v0.4 ([#164])
+
+[#146]: https://github.com/RustCrypto/AEADs/pull/146
+[#164]: https://github.com/RustCrypto/AEADs/pull/164
+
 ## 0.1.0 (2020-02-25)
 - Initial release

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.2.0-pre"
+version = "0.2.0"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman


### PR DESCRIPTION
### Changed
- Bump `aead` crate dependency to v0.3; MSRV 1.41+ ([#146])
- Bump `xsalsa20poly1305` dependency to v0.4 ([#164])

[#146]: https://github.com/RustCrypto/AEADs/pull/146
[#164]: https://github.com/RustCrypto/AEADs/pull/164