### PR TITLE
.cargo/audit.toml: ignore `heapless` advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,3 +1,3 @@
 [advisories]
-ignore = ["RUSTSEC-2019-0029"]
+ignore = ["RUSTSEC-2019-0029", "RUSTSEC-2020-0145", "RUSTSEC-2020-0146"]
 informational_warnings = ["unmaintained", "unsound"]


### PR DESCRIPTION
Ignores the following advisories:

- RUSTSEC-2020-0145: heapless: UAF cloning a partially consumed iterator
- RUSTSEC-2020-0146: generic-array: lifetime extension in old versions

Re: RUSTSEC-2020-0145, the `aead` crate consumes the `heapless` crate this advisory is filed against, and does not iterate over `Vec`s nor does it clone them, so it should be unaffected.

Re: RUSTSEC-2020-0146, these are pulled in via `as-slice` which actually pulls in *three* versions of `generic-array`. Only the latest version is actually used (v0.14).