### PR TITLE
eax: Allow variable tag length

### DIFF
--- a/eax/src/traits.rs
+++ b/eax/src/traits.rs
@@ -1,0 +1,18 @@
+use aead::consts::{U16, U4};
+use aead::generic_array::typenum::type_operators::{IsGreaterOrEqual, IsLessOrEqual};
+use aead::generic_array::typenum::Unsigned;
+use aead::generic_array::ArrayLength;
+
+mod private {
+    // Sealed traits stop other crates from implementing any traits that use it.
+    pub trait SealedTag {}
+
+    impl<T> SealedTag for T where
+        T: super::IsGreaterOrEqual<super::U4> + super::IsLessOrEqual<super::U16>
+    {
+    }
+}
+
+pub trait TagSize: ArrayLength<u8> + Unsigned + private::SealedTag {}
+
+impl<T> TagSize for T where T: ArrayLength<u8> + IsGreaterOrEqual<U4> + IsLessOrEqual<U16> {}


### PR DESCRIPTION
Implemented analogous to ccm by passing a second generic argument to
Eax.

Fixes #220.

This change should be mostly backwards compatible, apart from exporting the generic Tag instead of `pub type Tag = GenericArray<u8, U16>;`
It should be easy to make keep it completely backwards compatible if that’s better.