### PR TITLE
aes-gcm-siv: fix interleaved buffer size

### DIFF
--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -338,7 +338,7 @@ where
         self.polyval.update_padded(associated_data);
         let mut ctr = Ctr32LE::from_block_cipher(&self.enc_cipher, tag);
 
-        for chunk in buffer.chunks_mut(B::ParBlocks::to_usize() * B::ParBlocks::to_usize()) {
+        for chunk in buffer.chunks_mut(B::BlockSize::to_usize() * B::ParBlocks::to_usize()) {
             ctr.apply_keystream(chunk);
             self.polyval.update_padded(chunk);
         }


### PR DESCRIPTION
The implementation contained what's effectively a typo, albeit a harmless one.

It was trying to compute the size of a buffer to work on in parallel and was previously doing:

    ParBlocks (8) * ParBlocks (8) = 64

Semantically what was intended was:

    BlockSize (16) * ParBlocks (8) = 128

...which means the buffer was suboptimally sized for the underlying operation.