### PR TITLE
aes-gcm-siv: fix CHANGELOG.md entries

### DIFF
--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (2020-09-17)
+## 0.8.0 (2020-09-17)
 ### Added
 - Optional `std` feature; disabled by default ([#217])
 
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#217]: https://github.com/RustCrypto/AEADs/pull/217
 [#209]: https://github.com/RustCrypto/AEADs/pull/209
+
+## 0.7.0 (skipped)
+
+## 0.6.0 (skipped)
 
 ## 0.5.0 (2020-06-06)
 ### Changed


### PR DESCRIPTION
It appears I fat fingered the version number, releasing a v0.8.0 instead of a v0.6.0. Mea culpa.

Everything else about the release is consistent except CHANGELOG.md. This updates it to reflect what happened.