### PR TITLE
chacha20poly1305 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "aead",
  "chacha20",

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-04-29)
+### Added
+- Wycheproof test vectors ([#274])
+
+### Changed
+- `xchacha` feature name ([#257])
+- MSRV 1.49+ ([#286], [#289])
+- Bump `chacha20` crate dependency to v0.7 ([#286])
+- Bump `poly1305` crate dependency to v0.7 ([#289])
+
+[#257]: https://github.com/RustCrypto/AEADs/pull/257
+[#274]: https://github.com/RustCrypto/AEADs/pull/274
+[#286]: https://github.com/RustCrypto/AEADs/pull/286
+[#289]: https://github.com/RustCrypto/AEADs/pull/289
+
 ## 0.7.1 (2020-10-25)
 ### Changed
 - Expand README.md ([#233])

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.8.0-pre"
+version = "0.8.0"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -23,7 +23,7 @@ x25519-dalek = { version = "1", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dependencies.chacha20poly1305]
-version = "=0.8.0-pre"
+version = "0.8"
 default-features = false
 features = ["xchacha20poly1305"]
 path = "../chacha20poly1305"


### PR DESCRIPTION
### Added
- Wycheproof test vectors ([#274])

### Changed
- `xchacha` feature name ([#257])
- MSRV 1.49+ ([#286], [#289])
- Bump `chacha20` crate dependency to v0.7 ([#286])
- Bump `poly1305` crate dependency to v0.7 ([#289])

[#257]: https://github.com/RustCrypto/AEADs/pull/257
[#274]: https://github.com/RustCrypto/AEADs/pull/274
[#286]: https://github.com/RustCrypto/AEADs/pull/286
[#289]: https://github.com/RustCrypto/AEADs/pull/289