### PR TITLE
Expose AesGcm bits necessary to build a constant time decrypt

### DIFF
--- a/aes-gcm/src/ctr.rs
+++ b/aes-gcm/src/ctr.rs
@@ -14,7 +14,7 @@ type Block128 = GenericArray<u8, U16>;
 pub(crate) const BLOCK_SIZE: usize = 16;
 
 /// CTR mode with a 32-bit big endian counter
-pub(crate) struct Ctr32<Aes>
+pub struct Ctr32<Aes>
 where
     Aes: BlockCipher<BlockSize = U16>,
     Aes::ParBlocks: ArrayLength<GenericArray<u8, Aes::BlockSize>>,

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -170,7 +170,7 @@ where
     NonceSize: ArrayLength<u8>,
 {
     /// Encryption cipher
-    cipher: Aes,
+    pub cipher: Aes,
 
     /// GHASH authenticator
     ghash: GHash,
@@ -290,7 +290,7 @@ where
     /// > If len(IV)=96, then J0 = IV || 0{31} || 1.
     /// > If len(IV) ≠ 96, then let s = 128 ⎡len(IV)/128⎤-len(IV), and
     /// >     J0=GHASH(IV||0s+64||[len(IV)]64).
-    fn init_ctr(&self, nonce: &GenericArray<u8, NonceSize>) -> Ctr32<Aes> {
+    pub fn init_ctr(&self, nonce: &GenericArray<u8, NonceSize>) -> Ctr32<Aes> {
         let j0 = if NonceSize::to_usize() == 12 {
             let mut block = GenericArray::default();
             block[..12].copy_from_slice(nonce);
@@ -312,7 +312,7 @@ where
     }
 
     /// Authenticate the given plaintext and associated data using GHASH
-    fn compute_tag(&self, associated_data: &[u8], buffer: &[u8]) -> Tag {
+    pub fn compute_tag(&self, associated_data: &[u8], buffer: &[u8]) -> Tag {
         let mut ghash = self.ghash.clone();
         ghash.update_padded(associated_data);
         ghash.update_padded(buffer);


### PR DESCRIPTION
As discussed in https://github.com/RustCrypto/AEADs/issues/184, aes-gcm decrypt is not constant time.  @tarcieri suggested that for our use case, it would be better to build a custom crate rather than put a constant time decrypt in the base repo, since overwriting the buffer if the mac check fails is necessary to avoid leaking information.

We attempted to build a constant time decrypt module without duplicating the entire aes-gcm crate; unfortunately, the AesGcm struct does not allow access to the critical data and functions.  So I'm offering this PR, which simply makes one struct field and two functions pub.  
