### PR TITLE
Add optional `std` feature to all crates

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -27,6 +27,7 @@ zeroize = { version = "1", default-features = false }
 default = ["aes", "alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
+std = ["aead/std", "alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -30,6 +30,7 @@ hex-literal = "0.2"
 default = ["aes", "alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
+std = ["aead/std", "alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -33,6 +33,7 @@ hex-literal = "0.2"
 default = ["alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
+std = ["aead/std", "alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -26,3 +26,4 @@ hex-literal = "0.2"
 default = ["alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
+std = ["aead/std", "alloc"]

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -29,6 +29,7 @@ default = ["alloc", "chacha20", "xchacha20poly1305"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
 reduced-round = ["chacha20"]
+std = ["aead/std", "alloc"]
 xchacha20poly1305 = ["chacha20/xchacha20"]
 
 [package.metadata.docs.rs]

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -35,5 +35,6 @@ rand = "0.7"
 default = ["alloc", "u64_backend"]
 alloc = ["xsalsa20poly1305/alloc"]
 heapless = ["xsalsa20poly1305/heapless"]
+std = ["xsalsa20poly1305/std"]
 u32_backend = ["x25519-dalek/u32_backend"]
 u64_backend = ["x25519-dalek/u64_backend"]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -33,6 +33,7 @@ aead = { version = "0.3", features = ["dev"], default-features = false }
 default = ["alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
+std = ["aead/std", "alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -26,3 +26,4 @@ hex-literal = "0.2"
 default = ["alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
+std = ["aead/std", "alloc"]

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -26,6 +26,7 @@ zeroize = { version = "1", default-features = false }
 default = ["alloc", "rand_core"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
+std = ["aead/std", "alloc"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Disabled-by-default. Closes #204.

This mostly provides a `std::error::Error` impl on `aead::Error`.