### PR TITLE
xsalsa20poly1305 v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aead",
  "poly1305",

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2020-06-11)
+### Added
+- `KEY_SIZE` constant ([#172])
+
+[#172]: https://github.com/RustCrypto/AEADs/pull/172
+
 ## 0.4.1 (2020-06-11)
 ### Added
 - `Key` and `Nonce` type aliases + docs ([#167])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.4.1"
+version = "0.4.2"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
### Added
- `KEY_SIZE` constant ([#172])

[#172]: https://github.com/RustCrypto/AEADs/pull/172