### PR TITLE
mgm: decrypt only after tag verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "mgm"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aead",
  "cipher",

--- a/mgm/CHANGELOG.md
+++ b/mgm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 (2021-08-24)
+### Changed
+- Decrypt ciphertext only after tag verification ([#356])
+
+[#356]: https://github.com/RustCrypto/AEADs/pull/356
+
 ## 0.4.3 (2021-07-20)
 ### Changed
 - Pin `subtle` dependency to v2.4 ([#349])

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mgm"
-version = "0.4.3"
+version = "0.4.4"
 description = "Generic implementation of the Multilinear Galois Mode (MGM) cipher"
 authors = ["RustCrypto Developers"]
 edition = "2018"


### PR DESCRIPTION
It results in two-pass decryption which may be a bit less performant than the current approach, but should be a bit more secure in some contexts.