### PR TITLE
README: replace build badges column with MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # RustCrypto: Authenticated Encryption with Associated Data (AEAD) Algorithms
 
 [![CodeCov Status][codecov-image]][codecov-link]
-![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
 [![dependency status][deps-image]][deps-link]
 
@@ -50,7 +49,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [codecov-image]: https://codecov.io/gh/RustCrypto/AEADs/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/RustCrypto/AEADs
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
 [deps-image]: https://deps.rs/repo/github/RustCrypto/AEADs/status.svg

--- a/README.md
+++ b/README.md
@@ -18,21 +18,18 @@ crate.
 
 ## Crates
 
-| Name                 | Algorithm                    | Crates.io | Documentation | Build |
+| Name                 | Algorithm                    | Crates.io | Documentation | MSRV |
 |----------------------|------------------------------|-----------|---------------|-------|
-| [`aes-gcm-siv`]      | [AES-GCM-SIV]                | [![crates.io](https://img.shields.io/crates/v/aes-gcm-siv.svg)](https://crates.io/crates/aes-gcm-siv) | [![Documentation](https://docs.rs/aes-gcm-siv/badge.svg)](https://docs.rs/aes-gcm-siv) | ![aes-gcm-siv](https://github.com/RustCrypto/AEADs/workflows/aes-gcm-siv/badge.svg?branch=master&event=push) |
-| [`aes-gcm`]          | [AES-GCM]                    | [![crates.io](https://img.shields.io/crates/v/aes-gcm.svg)](https://crates.io/crates/aes-gcm) | [![Documentation](https://docs.rs/aes-gcm/badge.svg)](https://docs.rs/aes-gcm) | ![aes-gcm](https://github.com/RustCrypto/AEADs/workflows/aes-gcm/badge.svg?branch=master&event=push) |
-| [`aes-siv`]          | [AES-SIV]                    | [![crates.io](https://img.shields.io/crates/v/aes-siv.svg)](https://crates.io/crates/aes-siv) | [![Documentation](https://docs.rs/aes-siv/badge.svg)](https://docs.rs/aes-siv) | ![aes-siv](https://github.com/RustCrypto/AEADs/workflows/aes-siv/badge.svg?branch=master&event=push) |
-| [`ccm`]              | [CCM]                        | [![crates.io](https://img.shields.io/crates/v/ccm.svg)](https://crates.io/crates/ccm) | [![Documentation](https://docs.rs/ccm/badge.svg)](https://docs.rs/ccm) | ![ccm](https://github.com/RustCrypto/AEADs/workflows/ccm/badge.svg?branch=master&event=push) |
-| [`chacha20poly1305`] | [(X)ChaCha20Poly1305]        | [![crates.io](https://img.shields.io/crates/v/chacha20poly1305.svg)](https://crates.io/crates/chacha20poly1305) | [![Documentation](https://docs.rs/chacha20poly1305/badge.svg)](https://docs.rs/chacha20poly1305) | ![chacha20poly1305](https://github.com/RustCrypto/AEADs/workflows/chacha20poly1305/badge.svg?branch=master&event=push) |
-| [`deoxys`]           | [Deoxys-I/II]                | [![crates.io](https://img.shields.io/crates/v/deoxys.svg)](https://crates.io/crates/deoxys) | [![Documentation](https://docs.rs/deoxys/badge.svg)](https://docs.rs/deoxys) | ![deoxys](https://github.com/RustCrypto/AEADs/workflows/deoxys/badge.svg?branch=master&event=push) |
-| [`crypto_box`]       | [Curve25519XSalsa20Poly1305] | [![crates.io](https://img.shields.io/crates/v/crypto_box.svg)](https://crates.io/crates/crypto_box) | [![Documentation](https://docs.rs/crypto_box/badge.svg)](https://docs.rs/crypto_box) | ![crypto_box](https://github.com/RustCrypto/AEADs/workflows/crypto_box/badge.svg?branch=master&event=push) |
-| [`eax`]              | [EAX]                        | [![crates.io](https://img.shields.io/crates/v/eax.svg)](https://crates.io/crates/eax) | [![Documentation](https://docs.rs/eax/badge.svg)](https://docs.rs/eax) | ![eax](https://github.com/RustCrypto/AEADs/workflows/eax/badge.svg?branch=master&event=push) |
-| [`mgm`]              | [MGM]                        | [![crates.io](https://img.shields.io/crates/v/mgm.svg)](https://crates.io/crates/mgm) | [![Documentation](https://docs.rs/mgm/badge.svg)](https://docs.rs/mgm) | ![mgm](https://github.com/RustCrypto/AEADs/workflows/mgm/badge.svg?branch=master&event=push) |
-| [`xsalsa20poly1305`] | [XSalsa20Poly1305]           | [![crates.io](https://img.shields.io/crates/v/xsalsa20poly1305.svg)](https://crates.io/crates/xsalsa20poly1305) | [![Documentation](https://docs.rs/xsalsa20poly1305/badge.svg)](https://docs.rs/xsalsa20poly1305) | ![xsalsa20poly1305](https://github.com/RustCrypto/AEADs/workflows/xsalsa20poly1305/badge.svg?branch=master&event=push) |
-
-NOTE: the [`aes-ccm`] crate also implements the [`aead`] traits
-used by all of the other crates in this repository.
+| [`aes-gcm-siv`]      | [AES-GCM-SIV]                | [![crates.io](https://img.shields.io/crates/v/aes-gcm-siv.svg)](https://crates.io/crates/aes-gcm-siv) | [![Documentation](https://docs.rs/aes-gcm-siv/badge.svg)](https://docs.rs/aes-gcm-siv) | 1.49 |
+| [`aes-gcm`]          | [AES-GCM]                    | [![crates.io](https://img.shields.io/crates/v/aes-gcm.svg)](https://crates.io/crates/aes-gcm) | [![Documentation](https://docs.rs/aes-gcm/badge.svg)](https://docs.rs/aes-gcm) | 1.49 |
+| [`aes-siv`]          | [AES-SIV]                    | [![crates.io](https://img.shields.io/crates/v/aes-siv.svg)](https://crates.io/crates/aes-siv) | [![Documentation](https://docs.rs/aes-siv/badge.svg)](https://docs.rs/aes-siv) | 1.49 |
+| [`ccm`]              | [CCM]                        | [![crates.io](https://img.shields.io/crates/v/ccm.svg)](https://crates.io/crates/ccm) | [![Documentation](https://docs.rs/ccm/badge.svg)](https://docs.rs/ccm) | 1.41 |
+| [`chacha20poly1305`] | [(X)ChaCha20Poly1305]        | [![crates.io](https://img.shields.io/crates/v/chacha20poly1305.svg)](https://crates.io/crates/chacha20poly1305) | [![Documentation](https://docs.rs/chacha20poly1305/badge.svg)](https://docs.rs/chacha20poly1305) | 1.49 |
+| [`crypto_box`]       | [Curve25519XSalsa20Poly1305] | [![crates.io](https://img.shields.io/crates/v/crypto_box.svg)](https://crates.io/crates/crypto_box) | [![Documentation](https://docs.rs/crypto_box/badge.svg)](https://docs.rs/crypto_box) | 1.49 |
+| [`deoxys`]           | [Deoxys-I/II]                | [![crates.io](https://img.shields.io/crates/v/deoxys.svg)](https://crates.io/crates/deoxys) | [![Documentation](https://docs.rs/deoxys/badge.svg)](https://docs.rs/deoxys) | 1.50 |
+| [`eax`]              | [EAX]                        | [![crates.io](https://img.shields.io/crates/v/eax.svg)](https://crates.io/crates/eax) | [![Documentation](https://docs.rs/eax/badge.svg)](https://docs.rs/eax) | 1.41 |
+| [`mgm`]              | [MGM]                        | [![crates.io](https://img.shields.io/crates/v/mgm.svg)](https://crates.io/crates/mgm) | [![Documentation](https://docs.rs/mgm/badge.svg)](https://docs.rs/mgm) | 1.41 |
+| [`xsalsa20poly1305`] | [XSalsa20Poly1305]           | [![crates.io](https://img.shields.io/crates/v/xsalsa20poly1305.svg)](https://crates.io/crates/xsalsa20poly1305) | [![Documentation](https://docs.rs/xsalsa20poly1305/badge.svg)](https://docs.rs/xsalsa20poly1305) | 1.49 |
 
 ## License
 


### PR DESCRIPTION
I think MSRV information is more valuable than the build badges, especially considering that in this repository we have crates with 3 different MSRVs.

Also I've removed the `aes-ccm` mention, since the `ccm` crate should be preferred for now. Later we probably should introduce a folder with crates containing common common composition of primitives (AES-GCM, ChaCha20Poly1305, etc.).