### PR TITLE
Release new versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aead",
  "aes",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.5.0"
+version = "0.8.0"
 dependencies = [
  "aead",
  "aes",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aead",
  "aes",
@@ -118,7 +118,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "ccm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aead",
  "aes",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "aead",
  "chacha20",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "rand",
  "rand_core",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.2.0"
+version = "0.2.0-pre"
 dependencies = [
  "aead",
  "aes",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "aead",
  "poly1305",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-09-17)
+### Added
+- Optional `std` feature; disabled by default ([#217])
+
+### Changed
+- Upgrade `aes` to v0.5; `block-cipher` to v0.8 ([#209])
+
+[#217]: https://github.com/RustCrypto/AEADs/pull/217
+[#209]: https://github.com/RustCrypto/AEADs/pull/209
+
 ## 0.5.0 (2020-06-06)
 ### Changed
 - Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#142])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.5.0"
+version = "0.8.0"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-09-17)
+### Added
+- Optional `std` feature; disabled by default ([#217])
+
+### Changed
+- Renamed generic parameters to `Aes` and `NonceSize` ([#166])
+- Upgrade `aes` to v0.5; `block-cipher` to v0.8 ([#209])
+
+[#217]: https://github.com/RustCrypto/AEADs/pull/217
+[#209]: https://github.com/RustCrypto/AEADs/pull/209
+[#166]: https://github.com/RustCrypto/AEADs/pull/166
+
 ## 0.6.0 (2020-06-06)
 ### Changed
 - Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#140])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.6.0"
+version = "0.7.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-09-17)
+### Added
+- Optional `std` feature; disabled by default ([#217])
+
+### Changed
+- Upgrade `aes` to v0.5; `block-cipher` to v0.8 ([#209])
+
+[#217]: https://github.com/RustCrypto/AEADs/pull/217
+[#209]: https://github.com/RustCrypto/AEADs/pull/209
+
 ## 0.3.0 (2019-06-06)
 ### Changed
 - Bump `aead` crate dependency to v0.3.0; MSRV 1.41+ ([#143])

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.3.0"
+version = "0.4.0"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2020-09-17)
+### Added
+- Optional `std` feature; disabled by default ([#217])
+
+### Changed
+- Upgrade `aes` to v0.5; `block-cipher` to v0.8 ([#209])
+
+[#217]: https://github.com/RustCrypto/AEADs/pull/217
+[#209]: https://github.com/RustCrypto/AEADs/pull/209
+
 ## 0.1.0 (2020-07-01)
 - Initial release ([#174])
 

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.1.0"
+version = "0.2.0"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2018"

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-09-17)
+### Added
+- Optional `std` feature; disabled by default ([#217])
+
+### Changed
+- Upgrade `chacha20` to v0.5; `stream-cipher` to v0.7 ([#209])
+
+[#217]: https://github.com/RustCrypto/AEADs/pull/217
+[#209]: https://github.com/RustCrypto/AEADs/pull/209
+
 ## 0.5.1 (2020-06-11)
 ### Added
 - `Key`, `Nonce`, and `XNonce` type aliases ([#168])

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.5.1"
+version = "0.6.0"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-09-17)
+### Added
+- Optional `std` feature; disabled by default ([#217])
+
+### Changed
+- Upgrade `xsalsa20poly1305` to v0.5 ([#218])
+
+[#218]: https://github.com/RustCrypto/AEADs/pull/218
+[#217]: https://github.com/RustCrypto/AEADs/pull/217
+
 ## 0.3.0 (2020-08-18)
 ### Changed
 - Bump `x25519-dalek` dependency to 1.0 ([#194])

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.3.0"
+version = "0.4.0"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman
@@ -23,7 +23,7 @@ x25519-dalek = { version = "1", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dependencies.xsalsa20poly1305]
-version = "0.4"
+version = "0.5"
 default-features = false
 features = ["rand_core"]
 path = "../xsalsa20poly1305"

--- a/eax/CHANGELOG.md
+++ b/eax/CHANGELOG.md
@@ -5,8 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.2.0 (unreleased)
+### Added
+- Optional `std` feature; disabled by default ([#217])
+
 ### Changed
 - Use `aead` crate; MSRV 1.41+
+- Upgrade `aes` to v0.5, `block-cipher` to v0.8, `cmac` to v0.4, `ctr` to v0.5 ([#209])
+
+[#217]: https://github.com/RustCrypto/AEADs/pull/217
+[#209]: https://github.com/RustCrypto/AEADs/pull/209
 
 ## 0.1.0 (2019-03-29)
 - Initial release

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.2.0"
+version = "0.2.0-pre"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-09-17)
+### Added
+- Optional `std` feature; disabled by default ([#217])
+
+### Changed
+- Bump `salsa20` to v0.6; `stream-cipher` to v0.7 ([#207])
+
+[#217]: https://github.com/RustCrypto/AEADs/pull/217
+[#207]: https://github.com/RustCrypto/AEADs/pull/207
+
 ## 0.4.2 (2020-06-11)
 ### Added
 - `KEY_SIZE` constant ([#172])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.4.2"
+version = "0.5.0"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
Releases versions that are upgraded to use `block-cipher` v0.8 and `stream-cipher` v0.7.

- `aes-gcm` v0.7.0
- `aes-gcm-siv` v0.8.0
- `aes-siv` v0.4.0
- `ccm` v0.2.0
- `chacha20poly1305` v0.6.0
- `crypto_box` v0.4.0
- `eax` v0.2.0-pre (final release pending resolution of #214)
- `xsalsa20poly1305` v0.5.0