### PR TITLE
Relax `subtle` and `zeroize` requirements

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -21,8 +21,8 @@ aes = { version = "0.7.5", optional = true }
 cipher = "0.3"
 ctr = "0.8"
 polyval = { version = "0.5.1", default-features = false }
-subtle = { version = "=2.4", default-features = false }
-zeroize = { version = "=1.3", default-features = false }
+subtle = { version = ">=2, <2.5", default-features = false }
+zeroize = { version = ">=1, <1.4", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -21,8 +21,8 @@ aes = { version = "0.7.5", optional = true }
 cipher = "0.3"
 ctr = "0.8"
 ghash = { version = "0.4.2", default-features = false }
-subtle = { version = "=2.4", default-features = false }
-zeroize = { version = "=1.3", optional = true, default-features = false }
+subtle = { version = ">=2, <2.5", default-features = false }
+zeroize = { version = ">=1, <1.4", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -24,7 +24,7 @@ crypto-mac = "0.11"
 ctr = "0.8"
 dbl = "0.3"
 pmac = { version = "0.6", optional = true }
-zeroize = { version = "=1.3", default-features = false }
+zeroize = { version = ">=1, <1.4", default-features = false }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["encryption", "aead"]
 aead = { version = "0.4", default-features = false }
 cipher = { version = "0.3", default-features = false }
 ctr = { version = "0.8", default-features = false }
-subtle = { version = "=2.4", default-features = false }
+subtle = { version = ">=2, <2.5", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -22,7 +22,7 @@ aead = { version = "0.4", default-features = false }
 chacha20 = { version = "0.7", features = ["zeroize"], optional = true }
 cipher = "0.3"
 poly1305 = "0.7"
-zeroize = { version = "=1.3", default-features = false }
+zeroize = { version = ">=1, <1.4", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -18,9 +18,9 @@ edition = "2018"
 
 [dependencies]
 aead = { version = "0.4", default-features = false }
-subtle = { version = "=2.4", default-features = false }
-zeroize = { version = "=1.3", default-features = false }
-aes = { version = "0.7.5", features=["hazmat"], default-features = false}
+aes = { version = "0.7.5", features=["hazmat"], default-features = false }
+subtle = { version = ">=2, <2.5", default-features = false }
+zeroize = { version = ">=1, <1.4", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -23,7 +23,7 @@ aead = { version = "0.4", default-features = false }
 cipher = "0.3"
 cmac = "0.6"
 ctr = "0.8"
-subtle = { version = "=2.4", default-features = false }
+subtle = { version = ">=2, <2.5", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["encryption", "aead"]
 [dependencies]
 aead = { version = "0.4", default-features = false }
 cipher = "0.3"
-subtle = { version = "=2.4", default-features = false }
+subtle = { version = ">=2, <2.5", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -19,8 +19,8 @@ aead = { version = "0.4", default-features = false }
 salsa20 = { version = "0.8", features = ["xsalsa20", "zeroize"] }
 poly1305 = "0.7"
 rand_core = { version = "0.6", optional = true }
-subtle = { version = "=2.4", default-features = false }
-zeroize = { version = "=1.3", default-features = false }
+subtle = { version = ">=2, <2.5", default-features = false }
+zeroize = { version = ">=1, <1.4", default-features = false }
 
 [features]
 default = ["alloc", "rand_core", "aead/rand_core"]


### PR DESCRIPTION
The version was pinned to `subtle` 2.4.x and `zeroize` 1.3.x to prevent MSRV breakages, but these crates are comaptible with any version before that as well.

This commit loosens the restrictions to allow compatibility with earlier versions of these crates too. This permits a wider range of combinations.