### PR TITLE
Implement hash for PublicKey.

### DIFF
--- a/crypto_box/src/lib.rs
+++ b/crypto_box/src/lib.rs
@@ -249,7 +249,7 @@ impl Drop for SecretKey {
 }
 
 /// `crypto_box` public key
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct PublicKey([u8; KEY_SIZE]);
 
 impl PublicKey {


### PR DESCRIPTION
It's convenient to have PublicKey as key in a Map (for isntance, we [use it in tox](https://github.com/tox-rs/tox/blob/db7de02c6d699b03c014c8bc11d63101022cfbc4/tox_core/src/relay/client/connections.rs#L102)).