### PR TITLE
chacha20poly1305 v0.10.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.0"
+version = "0.10.0-pre"
 dependencies = [
  "aead",
  "chacha20",

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.9.0"
+version = "0.10.0-pre"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific


### PR DESCRIPTION
This release includes an updated `chacha20` v0.9 dependency which removes the previous `zeroize` version pinning, and should unblock people who are having `zeroize` version compatibility issues