### PR TITLE
Bump `aead` dependency to v0.4.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#252b77f0ee659b146c8aeb711d7372471cd65d0d"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aeaececfd937b9762778f2aca063ad24fdc827c48c07aeae36fb20c03afa11a"
 dependencies = [
  "blobby",
  "generic-array 0.14.4",
@@ -286,12 +287,12 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+checksum = "efb22866f8416bc2b65389ebcb8b48e1be541650c44063ea1288d04bcf903808"
 dependencies = [
  "as-slice",
- "generic-array 0.13.2",
+ "generic-array 0.14.4",
  "hash32",
  "stable_deref_trait",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ members = [
 ]
 
 [patch.crates-io]
-aead = { git = "https://github.com/RustCrypto/traits.git" }
 aes = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }
 cmac = { git = "https://github.com/RustCrypto/MACs.git" }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["aead", "aes", "aes-gcm", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "=0.4.0-pre", default-features = false }
+aead = { version = "0.4", default-features = false }
 aes = { version = "=0.7.0-pre", optional = true }
 cipher = "=0.3.0-pre.4"
 ctr = "=0.7.0-pre.3"

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["aead", "aes", "encryption", "gcm", "ghash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "=0.4.0-pre", default-features = false }
+aead = { version = "0.4", default-features = false }
 aes = { version = "=0.7.0-pre", optional = true }
 cipher = "=0.3.0-pre.4"
 ctr = "=0.7.0-pre.3"

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["aead", "aes", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = "=0.4.0-pre"
+aead = "0.4"
 aes = "=0.7.0-pre"
 cipher = "=0.3.0-pre.4"
 cmac = "=0.6.0-pre"

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -13,12 +13,12 @@ categories = ["cryptography", "no-std"]
 keywords = ["encryption", "aead"]
 
 [dependencies]
-aead = { version = "=0.4.0-pre", default-features = false }
+aead = { version = "0.4", default-features = false }
 cipher = { version = "=0.3.0-pre.4", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.4.0-pre", features = ["dev"], default-features = false }
+aead = { version = "0.4", features = ["dev"], default-features = false }
 aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 hex-literal = "0.2"
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "=0.4.0-pre", default-features = false }
+aead = { version = "0.4", default-features = false }
 chacha20 = { version = "=0.7.0-pre", features = ["zeroize"], optional = true }
 cipher = "=0.3.0-pre.4"
 poly1305 = "0.6"

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -19,14 +19,14 @@ keywords = ["aead", "aes", "encryption"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "=0.4.0-pre", default-features = false }
+aead = { version = "0.4", default-features = false }
 cipher = "=0.3.0-pre.4"
 cmac = "=0.6.0-pre"
 ctr = "=0.7.0-pre.3"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.4.0-pre", features = ["dev"], default-features = false }
+aead = { version = "0.4", features = ["dev"], default-features = false }
 aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 
 [features]

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -13,12 +13,12 @@ categories = ["cryptography", "no-std"]
 keywords = ["encryption", "aead"]
 
 [dependencies]
-aead = { version = "=0.4.0-pre", default-features = false }
+aead = { version = "0.4", default-features = false }
 cipher = "=0.3.0-pre.4"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.4.0-pre", features = ["dev"], default-features = false }
+aead = { version = "0.4", features = ["dev"], default-features = false }
 kuznyechik = "=0.7.0-pre"
 hex-literal = "0.2"
 

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["aead", "salsa20", "poly1305", "xsalsa20"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "=0.4.0-pre", default-features = false }
+aead = { version = "0.4", default-features = false }
 salsa20 = { version = "=0.8.0-pre", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.6"
 rand_core = { version = "0.5", optional = true }


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/526