### PR TITLE
Bump `aes` crate; `aes*` crates => MSRV 1.49+

### DIFF
--- a/.github/workflows/aes-gcm-siv.yml
+++ b/.github/workflows/aes-gcm-siv.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/aes-gcm.yml
+++ b/.github/workflows/aes-gcm.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/aes-siv.yml
+++ b/.github/workflows/aes-siv.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 [[package]]
 name = "aes"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpuid-bool",
  "opaque-debug",
@@ -102,12 +102,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -115,9 +109,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chacha20"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#e6b08f9709ed37caa8796906d987377772701bdb"
+source = "git+https://github.com/RustCrypto/stream-ciphers.git#03ecd495ff073bd74713fa21dc246ca5eec52455"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpuid-bool",
  "zeroize",
@@ -146,7 +140,7 @@ dependencies = [
 [[package]]
 name = "cmac"
 version = "0.6.0-pre"
-source = "git+https://github.com/RustCrypto/MACs.git#daf6c12a118206aab3f131749d0baeca15942268"
+source = "git+https://github.com/RustCrypto/MACs.git#74f50ad79bbc4786e9529de455cf4630fca35859"
 dependencies = [
  "crypto-mac",
  "dbl",
@@ -264,11 +258,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -326,7 +320,7 @@ dependencies = [
 [[package]]
 name = "kuznyechik"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -358,7 +352,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pmac"
 version = "0.6.0-pre"
-source = "git+https://github.com/RustCrypto/MACs.git#daf6c12a118206aab3f131749d0baeca15942268"
+source = "git+https://github.com/RustCrypto/MACs.git#74f50ad79bbc4786e9529de455cf4630fca35859"
 dependencies = [
  "crypto-mac",
  "dbl",
@@ -459,7 +453,7 @@ dependencies = [
 [[package]]
 name = "salsa20"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#e6b08f9709ed37caa8796906d987377772701bdb"
+source = "git+https://github.com/RustCrypto/stream-ciphers.git#03ecd495ff073bd74713fa21dc246ca5eec52455"
 dependencies = [
  "cipher",
  "zeroize",

--- a/aes-gcm-siv/README.md
+++ b/aes-gcm-siv/README.md
@@ -69,7 +69,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes-gcm-siv/badge.svg
 [docs-link]: https://docs.rs/aes-gcm-siv/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/aes-gcm/README.md
+++ b/aes-gcm/README.md
@@ -49,7 +49,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes-gcm/badge.svg
 [docs-link]: https://docs.rs/aes-gcm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/aes-siv/README.md
+++ b/aes-siv/README.md
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes-siv/badge.svg
 [docs-link]: https://docs.rs/aes-siv/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -19,7 +19,7 @@ subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.3.2", features = ["dev"], default-features = false }
-aes = "0.7.0-pre"
+aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 hex-literal = "0.2"
 
 [features]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -26,7 +26,7 @@ ctr = "0.7.0-pre.3"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aes = "0.7.0-pre"
+aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 aead = { version = "0.3", features = ["dev"], default-features = false }
 
 [features]


### PR DESCRIPTION
The `aes` crate is a key component of several crates in this repo, and just had an MSRV breaking change in RustCrypto/block-ciphers#216.

This commit bumps the MSRV of all crates in this repo which use the `aes` crate to MSRV 1.49+.

In the case of `aes-gcm` and `aes-gcm-siv` specifically, the changes in RustCrypto/universal-hashes#113 bumped the MSRV of `ghash` and `polyval` to 1.49+ as well, so there are multiple motivations for this new MSRV.