### PR TITLE
Pin zeroize dependency to v1.3 and subtle to v2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "aead",
  "aes",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "aead",
  "aes",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "aead",
  "aes",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aead",
  "chacha20",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "deoxys"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "aead",
  "aes",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aead",
  "poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "ccm"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aead",
  "aes",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aead",
  "aes",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "mgm"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aead",
  "cipher",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.10.2 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.3 ([#349])
+- Pin `zeroize` dependency to v1.3 and `subtle` to v2.4 ([#349])
 
 [#349]: https://github.com/RustCrypto/AEADs/pull/349
 

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.2 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.10.1 (2021-05-31)
 ### Added
 - Nightly-only `armv8` feature ([#318])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.10.1"
+version = "0.10.2"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific
@@ -22,7 +22,7 @@ cipher = "0.3"
 ctr = "0.8"
 polyval = { version = "0.5.1", default-features = false }
 subtle = { version = "2", default-features = false }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "=1.3", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -21,7 +21,7 @@ aes = { version = "0.7.4", optional = true }
 cipher = "0.3"
 ctr = "0.8"
 polyval = { version = "0.5.1", default-features = false }
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 zeroize = { version = "=1.3", default-features = false }
 
 [dev-dependencies]

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9.3 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.3 ([#349])
+- Pin `zeroize` dependency to v1.3 and `subtle` to v2.4 ([#349])
 
 [#349]: https://github.com/RustCrypto/AEADs/pull/349
 

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.3 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.9.2 (2021-05-31)
 ### Added
 - Nightly-only `armv8` feature ([#318])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.3"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher
@@ -22,7 +22,7 @@ cipher = "0.3"
 ctr = "0.8"
 ghash = { version = "0.4.2", default-features = false }
 subtle = { version = "2", default-features = false }
-zeroize = { version = "1", optional = true, default-features = false }
+zeroize = { version = "=1.3", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -21,7 +21,7 @@ aes = { version = "0.7.4", optional = true }
 cipher = "0.3"
 ctr = "0.8"
 ghash = { version = "0.4.2", default-features = false }
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 zeroize = { version = "=1.3", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.2 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.6.1 (2021-06-26)
 ### Fixed
 - `pmac` crate feature ([#321])

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.6.1"
+version = "0.6.2"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific
@@ -24,7 +24,7 @@ crypto-mac = "0.11"
 ctr = "0.8"
 dbl = "0.3"
 pmac = { version = "0.6", optional = true }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "=1.3", default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.4.3 (2021-07-09)
 ### Fixed
 - Doc links to `typenum` constants. ([#333])

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.4.3"
+version = "0.4.4"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2018"
@@ -16,7 +16,7 @@ keywords = ["encryption", "aead"]
 aead = { version = "0.4", default-features = false }
 cipher = { version = "0.3", default-features = false }
 ctr = { version = "0.8", default-features = false }
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.1 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.8.0 (2021-04-29)
 ### Added
 - Wycheproof test vectors ([#274])

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.8.0"
+version = "0.8.1"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific
@@ -22,7 +22,7 @@ aead = { version = "0.4", default-features = false }
 chacha20 = { version = "0.7", features = ["zeroize"], optional = true }
 cipher = "0.3"
 poly1305 = "0.7"
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "=1.3", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/crypto_box/CHANGELOG.md
+++ b/crypto_box/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.6.0 (2021-04-29)
 ### Changed
 - Bump `chacha20poly1305` crate dependency to v0.8 ([#290])

--- a/crypto_box/Cargo.toml
+++ b/crypto_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto_box"
-version = "0.6.0"
+version = "0.6.1"
 description = """
 Pure Rust implementation of NaCl's crypto_box public-key authenticated
 encryption primitive which combines the X25519 Elliptic Curve Diffie-Hellman
@@ -21,7 +21,7 @@ chacha20 = { version = "0.7.1", features = ["expose-core", "hchacha"] }
 rand_core = "0.6"
 salsa20 = { version = "0.8", features = ["hsalsa20"] }
 x25519-dalek = { version = "1", default-features = false }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "=1.3", default-features = false }
 
 [dependencies.chacha20poly1305]
 version = "0.8"

--- a/deoxys/CHANGELOG.md
+++ b/deoxys/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.0.2 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.3 ([#349])
+- Pin `zeroize` dependency to v1.3 and `subtle` to v2.4 ([#349])
 
 [#349]: https://github.com/RustCrypto/AEADs/pull/349
 

--- a/deoxys/CHANGELOG.md
+++ b/deoxys/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.2 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.0.1 (2021-06-26)
 - Initial release

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deoxys"
-version = "0.0.1"
+version = "0.0.2"
 description = """
 Pure Rust implementation of the Deoxys Authenticated Encryption with Associated
 Data (AEAD) cipher, including the Deoxys-II variant which was selected by the
@@ -19,7 +19,7 @@ edition = "2018"
 [dependencies]
 aead = { version = "0.4", default-features = false }
 subtle = { version = "2.4", default-features = false }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "=1.3", default-features = false }
 aes = { version = "0.7.4", features=["hazmat"], default-features = false}
 
 [dev-dependencies]

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 
 [dependencies]
 aead = { version = "0.4", default-features = false }
-subtle = { version = "2.4", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 zeroize = { version = "=1.3", default-features = false }
 aes = { version = "0.7.4", features=["hazmat"], default-features = false}
 

--- a/eax/CHANGELOG.md
+++ b/eax/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.4.0 (2021-04-29)
 ### Added
 - Allow variable tag length ([#231])

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher
@@ -23,7 +23,7 @@ aead = { version = "0.4", default-features = false }
 cipher = "0.3"
 cmac = "0.6"
 ctr = "0.8"
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/mgm/CHANGELOG.md
+++ b/mgm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.3 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.4.2 (2021-07-13)
 ### Added
 - Add support of 64 bit block ciphers ([#343])

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mgm"
-version = "0.4.2"
+version = "0.4.3"
 description = "Generic implementation of the Multilinear Galois Mode (MGM) cipher"
 authors = ["RustCrypto Developers"]
 edition = "2018"
@@ -15,7 +15,7 @@ keywords = ["encryption", "aead"]
 [dependencies]
 aead = { version = "0.4", default-features = false }
 cipher = "0.3"
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.7.2 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.3 ([#349])
+- Pin `zeroize` dependency to v1.3 and `subtle` to v2.4 ([#349])
 
 [#349]: https://github.com/RustCrypto/AEADs/pull/349
 

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.2 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#349])
+
+[#349]: https://github.com/RustCrypto/AEADs/pull/349
+
 ## 0.7.1 (2021-04-29)
 ### Changed
 - Bump `rand_core` crate dependency to v0.6 ([#292])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.7.1"
+version = "0.7.2"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm
@@ -20,7 +20,7 @@ salsa20 = { version = "0.8", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.7"
 rand_core = { version = "0.6", optional = true }
 subtle = { version = "2", default-features = false }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "=1.3", default-features = false }
 
 [features]
 default = ["alloc", "rand_core", "aead/rand_core"]

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -19,7 +19,7 @@ aead = { version = "0.4", default-features = false }
 salsa20 = { version = "0.8", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.7"
 rand_core = { version = "0.6", optional = true }
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 zeroize = { version = "=1.3", default-features = false }
 
 [features]


### PR DESCRIPTION
`zeroize` in v1.4 has updated its MSRV to 1.51 breaking our MSRV promise. This PR pins its version to v1.3.x. `subtle` is also preemptively pinned to v2.4.