### PR TITLE
aes-gcm: add `force-soft` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90df9c2964d71ba6591379cc3bff5127cc19dcbe6a62088a1b3718d6cbfe08cf"
+checksum = "5f6fb2a26dd2ebd268a68bc8e9acc9e67e487952f33384055a1cbe697514c64e"
 dependencies = [
  "opaque-debug",
  "polyval",

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -20,7 +20,7 @@ aead = { version = "0.4", default-features = false }
 aes = { version = "0.7", optional = true }
 cipher = "0.3"
 ctr = "0.7"
-ghash = { version = "0.4", default-features = false }
+ghash = { version = "0.4.1", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -32,6 +32,7 @@ hex-literal = "0.2"
 default = ["aes", "alloc"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+force-soft = ["aes/force-soft", "ghash/force-soft"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
 


### PR DESCRIPTION
Adds a `force-soft` crate feature which in turn enables the corresponding `aes/force-soft` and `ghash/force-soft` features.

This enables operation on Rust 1.41+.