### PR TITLE
eax v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aead",
  "aes",

--- a/eax/CHANGELOG.md
+++ b/eax/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-04-29)
+### Added
+- Allow variable tag length ([#231])
+
+### Changed
+- Bump `aead` crate dependency to v0.4 ([#270])
+- Bump `aes` and `ctr` crate dependencies to v0.7 ([#283])
+- Bump `cmac` and `pmac` deps to v0.6 releases ([#285])
+
+[#231]: https://github.com/RustCrypto/AEADs/pull/231
+[#270]: https://github.com/RustCrypto/AEADs/pull/270
+[#283]: https://github.com/RustCrypto/AEADs/pull/283
+[#285]: https://github.com/RustCrypto/AEADs/pull/285
+
 ## 0.3.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Added
- Allow variable tag length ([#231])

### Changed
- Bump `aead` crate dependency to v0.4 ([#270])
- Bump `aes` and `ctr` crate dependencies to v0.7 ([#283])
- Bump `cmac` and `pmac` deps to v0.6 releases ([#285])

[#231]: https://github.com/RustCrypto/AEADs/pull/231
[#270]: https://github.com/RustCrypto/AEADs/pull/270
[#283]: https://github.com/RustCrypto/AEADs/pull/283
[#285]: https://github.com/RustCrypto/AEADs/pull/285