### PR TITLE
Expose aes' `armv8` feature in aes-{gcm,gcm-siv,siv}

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -33,6 +33,7 @@ std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
+armv8 = ["aes/armv8"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -35,6 +35,7 @@ alloc = ["aead/alloc"]
 force-soft = ["aes/force-soft", "ghash/force-soft"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
+armv8 = ["aes/armv8"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -36,6 +36,7 @@ std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
+armv8 = ["aes/armv8"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I forgot if this needed, or if adding `aes = { version = "*", features = ["armv8"] }` will override the deps, If it's the latter, you can close this PR.