### PR TITLE
chacha20poly1305: bump `chacha20` to v0.9; MSRV 1.51

### DIFF
--- a/.github/workflows/chacha20poly1305.yml
+++ b/.github/workflows/chacha20poly1305.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -36,7 +36,8 @@ jobs:
           target: ${{ matrix.target }}
           override: true
           profile: minimal
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features reduced-round
 
   test:
     runs-on: ubuntu-latest
@@ -45,7 +46,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -53,7 +54,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -65,23 +66,9 @@ jobs:
           override: true
           profile: minimal
       - run: ${{ matrix.deps }}
+      - run: cargo test --target ${{ matrix.target }} --release --no-default-features
       - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features reduced-round,stream,std,xchacha20poly1305
+      - run: cargo test --target ${{ matrix.target }} --release --features reduced-round,stream,std
+      - run: cargo test --target ${{ matrix.target }} --release --all-features
       - run: cargo build --target ${{ matrix.target }} --benches
 
-  # TODO(tarcieri): re-unify this with `test` when MSRV is 1.51+
-  heapless:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.51.0 # MSRV for `heapless`
-          - stable
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
+checksum = "f8c5d87765c99be3d2cb08d11a3c14820ecaf2c7ad45d301c533103d2d8a146c"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.2"
+version = "0.9.0-pre"
 dependencies = [
  "aead",
  "chacha20",

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.8.2 (2021-08-28)
+### Added
+- `XChaCha*` reduced-round variants ([#355])
+
 ### Changed
 - Relax `subtle` and `zeroize` requirements ([#360])
 
+[#355]: https://github.com/RustCrypto/AEADs/pull/355
 [#360]: https://github.com/RustCrypto/AEADs/pull/360
 
 ## 0.8.1 (2021-07-20)

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.8.2"
+version = "0.9.0-pre"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific
@@ -19,25 +19,21 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.4", default-features = false }
-chacha20 = { version = "0.7", features = ["zeroize"], optional = true }
+chacha20 = { version = "0.8", features = ["zeroize"] }
 cipher = "0.3"
 poly1305 = "0.7"
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = ">=1, <1.5", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }
 
 [features]
-default = ["alloc", "chacha20", "xchacha20"]
+default = ["alloc"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
-xchacha20 = ["chacha20/xchacha"]
-xchacha20poly1305 = ["xchacha20"] # alias
-reduced-round = ["chacha20-reduced-round", "xchacha20-reduced-round"]
-chacha20-reduced-round = ["chacha20"]
-xchacha20-reduced-round = ["xchacha20"]
+reduced-round = []
 force-soft = ["chacha20/force-soft", "poly1305/force-soft"]
 
 [package.metadata.docs.rs]

--- a/chacha20poly1305/README.md
+++ b/chacha20poly1305/README.md
@@ -67,7 +67,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/chacha20poly1305/badge.svg
 [docs-link]: https://docs.rs/chacha20poly1305/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
 [downloads-image]: https://img.shields.io/crates/d/chacha20poly1305.svg

--- a/chacha20poly1305/tests/lib.rs
+++ b/chacha20poly1305/tests/lib.rs
@@ -1,5 +1,7 @@
 //! ChaCha20Poly1305 and XChaCha20Poly1305 tests
 
+#![cfg(feature = "alloc")]
+
 use chacha20poly1305::ChaCha20Poly1305;
 use chacha20poly1305::XChaCha20Poly1305;
 
@@ -137,7 +139,6 @@ mod chacha20 {
 /// XChaCha20Poly1305 test vectors.
 ///
 /// From <https://tools.ietf.org/html/draft-arciszewski-xchacha-03#appendix-A.1>
-#[cfg(feature = "xchacha20poly1305")]
 mod xchacha20 {
     use super::{AAD, KEY, PLAINTEXT};
     use chacha20poly1305::aead::generic_array::GenericArray;


### PR DESCRIPTION
Bumps `chacha20` to the latest release, which has the following
additional changes:

- `chacha20` is now a hard dependency, now that the main use case for making it optional, using `c2-chacha` instead of `chacha20`, is irrelevant in that the performance difference has been eliminated.
- The `xchacha20` feature has been removed making the `XChaCha*` types always available.
- The `chacha20-reduced-round` and `xchacha20-reduced-round` features have been coalesced into a single `reduced-round` feature.