### PR TITLE
aes-siv v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aead",
  "aes",

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2021-06-26)
+### Fixed
+- `pmac` crate feature ([#321])
+
+[#321]: https://github.com/RustCrypto/AEADs/pull/321
+
 ## 0.6.0 (2021-04-29)
 ### Added
 - AES-SIV-CMAC Wycheproof test vectors ([#276])

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.6.0"
+version = "0.6.1"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific
@@ -39,3 +39,4 @@ stream = ["aead/stream"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -72,6 +72,7 @@
 //! [4]: https://github.com/miscreant/meta/wiki/Nonce-Reuse-Misuse-Resistance
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
@@ -132,6 +133,7 @@ pub type CmacSivAead<BlockCipher> = SivAead<Ctr128BE<BlockCipher>, Cmac<BlockCip
 
 /// SIV AEAD modes based on PMAC
 #[cfg(feature = "pmac")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pmac")))]
 pub type PmacSivAead<BlockCipher> = SivAead<Ctr128BE<BlockCipher>, Pmac<BlockCipher>>;
 
 /// AES-CMAC-SIV in AEAD mode with 256-bit key size (128-bit security)
@@ -142,10 +144,12 @@ pub type Aes256SivAead = CmacSivAead<Aes256>;
 
 /// AES-PMAC-SIV in AEAD mode with 256-bit key size (128-bit security)
 #[cfg(feature = "pmac")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pmac")))]
 pub type Aes128PmacSivAead = PmacSivAead<Aes128>;
 
 /// AES-PMAC-SIV in AEAD mode with 512-bit key size (256-bit security)
 #[cfg(feature = "pmac")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pmac")))]
 pub type Aes256PmacSivAead = PmacSivAead<Aes256>;
 
 impl<M> NewAead for SivAead<Ctr128BE<Aes128>, M>

--- a/aes-siv/src/siv.rs
+++ b/aes-siv/src/siv.rs
@@ -46,6 +46,7 @@ pub type CmacSiv<BlockCipher> = Siv<Ctr128BE<BlockCipher>, Cmac<BlockCipher>>;
 
 /// SIV modes based on PMAC
 #[cfg(feature = "pmac")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pmac")))]
 pub type PmacSiv<BlockCipher> = Siv<Ctr128BE<BlockCipher>, Pmac<BlockCipher>>;
 
 /// AES-CMAC-SIV with a 128-bit key
@@ -56,10 +57,12 @@ pub type Aes256Siv = CmacSiv<Aes256>;
 
 /// AES-PMAC-SIV with a 128-bit key
 #[cfg(feature = "pmac")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pmac")))]
 pub type Aes128PmacSiv = PmacSiv<Aes128>;
 
 /// AES-PMAC-SIV with a 256-bit key
 #[cfg(feature = "pmac")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pmac")))]
 pub type Aes256PmacSiv = PmacSiv<Aes256>;
 
 impl<C, M> Siv<C, M>


### PR DESCRIPTION
### Fixed
- `pmac` crate feature ([#321])

[#321]: https://github.com/RustCrypto/AEADs/pull/321