### PR TITLE
Replace `block-cipher`/`stream-cipher` with `cipher` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,13 +13,13 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
 dependencies = [
  "aes-soft",
  "aesni",
- "block-cipher",
+ "cipher",
 ]
 
 [[package]]
@@ -28,8 +28,8 @@ version = "0.8.0-pre"
 dependencies = [
  "aead",
  "aes",
- "block-cipher",
- "ctr 0.6.0-pre",
+ "cipher",
+ "ctr",
  "ghash",
  "hex-literal",
  "subtle",
@@ -42,8 +42,8 @@ version = "0.9.0-pre"
 dependencies = [
  "aead",
  "aes",
- "block-cipher",
- "ctr 0.6.0-pre",
+ "cipher",
+ "ctr",
  "polyval",
  "subtle",
  "zeroize",
@@ -51,38 +51,38 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "aead",
  "aes",
+ "cipher",
  "cmac",
  "crypto-mac",
- "ctr 0.5.0",
+ "ctr",
  "dbl",
  "hex-literal",
  "pmac",
- "stream-cipher 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
+checksum = "8c5ab1fa47ce0ddf44cbd65b1b4e626e3c03b06fd42005603acdc6fa13526296"
 dependencies = [
- "block-cipher",
  "byteorder",
+ "cipher",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
- "block-cipher",
+ "cipher",
  "opaque-debug",
 ]
 
@@ -104,15 +104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 
 [[package]]
-name = "block-cipher"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
-dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,11 +111,11 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "ccm"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "aead",
  "aes",
- "block-cipher",
+ "cipher",
  "hex-literal",
  "subtle",
 ]
@@ -137,30 +128,39 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chacha20"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
+checksum = "ed8738f14471a99f0e316c327e68fc82a3611cc2895fcb604b89eedaf8f39d95"
 dependencies = [
- "stream-cipher 0.7.1",
+ "cipher",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.6.0"
+version = "0.7.0-pre"
 dependencies = [
  "aead",
  "chacha20",
+ "cipher",
  "poly1305",
- "stream-cipher 0.7.1",
  "zeroize",
 ]
 
 [[package]]
-name = "cmac"
-version = "0.4.0"
+name = "cipher"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5220604fe5c112e2851b00da795c72cbb71bf112f2cbd532bdcfb4106eeb320b"
+checksum = "a1f7954ae5588102b35257639b1c36a2e7425cc6540fcdb4de19dcb91055d659"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "cmac"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73d4de4f7724e5fe70addfb2bd37c2abd2f95084a429d7773b0b9645499b4272"
 dependencies = [
  "crypto-mac",
  "dbl",
@@ -168,18 +168,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "block-cipher",
+ "cipher",
  "generic-array 0.14.4",
  "subtle",
 ]
 
 [[package]]
 name = "crypto_box"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "chacha20poly1305",
  "rand",
@@ -192,20 +192,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc03dee3a2843ac6eb4b5fb39cfcf4cb034d078555d1f4a0afbed418b822f3c2"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [
- "stream-cipher 0.7.1",
-]
-
-[[package]]
-name = "ctr"
-version = "0.6.0-pre"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3a55c7d5d2c1a334c1e53c2a3ec28eae05592c4deb8c4dd2e2f0d36752f7e0"
-dependencies = [
- "stream-cipher 0.8.0-pre",
+ "cipher",
 ]
 
 [[package]]
@@ -241,13 +232,13 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "aead",
  "aes",
- "block-cipher",
+ "cipher",
  "cmac",
- "ctr 0.5.0",
+ "ctr",
  "subtle",
 ]
 
@@ -341,11 +332,11 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b14bb5ee0d7f49eb0dad8c4b293b9d2bca7437b931d9dd017f5012814ef6aad"
+checksum = "221139eedf77a90801f17be9f605bb63452436fc4bb5cac0f5b0cd358045115e"
 dependencies = [
- "block-cipher",
+ "cipher",
  "opaque-debug",
 ]
 
@@ -357,10 +348,10 @@ checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "mgm"
-version = "0.2.1"
+version = "0.3.0-pre"
 dependencies = [
  "aead",
- "block-cipher",
+ "cipher",
  "hex-literal",
  "kuznyechik",
  "subtle",
@@ -374,9 +365,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pmac"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617878d446faaf7294528e72683f082233e4b04b93982972e06dd17c293a727e"
+checksum = "e1c257eb89109a7e6115f40d44ca6d1816ecf9e90a1b38f6d477c78c1de505cb"
 dependencies = [
  "crypto-mac",
  "dbl",
@@ -474,11 +465,11 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f47b10fa80f6969bbbd9c8e7cc998f082979d402a9e10579e2303a87955395"
+checksum = "b900cdff5593338502f2dde9217add4a687c3b9d6fe2cd130a5b28fe2b39e04c"
 dependencies = [
- "stream-cipher 0.7.1",
+ "cipher",
  "zeroize",
 ]
 
@@ -487,26 +478,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "stream-cipher"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
-dependencies = [
- "block-cipher",
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "stream-cipher"
-version = "0.8.0-pre"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c22786b7392254461cf5f358c143035828bf5d95850d4adc483faf065f5b9e"
-dependencies = [
- "block-cipher",
- "generic-array 0.14.4",
-]
 
 [[package]]
 name = "subtle"
@@ -584,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aead",
  "poly1305",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,9 +17,9 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-aes = { version = "0.5", optional = true }
-block-cipher = "0.8"
-ctr = "0.6.0-pre"
+aes = { version = "0.6", optional = true }
+cipher = "0.2"
+ctr = "0.6"
 polyval = { version = "0.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -130,15 +130,13 @@
 pub use aead;
 
 use aead::{AeadInPlace, Error, NewAead};
-use block_cipher::{
+use cipher::{
+    block::{Block, BlockCipher, NewBlockCipher},
     consts::{U0, U12, U16},
     generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
-    Block, BlockCipher, NewBlockCipher,
+    stream::{FromBlockCipher, SyncStreamCipher},
 };
-use ctr::{
-    stream_cipher::{FromBlockCipher, SyncStreamCipher},
-    Ctr32LE,
-};
+use ctr::Ctr32LE;
 use polyval::{
     universal_hash::{NewUniversalHash, UniversalHash},
     Polyval,

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,9 +17,9 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-aes = { version = "0.5", optional = true }
-block-cipher = "0.8"
-ctr = "0.6.0-pre"
+aes = { version = "0.6", optional = true }
+cipher = "0.2"
+ctr = "0.6"
 ghash = { version = "0.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -110,16 +110,14 @@ pub use aead::{self, AeadInPlace, Error, NewAead};
 #[cfg(feature = "aes")]
 pub use aes;
 
-use block_cipher::{
+use cipher::{
+    block::{Block, BlockCipher, Key, NewBlockCipher},
     consts::{U0, U16},
     generic_array::{ArrayLength, GenericArray},
-    Block, BlockCipher, Key, NewBlockCipher,
+    stream::{FromBlockCipher, SyncStreamCipher},
 };
 use core::marker::PhantomData;
-use ctr::{
-    stream_cipher::{FromBlockCipher, SyncStreamCipher},
-    Ctr32BE,
-};
+use ctr::Ctr32BE;
 use ghash::{
     universal_hash::{NewUniversalHash, UniversalHash},
     GHash,
@@ -129,7 +127,7 @@ use ghash::{
 use zeroize::Zeroize;
 
 #[cfg(feature = "aes")]
-use aes::{block_cipher::generic_array::typenum::U12, Aes128, Aes256};
+use aes::{cipher::consts::U12, Aes128, Aes256};
 
 /// Maximum length of associated data
 pub const A_MAX: u64 = 1 << 36;

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.4.0"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific
@@ -16,14 +16,14 @@ keywords = ["aead", "aes", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "0.3", default-features = false }
-aes = "0.5"
-cmac = "0.4"
-crypto-mac = { version = "0.9", default-features = false }
-ctr = "0.5"
-dbl = { version = "0.3", default-features = false }
-pmac = { version = "0.4", optional = true }
-stream-cipher = { version = "0.7", default-features = false }
+aead = "0.3"
+aes = "0.6"
+cipher = "0.2"
+cmac = "0.5"
+crypto-mac = "0.10"
+ctr = "0.6"
+dbl = "0.3"
+pmac = "0.5"
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -92,11 +92,11 @@ use aead::{
     AeadInPlace, Buffer, Error, NewAead,
 };
 use aes::{Aes128, Aes256};
+use cipher::{NewStreamCipher, SyncStreamCipher};
 use cmac::Cmac;
 use core::{marker::PhantomData, ops::Add};
 use crypto_mac::{Mac, NewMac};
 use ctr::Ctr128;
-use stream_cipher::{NewStreamCipher, SyncStreamCipher};
 
 #[cfg(feature = "pmac")]
 use pmac::Pmac;

--- a/aes-siv/src/siv.rs
+++ b/aes-siv/src/siv.rs
@@ -10,12 +10,12 @@ use aead::generic_array::{
 };
 use aead::{Buffer, Error};
 use aes::{Aes128, Aes256};
+use cipher::{NewStreamCipher, SyncStreamCipher};
 use cmac::Cmac;
 use core::ops::Add;
 use crypto_mac::{Mac, NewMac};
 use ctr::Ctr128;
 use dbl::Dbl;
-use stream_cipher::{NewStreamCipher, SyncStreamCipher};
 use zeroize::Zeroize;
 
 #[cfg(feature = "alloc")]

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2018"
@@ -14,12 +14,12 @@ keywords = ["encryption", "aead"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-block-cipher = { version = "0.8", default-features = false }
+cipher = { version = "0.2", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.3.2", features = ["dev"], default-features = false }
-aes = "0.5"
+aes = "0.6"
 hex-literal = "0.2"
 
 [features]

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -44,11 +44,12 @@
 pub use aead;
 pub use aead::consts;
 
-use aead::consts::{U0, U16};
-use aead::generic_array::typenum::Unsigned;
-use aead::generic_array::ArrayLength;
-use aead::{AeadInPlace, Error, Key, NewAead, Nonce, Tag};
-use block_cipher::{Block, BlockCipher, NewBlockCipher};
+use aead::{
+    consts::{U0, U16},
+    generic_array::{typenum::Unsigned, ArrayLength},
+    AeadInPlace, Error, Key, NewAead, Nonce, Tag,
+};
+use cipher::block::{Block, BlockCipher, NewBlockCipher};
 use core::marker::PhantomData;
 use subtle::ConstantTimeEq;
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.6.0"
+version = "0.7.0-pre"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific
@@ -19,9 +19,9 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-chacha20 = { version = "0.5", features = ["zeroize"], optional = true }
+chacha20 = { version = "0.6", features = ["zeroize"], optional = true }
+cipher = "0.2"
 poly1305 = "0.6"
-stream-cipher = "0.7"
 zeroize = { version = "1", default-features = false }
 
 [features]

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -1,5 +1,6 @@
 //! Core AEAD cipher implementation for (X)ChaCha20Poly1305.
 
+use ::cipher::{SyncStreamCipher, SyncStreamCipherSeek};
 use aead::generic_array::GenericArray;
 use aead::Error;
 use core::convert::TryInto;
@@ -7,7 +8,6 @@ use poly1305::{
     universal_hash::{NewUniversalHash, UniversalHash},
     Poly1305,
 };
-use stream_cipher::{SyncStreamCipher, SyncStreamCipherSeek};
 use zeroize::Zeroize;
 
 use super::Tag;

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -132,13 +132,13 @@ pub use aead;
 pub use xchacha20poly1305::{XChaCha20Poly1305, XNonce};
 
 use self::cipher::Cipher;
+use ::cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 use aead::{
     consts::{U0, U12, U16, U32},
     generic_array::GenericArray,
     AeadInPlace, Error, NewAead,
 };
 use core::marker::PhantomData;
-use stream_cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 use zeroize::Zeroize;
 
 #[cfg(feature = "chacha20")]

--- a/chacha20poly1305/src/xchacha20poly1305.rs
+++ b/chacha20poly1305/src/xchacha20poly1305.rs
@@ -5,12 +5,12 @@
 pub use chacha20::XNonce;
 
 use crate::{cipher::Cipher, Key, Tag};
+use ::cipher::NewStreamCipher;
 use aead::{
     consts::{U0, U16, U24, U32},
     AeadInPlace, Error, NewAead,
 };
 use chacha20::XChaCha20;
-use stream_cipher::NewStreamCipher;
 use zeroize::Zeroize;
 
 /// ChaCha20Poly1305 variant with an extended 192-bit (24-byte) nonce.

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.4.0"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman
@@ -18,21 +18,21 @@ keywords = ["nacl", "libsodium", "public-key", "x25519", "xsalsa20poly1305"]
 
 [dependencies]
 rand_core = "0.5"
-salsa20 = { version = "0.6", features = ["hsalsa20"] }
+salsa20 = { version = "0.7", features = ["hsalsa20"] }
 x25519-dalek = { version = "1", default-features = false }
 zeroize = { version = "1", default-features = false }
 
-[dependencies.xsalsa20poly1305]
-version = "0.5"
-default-features = false
-features = ["rand_core"]
-path = "../xsalsa20poly1305"
-
 [dependencies.chacha20poly1305]
-version = "0.6"
+version = "0.7.0-pre"
 default-features = false
 features = ["xchacha20poly1305"]
 path = "../chacha20poly1305"
+
+[dependencies.xsalsa20poly1305]
+version = "0.6.0-pre"
+default-features = false
+features = ["rand_core"]
+path = "../xsalsa20poly1305"
 
 [dev-dependencies]
 rand = "0.7"

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher
@@ -20,13 +20,13 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-block-cipher = "0.8"
-cmac = "0.4"
-ctr = "0.5"
+cipher = "0.2"
+cmac = "0.5"
+ctr = "0.6"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aes = "0.5"
+aes = "0.6"
 aead = { version = "0.3", features = ["dev"], default-features = false }
 
 [features]

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -79,16 +79,15 @@
 #![warn(missing_docs, rust_2018_idioms)]
 
 pub use aead::{self, AeadInPlace, Error, NewAead, Nonce};
+pub use cipher;
 
-use block_cipher::{
+use cipher::{
+    block::{Block, BlockCipher, Key, NewBlockCipher},
     consts::{U0, U16},
-    generic_array::functional::FunctionalSequence,
-    generic_array::{ArrayLength, GenericArray},
-    Block, BlockCipher, Key, NewBlockCipher,
+    generic_array::{functional::FunctionalSequence, ArrayLength, GenericArray},
+    stream::{FromBlockCipher, SyncStreamCipher},
 };
-use cmac::crypto_mac::NewMac;
-use cmac::{Cmac, Mac};
-use ctr::stream_cipher::{FromBlockCipher, SyncStreamCipher};
+use cmac::{crypto_mac::NewMac, Cmac, Mac};
 
 // TODO Max values?
 /// Maximum length of associated data

--- a/eax/src/online.rs
+++ b/eax/src/online.rs
@@ -13,9 +13,8 @@
 //!
 //! ## Example
 //! ```
-//! use eax::{Error, online::{Eax, Decrypt, Encrypt}};
+//! use eax::{Error, online::{Eax, Decrypt, Encrypt}, cipher::generic_array::GenericArray};
 //! use aes::Aes256;
-//! use block_cipher::generic_array::GenericArray;
 //!
 //! let key = GenericArray::from_slice(b"an example very very secret key.");
 //! let nonce = GenericArray::from_slice(b"my unique nonces"); // 128-bits; unique per message
@@ -94,9 +93,8 @@ impl CipherOp for Decrypt {}
 ///
 /// ## Example
 /// ```
-/// use eax::{Error, online::{Eax, Decrypt, Encrypt}};
+/// use eax::{Error, online::{Eax, Decrypt, Encrypt}, cipher::generic_array::GenericArray};
 /// use aes::Aes256;
-/// use block_cipher::generic_array::GenericArray;
 ///
 /// let key = GenericArray::from_slice(b"an example very very secret key.");
 ///

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mgm"
-version = "0.2.1"
+version = "0.3.0-pre"
 description = "Generic implementation of the Multilinear Galois Mode (MGM) cipher"
 authors = ["RustCrypto Developers"]
 edition = "2018"
@@ -14,12 +14,12 @@ keywords = ["encryption", "aead"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-block-cipher = { version = "0.8", default-features = false }
+cipher = "0.2"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.3.2", features = ["dev"], default-features = false }
-kuznyechik = "0.5"
+kuznyechik = "0.6"
 hex-literal = "0.2"
 
 [features]

--- a/mgm/src/lib.rs
+++ b/mgm/src/lib.rs
@@ -33,10 +33,12 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
-use aead::consts::{U0, U16};
-use aead::generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
-use aead::{AeadInPlace, Error, Key, NewAead, Nonce, Tag};
-use block_cipher::{BlockCipher, NewBlockCipher};
+use aead::{
+    consts::{U0, U16},
+    generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
+    AeadInPlace, Error, Key, NewAead, Nonce, Tag,
+};
+use cipher::{BlockCipher, NewBlockCipher};
 use core::{convert::TryInto, fmt, num::Wrapping};
 
 pub use aead;

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.5.0"
+version = "0.6.0-pre"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.3", default-features = false }
-salsa20 = { version = "0.6.0", features = ["xsalsa20", "zeroize"] }
+salsa20 = { version = "0.7", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.6"
 rand_core = { version = "0.5", optional = true }
 subtle = { version = "2", default-features = false }

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -101,12 +101,16 @@
 pub use aead;
 pub use salsa20::{Key, XNonce as Nonce};
 
-use aead::consts::{U0, U16, U24, U32};
-use aead::generic_array::GenericArray;
-use aead::{AeadInPlace, Buffer, Error, NewAead};
+use aead::{
+    consts::{U0, U16, U24, U32},
+    generic_array::GenericArray,
+    AeadInPlace, Buffer, Error, NewAead,
+};
 use poly1305::{universal_hash::NewUniversalHash, Poly1305};
-use salsa20::stream_cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
-use salsa20::XSalsa20;
+use salsa20::{
+    cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek},
+    XSalsa20,
+};
 use zeroize::Zeroize;
 
 #[cfg(feature = "rand_core")]


### PR DESCRIPTION
...and updates associated dependencies:

- `aes` v0.6.0
- `ctr` v0.6.0