### PR TITLE
chacha20poly1305: Add `force-soft` feature

### DIFF
--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -35,6 +35,7 @@ heapless = ["aead/heapless"]
 reduced-round = ["chacha20"]
 stream = ["aead/stream"]
 xchacha20poly1305 = ["chacha20/xchacha"]
+force-soft = ["chacha20/force-soft", "poly1305/force-soft"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Adds a `force-soft` feature which forces non-SSE implementations for the `chacha20` and `poly1305` crates.

Follows the same pattern as #305.