### PR TITLE
aes-gcm v0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.4 (2021-08-28)
+### Changed
+- Relax `subtle` and `zeroize` requirements ([#360])
+
+[#360]: https://github.com/RustCrypto/AEADs/pull/360
+
 ## 0.9.3 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 and `subtle` to v2.4 ([#349])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.9.3"
+version = "0.9.4"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Changed
- Relax `subtle` and `zeroize` requirements ([#360])

[#360]: https://github.com/RustCrypto/AEADs/pull/360