### PR TITLE
aes-gcm-siv v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2021-04-29)
+### Added
+- Wycheproof test vectors ([#274])
+
+### Changed
+- Bump `aead` crate dependency to v0.4 ([#270])
+- Bump `aes` and `ctr` crate dependencies to v0.7 ([#283])
+- Bump `polyval` to v0.5 ([#284])
+
+### Fixed
+- Interleaved buffer size ([#235])
+
+[#235]: https://github.com/RustCrypto/AEADs/pull/235
+[#270]: https://github.com/RustCrypto/AEADs/pull/270
+[#274]: https://github.com/RustCrypto/AEADs/pull/274
+[#283]: https://github.com/RustCrypto/AEADs/pull/283
+[#284]: https://github.com/RustCrypto/AEADs/pull/284
+
 ## 0.9.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.10.0-pre"
+version = "0.10.0"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific


### PR DESCRIPTION
### Added
- Wycheproof test vectors ([#274])

### Changed
- Bump `aead` crate dependency to v0.4 ([#270])
- Bump `aes` and `ctr` crate dependencies to v0.7 ([#283])
- Bump `polyval` to v0.5 ([#284])

### Fixed
- Interleaved buffer size ([#235])

[#235]: https://github.com/RustCrypto/AEADs/pull/235
[#270]: https://github.com/RustCrypto/AEADs/pull/270
[#274]: https://github.com/RustCrypto/AEADs/pull/274
[#283]: https://github.com/RustCrypto/AEADs/pull/283
[#284]: https://github.com/RustCrypto/AEADs/pull/284