### PR TITLE
aes-gcm-siv v0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2021-08-28)
+### Changed
+- Relax `subtle` and `zeroize` requirements ([#360])
+
+[#360]: https://github.com/RustCrypto/AEADs/pull/360
+
 ## 0.10.2 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 and `subtle` to v2.4 ([#349])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.10.2"
+version = "0.10.3"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific


### PR DESCRIPTION
### Changed
- Relax `subtle` and `zeroize` requirements ([#360])

[#360]: https://github.com/RustCrypto/AEADs/pull/360