### PR TITLE
AesPmacSiv features were not selectable by end users

### DIFF
--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -23,7 +23,7 @@ cmac = "0.6"
 crypto-mac = "0.11"
 ctr = "0.7"
 dbl = "0.3"
-pmac = "0.6"
+pmac = { version = "0.6", optional = true }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This change exposes a feature to enable users to use AES-PMAC-SIV constructs.

Unfortunately it renamed the "pmac" feature because it conflicts with the pmac dependency.