### PR TITLE
ccm v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "ccm"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aead",
  "aes",

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-04-29)
+### Changed
+- Bump `aead` dependency to v0.4 ([#270])
+- Bump `cipher` dependency to v0.3 ([#283])
+
+### Fixed
+- Panic on 32-bit targets ([#263])
+
+[#263]: https://github.com/RustCrypto/AEADs/pull/263
+[#270]: https://github.com/RustCrypto/AEADs/pull/270
+[#283]: https://github.com/RustCrypto/AEADs/pull/283
+
 ## 0.3.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2018"


### PR DESCRIPTION
### Changed
- Bump `aead` dependency to v0.4 ([#270])
- Bump `cipher` dependency to v0.3 ([#283])

### Fixed
- Panic on 32-bit targets ([#263])

[#263]: https://github.com/RustCrypto/AEADs/pull/263
[#270]: https://github.com/RustCrypto/AEADs/pull/270
[#283]: https://github.com/RustCrypto/AEADs/pull/283