### PR TITLE
WIP: Legacy ChaCha20Poly1305 Construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "chacha20",
  "cipher",
  "poly1305",
+ "subtle",
  "zeroize",
 ]
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -23,6 +23,7 @@ chacha20 = { version = "0.7", features = ["zeroize"], optional = true }
 cipher = "0.3"
 poly1305 = "0.7"
 zeroize = { version = "1", default-features = false }
+subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }
@@ -35,6 +36,7 @@ heapless = ["aead/heapless"]
 reduced-round = ["chacha20"]
 stream = ["aead/stream"]
 xchacha20poly1305 = ["chacha20/xchacha"]
+legacy = ["chacha20/legacy"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/chacha20poly1305/src/chacha20poly1305legacy.rs
+++ b/chacha20poly1305/src/chacha20poly1305legacy.rs
@@ -1,0 +1,206 @@
+pub use chacha20::LegacyNonce;
+
+use crate::{Key, Tag};
+use aead::{
+    consts::{U0, U16, U32, U8},
+    AeadCore, AeadInPlace, Buffer, Error, NewAead,
+};
+use chacha20::ChaCha20Legacy;
+use cipher::NewCipher;
+use zeroize::Zeroize;
+
+use aead::generic_array::GenericArray;
+use cipher::{StreamCipher, StreamCipherSeek};
+use core::convert::TryInto;
+use poly1305::{
+    universal_hash::{NewUniversalHash, UniversalHash},
+    Poly1305,
+};
+use subtle::ConstantTimeEq;
+
+#[derive(Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
+pub struct ChaCha20Poly1305Legacy {
+    /// Secret key
+    key: Key,
+}
+
+impl NewAead for ChaCha20Poly1305Legacy {
+    type KeySize = U32;
+
+    fn new(key: &Key) -> Self {
+        ChaCha20Poly1305Legacy { key: *key }
+    }
+}
+
+impl AeadCore for ChaCha20Poly1305Legacy {
+    type NonceSize = U8;
+    type TagSize = U16;
+    type CiphertextOverhead = U0;
+}
+
+impl AeadInPlace for ChaCha20Poly1305Legacy {
+    fn encrypt_in_place_detached(
+        &self,
+        nonce: &LegacyNonce,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<Tag, Error> {
+        Cipher::new(ChaCha20Legacy::new(&self.key, nonce))
+            .encrypt_in_place_detached(associated_data, buffer)
+    }
+
+    fn decrypt_in_place_detached(
+        &self,
+        nonce: &LegacyNonce,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &Tag,
+    ) -> Result<(), Error> {
+        Cipher::new(ChaCha20Legacy::new(&self.key, nonce)).decrypt_in_place_detached(
+            associated_data,
+            buffer,
+            tag,
+        )
+    }
+}
+
+impl Drop for ChaCha20Poly1305Legacy {
+    fn drop(&mut self) {
+        self.key.as_mut_slice().zeroize();
+    }
+}
+
+/// Size of a ChaCha20 block in bytes
+const BLOCK_SIZE: usize = 64;
+
+/// Maximum number of blocks that can be encrypted with ChaCha20 before the
+/// counter overflows.
+const MAX_BLOCKS: usize = core::u32::MAX as usize;
+
+/// ChaCha20Poly1305 instantiated with a particular nonce
+pub(crate) struct Cipher<C>
+where
+    C: StreamCipher + StreamCipherSeek,
+{
+    cipher: C,
+    mac: BufferedPoly1305,
+}
+
+impl<C> Cipher<C>
+where
+    C: StreamCipher + StreamCipherSeek,
+{
+    /// Instantiate the underlying cipher with a particular nonce
+    pub(crate) fn new(mut cipher: C) -> Self {
+        // Derive Poly1305 key from the first 32-bytes of the ChaCha20 keystream
+        let mut mac_key = poly1305::Key::default();
+        cipher.apply_keystream(&mut *mac_key);
+        let mac = BufferedPoly1305::new(GenericArray::from_slice(&*mac_key));
+        mac_key.zeroize();
+
+        // Set ChaCha20 counter to 1
+        cipher.seek(BLOCK_SIZE as u64);
+
+        Self { cipher, mac }
+    }
+
+    /// Encrypt the given message in-place, returning the authentication tag
+    pub(crate) fn encrypt_in_place_detached(
+        mut self,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<Tag, Error> {
+        if buffer.len() / BLOCK_SIZE >= MAX_BLOCKS {
+            return Err(Error);
+        }
+
+        // TODO(tarcieri): interleave encryption with Poly1305
+        // See: <https://github.com/RustCrypto/AEADs/issues/74>
+        self.cipher.apply_keystream(buffer);
+
+        self.mac.update_buffered(associated_data);
+        self.mac
+            .update_buffered(&(associated_data.len() as u64).to_le_bytes());
+        self.mac.update_buffered(buffer);
+        self.mac
+            .update_buffered(&(buffer.len() as u64).to_le_bytes());
+
+        Ok(self.mac.finalize().into_bytes())
+    }
+
+    /// Decrypt the given message, first authenticating ciphertext integrity
+    /// and returning an error if it's been tampered with.
+    pub(crate) fn decrypt_in_place_detached(
+        mut self,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &Tag,
+    ) -> Result<(), Error> {
+        if buffer.len() / BLOCK_SIZE >= MAX_BLOCKS {
+            return Err(Error);
+        }
+
+        self.mac.update_buffered(associated_data);
+        self.mac
+            .update_buffered(&(associated_data.len() as u64).to_le_bytes());
+        self.mac.update_buffered(buffer);
+        self.mac
+            .update_buffered(&(buffer.len() as u64).to_le_bytes());
+
+        let expected_tag = self.mac.finalize().into_bytes();
+
+        // This performs a constant-time comparison using the `subtle` crate
+        if expected_tag.ct_eq(tag).unwrap_u8() == 1 {
+            // TODO(tarcieri): interleave decryption with Poly1305
+            // See: <https://github.com/RustCrypto/AEADs/issues/74>
+            self.cipher.apply_keystream(buffer);
+            Ok(())
+        } else {
+            Err(Error)
+        }
+    }
+}
+
+struct BufferedPoly1305 {
+    poly1305: Poly1305,
+    remainder: [u8; poly1305::BLOCK_SIZE],
+    rem_size: usize,
+}
+
+impl BufferedPoly1305 {
+    fn new(key: &poly1305::Key) -> Self {
+        BufferedPoly1305 {
+            poly1305: Poly1305::new(key),
+            remainder: [0; 16],
+            rem_size: 0,
+        }
+    }
+
+    fn update_buffered(&mut self, data: &[u8]) {
+        if data.len() + self.rem_size < self.remainder.len() {
+            self.remainder[self.rem_size..self.rem_size + data.len()].copy_from_slice(data);
+            self.rem_size += data.len();
+        } else {
+            let (head, body) = data.split_at(self.remainder.len() - self.rem_size);
+            self.remainder[self.rem_size..self.rem_size + head.len()].copy_from_slice(head);
+            self.poly1305.update((&self.remainder).into());
+
+            let mut chunks = body.chunks_exact(poly1305::BLOCK_SIZE);
+
+            for chunk in chunks.by_ref() {
+                self.poly1305.update(chunk.into());
+            }
+
+            let rem = chunks.remainder();
+
+            self.remainder[0..rem.len()].copy_from_slice(rem);
+            self.rem_size = rem.len();
+        }
+    }
+
+    fn finalize(self) -> poly1305::Tag {
+        self.poly1305
+            .compute_unpadded(&self.remainder[..self.rem_size])
+    }
+}

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -113,6 +113,12 @@ pub use aead;
 #[cfg(feature = "xchacha20poly1305")]
 pub use xchacha20poly1305::{XChaCha20Poly1305, XNonce};
 
+#[cfg(feature = "legacy")]
+mod chacha20poly1305legacy;
+
+#[cfg(feature = "legacy")]
+pub use chacha20poly1305legacy::{ChaCha20Poly1305Legacy, LegacyNonce};
+
 use self::cipher::Cipher;
 use ::cipher::{NewCipher, StreamCipher, StreamCipherSeek};
 use aead::{


### PR DESCRIPTION
I just quickly copied the code from the `xchacha20poly1305` module and adapted it to `ChaCha20Legacy` together with the `LegacyNonce`. I set the `NonceSize` to `U8`.

It is however not working and I could use some hints where to search. When I encrypt using libsodium and decrypt using my new module the mac verification fails (`if self.mac.verify(tag).is_ok()` in `cipher.rs:87`). When I do the same thing with XChaCha20Poly1305 everything works. So probably I just did not change something I am supposed to change, but I don't know what that is.

This is my test program:

Cargo.toml
``` toml
[package]
name = "chacha"
version = "0.1.0"
edition = "2018"

[dependencies]
sodiumoxide = "0.2"
chacha20poly1305 = { path = "../AEADs/chacha20poly1305", features = ["legacy"] }
```

main.rs (comment in and out to switch to xchacha)
``` rust
// use sodiumoxide::crypto::aead::xchacha20poly1305_ietf as sodium_algo;
// const NONCE: &[u8; 24] = b"123456781234567812345678";
// type RustCryptoChaCha = chacha20poly1305::XChaCha20Poly1305;
// type RustCryptoNonce = chacha20poly1305::XNonce;

use sodiumoxide::crypto::aead::chacha20poly1305 as sodium_algo;
const NONCE: &[u8; 8] = b"12345678";
type RustCryptoChaCha = chacha20poly1305::ChaCha20Poly1305Legacy;
type RustCryptoNonce = chacha20poly1305::LegacyNonce;

use chacha20poly1305::aead::{Aead, NewAead};

fn main() {
    sodiumoxide::init().unwrap();
    let k = sodium_algo::gen_key();
    let n = sodium_algo::Nonce::from_slice(NONCE).unwrap();

    let cipher = sodium_algo::seal(b"Hello World!", None, &n, &k);

    println!(
        "sodium: {}",
        std::str::from_utf8(&sodium_algo::open(&cipher, None, &n, &k).unwrap()).unwrap()
    );

    let decrypter = RustCryptoChaCha::new_from_slice(&k.0).unwrap();
    let plaintext = decrypter
        .decrypt(RustCryptoNonce::from_slice(&n.0), &cipher[..])
        .unwrap();

    println!(
        "rust crypto: {}",
        std::str::from_utf8(&plaintext[..]).unwrap()
    );
}
```