### PR TITLE
xsalsa20poly1305 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "aead",
  "poly1305",

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wycheproof test vectors ([#274])
 
 ### Changed
+- Bump `aead` crate dependency to v0.4 ([#270])
 - `xchacha` feature name ([#257])
 - MSRV 1.49+ ([#286], [#289])
 - Bump `chacha20` crate dependency to v0.7 ([#286])
 - Bump `poly1305` crate dependency to v0.7 ([#289])
 
 [#257]: https://github.com/RustCrypto/AEADs/pull/257
+[#270]: https://github.com/RustCrypto/AEADs/pull/270
 [#274]: https://github.com/RustCrypto/AEADs/pull/274
 [#286]: https://github.com/RustCrypto/AEADs/pull/286
 [#289]: https://github.com/RustCrypto/AEADs/pull/289

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -29,7 +29,7 @@ features = ["xchacha20poly1305"]
 path = "../chacha20poly1305"
 
 [dependencies.xsalsa20poly1305]
-version = "=0.7.0-pre"
+version = "0.7"
 default-features = false
 features = ["rand_core"]
 path = "../xsalsa20poly1305"

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Changed
+- Bump `aead` crate dependency to v0.4 ([#270])
+- MSRV 1.49+ ([#286], [#289])
+- Bump `chacha20` crate dependency to v0.7 ([#286])
+- Bump `poly1305` crate dependency to v0.7 ([#289])
+
+[#270]: https://github.com/RustCrypto/AEADs/pull/270
+[#286]: https://github.com/RustCrypto/AEADs/pull/286
+[#289]: https://github.com/RustCrypto/AEADs/pull/289
+
 ## 0.6.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
### Changed
- Bump `aead` crate dependency to v0.4 ([#270])
- MSRV 1.49+ ([#286], [#289])
- Bump `chacha20` crate dependency to v0.7 ([#286])
- Bump `poly1305` crate dependency to v0.7 ([#289])

[#270]: https://github.com/RustCrypto/AEADs/pull/270
[#286]: https://github.com/RustCrypto/AEADs/pull/286
[#289]: https://github.com/RustCrypto/AEADs/pull/289