### PR TITLE
Bump hex-literal to v0.3 for aes-gcm and aes-siv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "cipher",
  "ctr",
  "ghash",
- "hex-literal 0.2.1",
+ "hex-literal 0.3.1",
  "subtle",
  "zeroize",
 ]
@@ -65,7 +65,7 @@ dependencies = [
  "crypto-mac",
  "ctr",
  "dbl",
- "hex-literal 0.2.1",
+ "hex-literal 0.3.1",
  "pmac",
  "zeroize",
 ]

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -26,7 +26,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }
-hex-literal = "0.2"
+hex-literal = "0.3"
 
 [features]
 default    = ["aes", "alloc"]

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"
-hex-literal = "0.2"
+hex-literal = "0.3"
 
 [features]
 default = ["alloc"]


### PR DESCRIPTION
The crates have MSRV 1.49, which is higher than the `hex-literal`'s MSRV.