### PR TITLE
aes-gcm v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1 (2021-05-04)
+### Added
+- `force-soft` feature ([#305])
+
+[#305]: https://github.com/RustCrypto/AEADs/pull/305
+
 ## 0.9.0 (2021-04-29)
 ### Added
 - Wycheproof test vectors ([#274])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.9.0"
+version = "0.9.1"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Added
- `force-soft` feature ([#305])

[#305]: https://github.com/RustCrypto/AEADs/pull/305