### PR TITLE
crypto_box: tweak `aead` type imports

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -128,14 +128,14 @@
 pub use x25519_dalek::PublicKey;
 pub use xsalsa20poly1305::{aead, generate_nonce};
 
-use aead::{
+use core::fmt::{self, Debug};
+use rand_core::{CryptoRng, RngCore};
+use salsa20::hsalsa20;
+use xsalsa20poly1305::aead::{
     consts::{U0, U16, U24},
     generic_array::GenericArray,
     AeadInPlace, Buffer, Error, NewAead,
 };
-use core::fmt::{self, Debug};
-use rand_core::{CryptoRng, RngCore};
-use salsa20::hsalsa20;
 use xsalsa20poly1305::{Tag, XSalsa20Poly1305};
 use zeroize::Zeroize;
 


### PR DESCRIPTION
This commit switches from importing the `aead` types through the re-export of the `aead` crate from the `xsalsa20poly1305` crate to importing them as `use xsalsa20poly1305::aead::*`.

The reason is https://docs.rs is not rendering the links to the `AeadInPlace::{encrypt_in_place, decrypt_in_place}` methods.
However, these links are rendering in all other AEAD crates besides this one, suggesting it's something this crate is doing differently from the others.

It's also possible that the reason is unlike the other AEAD crates, this one does not directly depend on `aead`, but accesses it vicariously through the `xsalsa20poly1305` crate. But we can cross that bridge when we get there if this doesn't fix the issue.