### PR TITLE
ccm: use the ctr crate for encryption and decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "aead",
  "aes",
  "cipher",
- "ctr",
+ "ctr 0.7.0",
  "ghash",
  "hex-literal 0.2.1",
  "subtle",
@@ -47,7 +47,7 @@ dependencies = [
  "aead",
  "aes",
  "cipher",
- "ctr",
+ "ctr 0.7.0",
  "polyval",
  "subtle",
  "zeroize",
@@ -63,7 +63,7 @@ dependencies = [
  "cipher",
  "cmac",
  "crypto-mac",
- "ctr",
+ "ctr 0.7.0",
  "dbl",
  "hex-literal 0.2.1",
  "pmac",
@@ -108,11 +108,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "ccm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aead",
  "aes",
  "cipher",
+ "ctr 0.8.0",
  "hex-literal 0.2.1",
  "subtle",
 ]
@@ -220,6 +221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +279,7 @@ dependencies = [
  "aes",
  "cipher",
  "cmac",
- "ctr",
+ "ctr 0.7.0",
  "subtle",
 ]
 

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2021-07-09)
+### Changed
+- Use the `ctr` crate for encryption and decryption. ([#332])
+
+[#332]: https://github.com/RustCrypto/AEADs/pull/332
+
 ## 0.4.1 (2021-07-09)
 ### Added
 - Make `NonceSize` and `TagSize` traits publicly visible. ([#331])

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.4.2 (2021-07-09)
+### Added
+- `From<BlockCipher>` and `Clone` impls. ([#332])
+
 ### Changed
 - Use the `ctr` crate for encryption and decryption. ([#332])
 

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.4.1"
+version = "0.4.2"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2018"
@@ -15,6 +15,7 @@ keywords = ["encryption", "aead"]
 [dependencies]
 aead = { version = "0.4", default-features = false }
 cipher = { version = "0.3", default-features = false }
+ctr = { version = "0.8", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -127,7 +127,7 @@ where
             let alen = adata.len();
             let (n, mut b) = fill_aad_header(alen);
             if b.len() - n >= alen {
-                b[n..n + alen].copy_from_slice(adata);
+                b[n..][..alen].copy_from_slice(adata);
                 mac.block_update(&b);
             } else {
                 let (l, r) = adata.split_at(b.len() - n);

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -51,7 +51,7 @@ use aead::{
     generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
     AeadCore, AeadInPlace, Error, Key, NewAead,
 };
-use cipher::{Block, BlockCipher, BlockEncrypt, NewBlockCipher, FromBlockCipher, StreamCipher};
+use cipher::{Block, BlockCipher, BlockEncrypt, FromBlockCipher, NewBlockCipher, StreamCipher};
 use core::marker::PhantomData;
 use subtle::ConstantTimeEq;
 


### PR DESCRIPTION
Closes #178

Also includes minor improvements of the CBC-MAC computation and adds `From<BlockCipher>` and `Clone` impls.