### PR TITLE
aes-siv v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2021-04-29)
+### Added
+- AES-SIV-CMAC Wycheproof test vectors ([#276])
+
+### Changed
+- Bump `aead` crate dependency to v0.4 ([#270])
+- Bump `aes` and `ctr` crate dependencies to v0.7 ([#283])
+- Bump `cmac` and `pmac` deps to v0.6 releases ([#285])
+
+[#270]: https://github.com/RustCrypto/AEADs/pull/270
+[#276]: https://github.com/RustCrypto/AEADs/pull/276
+[#283]: https://github.com/RustCrypto/AEADs/pull/283
+[#285]: https://github.com/RustCrypto/AEADs/pull/285
+
 ## 0.5.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific


### PR DESCRIPTION
### Added
- AES-SIV-CMAC Wycheproof test vectors ([#276])

### Changed
- Bump `aead` crate dependency to v0.4 ([#270])
- Bump `aes` and `ctr` crate dependencies to v0.7 ([#283])
- Bump `cmac` and `pmac` deps to v0.6 releases ([#285])

[#270]: https://github.com/RustCrypto/AEADs/pull/270
[#276]: https://github.com/RustCrypto/AEADs/pull/276
[#283]: https://github.com/RustCrypto/AEADs/pull/283
[#285]: https://github.com/RustCrypto/AEADs/pull/285