### PR TITLE
Release new versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "aead",
  "aes",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "aead",
  "aes",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "aead",
  "aes",
@@ -111,7 +111,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "ccm"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "aead",
  "aes",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "aead",
  "chacha20",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "chacha20poly1305",
  "rand",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "aead",
  "aes",
@@ -348,7 +348,7 @@ checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "mgm"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "aead",
  "cipher",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aead",
  "poly1305",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+- Bump `aes` dependency to v0.6 ([#229])
+- Use `ctr::Ctr32LE` ([#227])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+[#227]: https://github.com/RustCrypto/AEADs/pull/227
+
 ## 0.8.0 (2020-09-17)
 ### Added
 - Optional `std` feature; disabled by default ([#217])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+- Bump `aes` dependency to v0.6 ([#229])
+- Use `ctr::Ctr32BE` ([#227])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+[#227]: https://github.com/RustCrypto/AEADs/pull/227
+
 ## 0.7.0 (2020-09-17)
 ### Added
 - Optional `std` feature; disabled by default ([#217])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.8.0-pre"
+version = "0.8.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+- Bump `aes` dependency to v0.6 ([#229])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+
 ## 0.4.0 (2020-09-17)
 ### Added
 - Optional `std` feature; disabled by default ([#217])

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+
 ## 0.2.0 (2020-09-17)
 ### Added
 - Optional `std` feature; disabled by default ([#217])

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2018"

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+- Bump `chacha20` dependency to v0.6 ([#229])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+
 ## 0.6.0 (2020-09-17)
 ### Added
 - Optional `std` feature; disabled by default ([#217])

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-10-16)
+### Added
+- `ChaChaBox` ([#225])
+
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+- Bump `xsalsa20poly1305` dependency to v0.6 ([#229])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+[#225]: https://github.com/RustCrypto/AEADs/pull/225
+
 ## 0.4.0 (2020-09-17)
 ### Added
 - Optional `std` feature; disabled by default ([#217])

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman
@@ -23,13 +23,13 @@ x25519-dalek = { version = "1", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dependencies.chacha20poly1305]
-version = "0.7.0-pre"
+version = "0.7"
 default-features = false
 features = ["xchacha20poly1305"]
 path = "../chacha20poly1305"
 
 [dependencies.xsalsa20poly1305]
-version = "0.6.0-pre"
+version = "0.6"
 default-features = false
 features = ["rand_core"]
 path = "../xsalsa20poly1305"

--- a/eax/CHANGELOG.md
+++ b/eax/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+
 ## 0.2.0 (2020-09-30
 ### Added
 - API for online encryption/decryption ([#214])

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/mgm/CHANGELOG.md
+++ b/mgm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+
 ## 0.2.1 (2020-08-14)
 ### Added
 - `Clone` and `fmt::Debug` trait implementations ([#192])

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mgm"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "Generic implementation of the Multilinear Galois Mode (MGM) cipher"
 authors = ["RustCrypto Developers"]
 edition = "2018"

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])
+- Bump `salsa20` dependency to v0.7 ([#229])
+
+[#229]: https://github.com/RustCrypto/AEADs/pull/229
+
 ## 0.5.0 (2020-09-17)
 ### Added
 - Optional `std` feature; disabled by default ([#217])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
Releases new versions of all crates in this repository which incorporate the migration to the new `cipher` crate (#229).