### PR TITLE
aes-gcm-siv v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.1 (2021-05-31)
+### Added
+- Nightly-only `armv8` feature ([#318])
+
+[#318]: https://github.com/RustCrypto/AEADs/pull/318
+
 ## 0.10.0 (2021-04-29)
 ### Added
 - Wycheproof test vectors ([#274])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.10.0"
+version = "0.10.1"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -23,7 +23,7 @@ cmac = "0.6"
 crypto-mac = "0.11"
 ctr = "0.7"
 dbl = "0.3"
-pmac = "0.6"
+pmac = { version = "0.6", optional = true }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
### Added
- Nightly-only `armv8` feature ([#318])

[#318]: https://github.com/RustCrypto/AEADs/pull/318