### PR TITLE
mgm: remove unnecessary NewBlockCipher bounds

### DIFF
--- a/mgm/CHANGELOG.md
+++ b/mgm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2021-05-20)
+### Changed
+- Remove unnecessary `NewBlockCipher` bounds ([#314])
+
+[#314]: https://github.com/RustCrypto/AEADs/pull/314
+
 ## 0.4.0 (2021-04-29)
 ### Changed
 - Bump `aead` dependency to v0.4.0 release ([#270])

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mgm"
-version = "0.4.0"
+version = "0.4.1"
 description = "Generic implementation of the Multilinear Galois Mode (MGM) cipher"
 authors = ["RustCrypto Developers"]
 edition = "2018"

--- a/mgm/src/lib.rs
+++ b/mgm/src/lib.rs
@@ -60,7 +60,7 @@ const ONE: Wrapping<u64> = Wrapping(1);
 #[derive(Clone)]
 pub struct Mgm<C>
 where
-    C: BlockCipher<BlockSize = U16> + BlockEncrypt + NewBlockCipher,
+    C: BlockCipher<BlockSize = U16> + BlockEncrypt,
     C::ParBlocks: ArrayLength<Block>,
 {
     cipher: C,
@@ -68,7 +68,7 @@ where
 
 impl<C> Mgm<C>
 where
-    C: BlockCipher<BlockSize = U16> + BlockEncrypt + NewBlockCipher,
+    C: BlockCipher<BlockSize = U16> + BlockEncrypt,
     C::ParBlocks: ArrayLength<Block>,
 {
     fn get_h(&self, counter: &Counter) -> Block {
@@ -86,7 +86,7 @@ where
 
 impl<C> From<C> for Mgm<C>
 where
-    C: BlockCipher<BlockSize = U16> + BlockEncrypt + NewBlockCipher,
+    C: BlockCipher<BlockSize = U16> + BlockEncrypt,
     C::ParBlocks: ArrayLength<Block>,
 {
     fn from(cipher: C) -> Self {
@@ -108,7 +108,7 @@ where
 
 impl<C> AeadCore for Mgm<C>
 where
-    C: BlockCipher<BlockSize = U16> + BlockEncrypt + NewBlockCipher,
+    C: BlockCipher<BlockSize = U16> + BlockEncrypt,
     C::ParBlocks: ArrayLength<Block>,
 {
     type NonceSize = C::BlockSize;
@@ -118,7 +118,7 @@ where
 
 impl<C> AeadInPlace for Mgm<C>
 where
-    C: BlockCipher<BlockSize = U16> + BlockEncrypt + NewBlockCipher,
+    C: BlockCipher<BlockSize = U16> + BlockEncrypt,
     C::ParBlocks: ArrayLength<Block>,
 {
     fn encrypt_in_place_detached(
@@ -293,7 +293,7 @@ fn to_bytes(v: &Counter) -> Block {
 
 impl<C> fmt::Debug for Mgm<C>
 where
-    C: BlockCipher<BlockSize = U16> + BlockEncrypt + NewBlockCipher + fmt::Debug,
+    C: BlockCipher<BlockSize = U16> + BlockEncrypt + fmt::Debug,
     C::ParBlocks: ArrayLength<Block>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {


### PR DESCRIPTION
This change allows us to work with `Mgm<&'a BlockCipher>`.