### PR TITLE
chacha20poly1305: bump `chacha20` crate; MSRV 1.49+

### DIFF
--- a/.github/workflows/aes-gcm-siv.yml
+++ b/.github/workflows/aes-gcm-siv.yml
@@ -25,7 +25,7 @@ jobs:
           - 1.49.0 # MSRV
           - stable
         target:
-          # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
+          - armv7a-none-eabi
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:

--- a/.github/workflows/aes-gcm.yml
+++ b/.github/workflows/aes-gcm.yml
@@ -25,7 +25,7 @@ jobs:
           - 1.49.0 # MSRV
           - stable
         target:
-          # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
+          - armv7a-none-eabi
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:

--- a/.github/workflows/aes-siv.yml
+++ b/.github/workflows/aes-siv.yml
@@ -25,7 +25,7 @@ jobs:
           - 1.49.0 # MSRV
           - stable
         target:
-          # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
+          - armv7a-none-eabi
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:

--- a/.github/workflows/chacha20poly1305.yml
+++ b/.github/workflows/chacha20poly1305.yml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
-          # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
+          - armv7a-none-eabi
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/crypto_box.yml
+++ b/.github/workflows/crypto_box.yml
@@ -23,10 +23,9 @@ jobs:
 #    strategy:
 #      matrix:
 #        rust:
-#          - 1.41.0 # MSRV
+#          - 1.49.0 # MSRV
 #          - stable
 #        target:
-#          # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
 #          - thumbv7em-none-eabi
 #          - wasm32-unknown-unknown
 #    steps:
@@ -44,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -62,7 +61,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.41.0 # MSRV
+          toolchain: 1.49.0 # MSRV
           components: clippy
           override: true
       - run: cargo clippy -- -D warnings

--- a/.github/workflows/eax.yml
+++ b/.github/workflows/eax.yml
@@ -25,7 +25,6 @@ jobs:
           - 1.41.0 # MSRV
           - stable
         target:
-          # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:

--- a/.github/workflows/mgm.yml
+++ b/.github/workflows/mgm.yml
@@ -25,7 +25,6 @@ jobs:
           - 1.41.0 # MSRV
           - stable
         target:
-          # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:

--- a/.github/workflows/xsalsa20poly1305.yml
+++ b/.github/workflows/xsalsa20poly1305.yml
@@ -25,7 +25,6 @@ jobs:
           - 1.41.0 # MSRV
           - stable
         target:
-          # - armv7-none-eabi TODO: test after MSRV is bumped to 1.42
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chacha20"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#03ecd495ff073bd74713fa21dc246ca5eec52455"
+source = "git+https://github.com/RustCrypto/stream-ciphers.git#d5839255bd89fbe58ee36211deca7c39bc2597d2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "salsa20"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#03ecd495ff073bd74713fa21dc246ca5eec52455"
+source = "git+https://github.com/RustCrypto/stream-ciphers.git#d5839255bd89fbe58ee36211deca7c39bc2597d2"
 dependencies = [
  "cipher",
  "zeroize",
@@ -471,9 +471,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
+checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/chacha20poly1305/README.md
+++ b/chacha20poly1305/README.md
@@ -31,20 +31,6 @@ in the Transport Layer Security (TLS) protocol. The underlying ChaCha20 cipher
 is also widely used as a cryptographically secure random number generator,
 including internal use by the Rust standard library.
 
-## Performance Notes
-
-By default this crate will use portable software implementations of the
-underlying ChaCha20 and Poly1305 ciphers it's based on.
-
-When targeting modern x86/x86_64 CPUs, use the following `RUSTFLAGS` to
-take advantage of AVX2 acceleration:
-
-    RUSTFLAGS="-Ctarget-feature=+avx2"
-
-Ideally target the `haswell` or `skylake` architectures as a baseline:
-
-    RUSTFLAGS="-Ctarget-cpu=haswell -Ctarget-feature=+avx2"
-
 ## Security Notes
 
 This crate has received one [security audit by NCC Group][5], with no significant
@@ -81,7 +67,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/chacha20poly1305/badge.svg
 [docs-link]: https://docs.rs/chacha20poly1305/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -12,24 +12,6 @@
 //!   paper for background and rationale on when these constructions could be used.
 //!   When in doubt, prefer `ChaCha20Poly1305`.
 //!
-//! ## Performance Notes
-//!
-//! By default this crate will use portable software implementations of the
-//! underlying ChaCha20 and Poly1305 ciphers it's based on.
-//!
-//! When targeting modern x86/x86_64 CPUs, use the following `RUSTFLAGS` to
-//! take advantage of AVX2 acceleration:
-//!
-//! ```text
-//! RUSTFLAGS="-Ctarget-feature=+avx2"
-//! ```
-//!
-//! Ideally target the `haswell` or `skylake` architectures as a baseline:
-//!
-//! ```text
-//! RUSTFLAGS="-Ctarget-cpu=haswell -Ctarget-feature=+avx2"
-//! ```
-//!
 //! ## Security Notes
 //!
 //! This crate has received one [security audit by NCC Group][6], with no significant

--- a/crypto_box/README.md
+++ b/crypto_box/README.md
@@ -37,7 +37,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto_box/badge.svg
 [docs-link]: https://docs.rs/crypto_box/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg


### PR DESCRIPTION
Like we did with the `aes` crate in #252, this bumps the `chacha20` crate to a version which implements runtime CPU feature detection (AVX2/SSE2) and uses new support for `ManuallyDrop` union fields which became available in Rust 1.49.