### PR TITLE
xsalsa20poly1305 v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "aead",
  "poly1305",

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2021-08-30)
+### Changed
+- Bump `salsa20` dependency to v0.9 ([#366])
+
+[#366]: https://github.com/RustCrypto/AEADs/pull/366
+
 ## 0.7.2 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 and `subtle` to v2.4 ([#349])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.8.0-pre"
+version = "0.8.0"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
### Changed
- Bump `salsa20` dependency to v0.9 ([#366])

[#366]: https://github.com/RustCrypto/AEADs/pull/366