### PR TITLE
xsalsa20poly1305 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,9 +768,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "salsa20"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfc3e1db25d6d85c23f2c61b6a22bf3ea6e44d508e2d2df5b0279af7f1e5104"
+checksum = "6fc17dc5eee5d3040d9f95a2d3ac42fb2c1829a80f417045da6cfd2befa66769"
 dependencies = [
  "stream-cipher",
  "zeroize",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aead",
  "poly1305",

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -146,13 +146,20 @@ use chacha20::{ChaCha12, ChaCha8};
 
 /// Key type (256-bits/32-bytes).
 ///
-/// This is the same for all [`ChaChaPoly1305`] variants (including XChaCha20Poly1305)
+/// Implemented as an alias for [`GenericArray`].
+///
+/// All [`ChaChaPoly1305`] variants (including `XChaCha20Poly1305`) use this
+/// key type.
 pub type Key = GenericArray<u8, U32>;
 
 /// Nonce type (96-bits/12-bytes).
+///
+/// Implemented as an alias for [`GenericArray`].
 pub type Nonce = GenericArray<u8, U12>;
 
 /// Poly1305 tag.
+///
+/// Implemented as an alias for [`GenericArray`].
 pub type Tag = GenericArray<u8, U16>;
 
 /// ChaCha20Poly1305 Authenticated Encryption with Additional Data (AEAD).

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2020-06-11)
+### Added
+- `Key` and `Nonce` type aliases + docs ([#167])
+
+[#167]: https://github.com/RustCrypto/AEADs/pull/159
+
 ## 0.4.0 (2020-06-06)
 ### Changed
 - Bump `aead` crate dependency to v0.3; MSRV 1.41+ ([#146])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-salsa20 = { version = "0.5.1", features = ["xsalsa20", "zeroize"] }
+salsa20 = { version = "0.5.2", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.6"
 rand_core = { version = "0.5", optional = true }
 subtle = { version = "2", default-features = false }


### PR DESCRIPTION
### Added
- `Key` and `Nonce` type aliases + docs ([#167])

[#167]: https://github.com/RustCrypto/AEADs/pull/159