### PR TITLE
xsalsa20poly1305 v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aead",
  "poly1305",

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (2021-04-29)
+## 0.7.1 (2021-04-29)
+### Changed
+- Bump `rand_core` crate dependency to v0.6 ([#292])
+
+[#292]: https://github.com/RustCrypto/AEADs/pull/292
+
+## 0.7.0 (2021-04-29) [YANKED]
 ### Changed
 - Bump `aead` crate dependency to v0.4 ([#270])
 - MSRV 1.49+ ([#286], [#289])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.7.0"
+version = "0.7.1"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
### Changed
- Bump `rand_core` crate dependency to v0.6 ([#292])

[#292]: https://github.com/RustCrypto/AEADs/pull/292