### PR TITLE
mgm v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "mgm"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aead",
  "cipher",

--- a/mgm/CHANGELOG.md
+++ b/mgm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-04-29)
+### Changed
+- Bump `aead` dependency to v0.4.0 release ([#270])
+
+[#270]: https://github.com/RustCrypto/AEADs/pull/270
+
 ## 0.3.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#229])

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mgm"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Generic implementation of the Multilinear Galois Mode (MGM) cipher"
 authors = ["RustCrypto Developers"]
 edition = "2018"


### PR DESCRIPTION
### Changed
- Bump `aead` dependency to v0.4.0 release ([#270])

[#270]: https://github.com/RustCrypto/AEADs/pull/270