### PR TITLE
chacha20poly1305: add `Key` and `Nonce` type aliases

### DIFF
--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-chacha20 = { version = "0.4", features = ["zeroize"], optional = true }
+chacha20 = { version = "0.4.2", features = ["zeroize"], optional = true }
 poly1305 = "0.6"
 stream-cipher = "0.4"
 zeroize = { version = "1", default-features = false }

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -126,7 +126,7 @@ mod xchacha20poly1305;
 pub use aead;
 
 #[cfg(feature = "xchacha20poly1305")]
-pub use xchacha20poly1305::XChaCha20Poly1305;
+pub use xchacha20poly1305::{XChaCha20Poly1305, XNonce};
 
 use self::cipher::Cipher;
 use aead::{
@@ -144,7 +144,15 @@ use chacha20::ChaCha20;
 #[cfg(feature = "reduced-round")]
 use chacha20::{ChaCha12, ChaCha8};
 
-/// Poly1305 tags
+/// Key type (256-bits/32-bytes).
+///
+/// This is the same for all [`ChaChaPoly1305`] variants (including XChaCha20Poly1305)
+pub type Key = GenericArray<u8, U32>;
+
+/// Nonce type (96-bits/12-bytes).
+pub type Nonce = GenericArray<u8, U12>;
+
+/// Poly1305 tag.
 pub type Tag = GenericArray<u8, U16>;
 
 /// ChaCha20Poly1305 Authenticated Encryption with Additional Data (AEAD).
@@ -182,7 +190,7 @@ where
 {
     type KeySize = U32;
 
-    fn new(key: &GenericArray<u8, U32>) -> Self {
+    fn new(key: &Key) -> Self {
         Self {
             key: *key,
             stream_cipher: PhantomData,
@@ -200,7 +208,7 @@ where
 
     fn encrypt_in_place_detached(
         &self,
-        nonce: &GenericArray<u8, Self::NonceSize>,
+        nonce: &Nonce,
         associated_data: &[u8],
         buffer: &mut [u8],
     ) -> Result<Tag, Error> {
@@ -209,7 +217,7 @@ where
 
     fn decrypt_in_place_detached(
         &self,
-        nonce: &GenericArray<u8, Self::NonceSize>,
+        nonce: &Nonce,
         associated_data: &[u8],
         buffer: &mut [u8],
         tag: &Tag,

--- a/chacha20poly1305/src/xchacha20poly1305.rs
+++ b/chacha20poly1305/src/xchacha20poly1305.rs
@@ -2,13 +2,15 @@
 //!
 //! See [`XChaCha20Poly1305`] documentation for usage.
 
-use crate::{cipher::Cipher, Tag};
+pub use chacha20::XNonce;
+
+use crate::{cipher::Cipher, Key, Tag};
 use aead::{
     consts::{U0, U16, U24, U32},
-    generic_array::GenericArray,
     AeadInPlace, Error, NewAead,
 };
-use chacha20::{stream_cipher::NewStreamCipher, XChaCha20};
+use chacha20::XChaCha20;
+use stream_cipher::NewStreamCipher;
 use zeroize::Zeroize;
 
 /// ChaCha20Poly1305 variant with an extended 192-bit (24-byte) nonce.
@@ -57,13 +59,13 @@ use zeroize::Zeroize;
 #[cfg_attr(docsrs, doc(cfg(feature = "xchacha20poly1305")))]
 pub struct XChaCha20Poly1305 {
     /// Secret key
-    key: GenericArray<u8, U32>,
+    key: Key,
 }
 
 impl NewAead for XChaCha20Poly1305 {
     type KeySize = U32;
 
-    fn new(key: &GenericArray<u8, U32>) -> Self {
+    fn new(key: &Key) -> Self {
         XChaCha20Poly1305 { key: *key }
     }
 }
@@ -75,7 +77,7 @@ impl AeadInPlace for XChaCha20Poly1305 {
 
     fn encrypt_in_place_detached(
         &self,
-        nonce: &GenericArray<u8, Self::NonceSize>,
+        nonce: &XNonce,
         associated_data: &[u8],
         buffer: &mut [u8],
     ) -> Result<Tag, Error> {
@@ -85,7 +87,7 @@ impl AeadInPlace for XChaCha20Poly1305 {
 
     fn decrypt_in_place_detached(
         &self,
-        nonce: &GenericArray<u8, Self::NonceSize>,
+        nonce: &XNonce,
         associated_data: &[u8],
         buffer: &mut [u8],
         tag: &Tag,


### PR DESCRIPTION
Imports the type aliases added to the upstream `chacha20` crate.