### PR TITLE
Add aead/rand_core to default features to xsalsa20poly1305.

### DIFF
--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -23,7 +23,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [features]
-default = ["alloc", "rand_core"]
+default = ["alloc", "rand_core", "aead/rand_core"]
 std = ["aead/std", "alloc", "rand_core/std"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]


### PR DESCRIPTION
Currently it's not enabled by default even though rand_core dependency
is enabled by default.