### PR TITLE
aes-gcm v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2021-04-29)
+### Added
+- Wycheproof test vectors ([#274])
+
+### Changed
+- Bump `aead` crate dependency to v0.4 ([#270])
+- Bump `aes` crate dependency to v0.7; MSRV 1.49+ ([#283])
+- Bump `ctr` crate dependency to v0.7 ([#283])
+- Bump `ghash` crate dependency to v0.4 ([#284])
+
+[#270]: https://github.com/RustCrypto/AEADs/pull/270
+[#274]: https://github.com/RustCrypto/AEADs/pull/274
+[#283]: https://github.com/RustCrypto/AEADs/pull/283
+[#284]: https://github.com/RustCrypto/AEADs/pull/284
+
 ## 0.8.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Added
- Wycheproof test vectors ([#274])

### Changed
- Bump `aead` crate dependency to v0.4 ([#270])
- Bump `aes` crate dependency to v0.7; MSRV 1.49+ ([#283])
- Bump `ctr` crate dependency to v0.7 ([#283])
- Bump `ghash` crate dependency to v0.4 ([#284])

[#270]: https://github.com/RustCrypto/AEADs/pull/270
[#274]: https://github.com/RustCrypto/AEADs/pull/274
[#283]: https://github.com/RustCrypto/AEADs/pull/283
[#284]: https://github.com/RustCrypto/AEADs/pull/284