### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,13 +13,13 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
+checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
 dependencies = [
  "aes-soft",
  "aesni",
- "block-cipher 0.7.1",
+ "block-cipher",
 ]
 
 [[package]]
@@ -28,7 +28,7 @@ version = "0.6.0"
 dependencies = [
  "aead",
  "aes",
- "block-cipher 0.7.1",
+ "block-cipher",
  "criterion",
  "criterion-cycles-per-byte",
  "ghash",
@@ -43,7 +43,7 @@ version = "0.5.0"
 dependencies = [
  "aead",
  "aes",
- "block-cipher 0.7.1",
+ "block-cipher",
  "criterion",
  "criterion-cycles-per-byte",
  "polyval",
@@ -58,34 +58,34 @@ dependencies = [
  "aead",
  "aes",
  "cmac",
- "crypto-mac 0.8.0",
+ "crypto-mac",
  "ctr",
  "dbl",
  "hex-literal",
  "pmac",
- "stream-cipher 0.4.1",
+ "stream-cipher",
  "zeroize",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
+checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
 dependencies = [
- "block-cipher 0.7.1",
+ "block-cipher",
  "byteorder",
- "opaque-debug 0.2.3",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
+checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
 dependencies = [
- "block-cipher 0.7.1",
- "opaque-debug 0.2.3",
+ "block-cipher",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -127,15 +127,6 @@ name = "blobby"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
-
-[[package]]
-name = "block-cipher"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
-dependencies = [
- "generic-array 0.14.4",
-]
 
 [[package]]
 name = "block-cipher"
@@ -185,7 +176,7 @@ version = "0.1.0"
 dependencies = [
  "aead",
  "aes",
- "block-cipher 0.7.1",
+ "block-cipher",
  "hex-literal",
  "subtle",
 ]
@@ -198,11 +189,11 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chacha20"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
+checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
 dependencies = [
- "stream-cipher 0.4.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -215,7 +206,7 @@ dependencies = [
  "criterion",
  "criterion-cycles-per-byte",
  "poly1305",
- "stream-cipher 0.4.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -232,12 +223,11 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a681d7c344a6fbe3dcd1565e76dac74eed379c8a9326b29654ae34a718d16a49"
+checksum = "5220604fe5c112e2851b00da795c72cbb71bf112f2cbd532bdcfb4106eeb320b"
 dependencies = [
- "block-cipher 0.7.1",
- "crypto-mac 0.8.0",
+ "crypto-mac",
  "dbl",
 ]
 
@@ -336,21 +326,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array 0.14.4",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
- "block-cipher 0.8.0",
+ "block-cipher",
  "generic-array 0.14.4",
  "subtle",
 ]
@@ -391,11 +371,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3592740fd55aaf61dd72df96756bd0d11e6037b89dcf30ae2e1895b267692be"
+checksum = "cc03dee3a2843ac6eb4b5fb39cfcf4cb034d078555d1f4a0afbed418b822f3c2"
 dependencies = [
- "stream-cipher 0.4.1",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -435,7 +415,7 @@ version = "0.2.0"
 dependencies = [
  "aead",
  "aes",
- "block-cipher 0.7.1",
+ "block-cipher",
  "cmac",
  "criterion",
  "criterion-cycles-per-byte",
@@ -582,8 +562,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b14bb5ee0d7f49eb0dad8c4b293b9d2bca7437b931d9dd017f5012814ef6aad"
 dependencies = [
- "block-cipher 0.8.0",
- "opaque-debug 0.3.0",
+ "block-cipher",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -633,7 +613,7 @@ name = "mgm"
 version = "0.2.1"
 dependencies = [
  "aead",
- "block-cipher 0.8.0",
+ "block-cipher",
  "hex-literal",
  "kuznyechik",
  "subtle",
@@ -666,12 +646,6 @@ checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -694,7 +668,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617878d446faaf7294528e72683f082233e4b04b93982972e06dd17c293a727e"
 dependencies = [
- "crypto-mac 0.9.1",
+ "crypto-mac",
  "dbl",
 ]
 
@@ -858,7 +832,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f47b10fa80f6969bbbd9c8e7cc998f082979d402a9e10579e2303a87955395"
 dependencies = [
- "stream-cipher 0.7.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -938,21 +912,11 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stream-cipher"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
-dependencies = [
- "block-cipher 0.7.1",
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "stream-cipher"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
 dependencies = [
- "block-cipher 0.8.0",
+ "block-cipher",
  "generic-array 0.14.4",
 ]
 

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,8 +17,8 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-aes = { version = "0.4", optional = true }
-block-cipher = "0.7"
+aes = { version = "0.5", optional = true }
+block-cipher = "0.8"
 polyval = { version = "0.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,8 +17,8 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-aes = { version = "0.4", optional = true }
-block-cipher = "0.7"
+aes = { version = "0.5", optional = true }
+block-cipher = "0.8"
 ghash = { version = "0.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -17,13 +17,13 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-aes = "0.4"
-cmac = "0.3"
-crypto-mac = { version = "0.8", default-features = false }
-ctr = "0.4"
+aes = "0.5"
+cmac = "0.4"
+crypto-mac = { version = "0.9", default-features = false }
+ctr = "0.5"
 dbl = { version = "0.3", default-features = false }
 pmac = { version = "0.4", optional = true }
-stream-cipher = { version = "0.4", default-features = false }
+stream-cipher = { version = "0.7", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -14,12 +14,12 @@ keywords = ["encryption", "aead"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-block-cipher = { version = "0.7", default-features = false }
+block-cipher = { version = "0.8", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.3.2", features = ["dev"], default-features = false }
-aes = "0.4"
+aes = "0.5"
 hex-literal = "0.2"
 
 [features]

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -19,9 +19,9 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-chacha20 = { version = "0.4.2", features = ["zeroize"], optional = true }
+chacha20 = { version = "0.5", features = ["zeroize"], optional = true }
 poly1305 = "0.6"
-stream-cipher = "0.4"
+stream-cipher = "0.7"
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -20,13 +20,13 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-block-cipher = "0.7"
-cmac = "0.3"
-ctr = "0.4"
+block-cipher = "0.8"
+cmac = "0.4"
+ctr = "0.5"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aes = "0.4"
+aes = "0.5"
 aead = { version = "0.3", features = ["dev"], default-features = false }
 criterion = "0.3.0"
 criterion-cycles-per-byte = "0.1.1"


### PR DESCRIPTION
- `aes-gcm`: `aes` v0.4 -> v0.5, `block-cipher` v0.7 -> v0.8
- `aes-gcm-siv`: `aes` v0.4 -> v0.5, `block-cipher` v0.7 -> v0.8
- `aes-siv`: `aes` v0.4 -> v0.5, `cmac` v0.3 -> v0.4, `crypto-mac` v0.8 -> v0.9, `ctr` v0.4 -> v0.5, `stream-cipher` v0.4 -> v0.7
- `ccm`: `aes` v0.4 -> v0.5, `block-cipher` v0.7 -> v0.8
-  `chacha20poly1305`: `chacha20` v0.4.2 -> v0.5, `stream-cipher` v0.4 -> v0.7
- `eax`: `aes` v0.4 -> v0.5, `cmac` v0.3 -> v0.4, `ctr` v0.4 -> v0.5