### PR TITLE
xsalsa20poly1305: bump `salsa20` dependency to v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
+checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
 dependencies = [
  "cipher",
  "zeroize",
@@ -421,7 +421,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.7.2"
+version = "0.8.0-pre"
 dependencies = [
  "aead",
  "poly1305",

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.7.2"
+version = "0.8.0-pre"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 aead = { version = "0.4", default-features = false }
-salsa20 = { version = "0.8", features = ["xsalsa20", "zeroize"] }
+salsa20 = { version = "0.9", features = ["zeroize"] }
 poly1305 = "0.7"
 rand_core = { version = "0.6", optional = true }
 subtle = { version = ">=2, <2.5", default-features = false }


### PR DESCRIPTION
This release removed the `xsalsa20` feature, and always includes it.