### PR TITLE
Remove `subtle` pinning

### DIFF
--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -21,7 +21,7 @@ aes = { version = "0.7.5", optional = true }
 cipher = "0.3"
 ctr = "0.8"
 polyval = { version = "0.5.1", default-features = false }
-subtle = { version = ">=2, <2.5", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -21,7 +21,7 @@ aes = { version = "0.7.5", optional = true }
 cipher = "0.3"
 ctr = "0.8"
 ghash = { version = "0.4.2", default-features = false }
-subtle = { version = ">=2, <2.5", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["encryption", "aead"]
 aead = { version = "0.4", default-features = false }
 cipher = { version = "0.3", default-features = false }
 ctr = { version = "0.8", default-features = false }
-subtle = { version = ">=2, <2.5", default-features = false }
+subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 [dependencies]
 aead = { version = "0.4", default-features = false }
 aes = { version = "0.7.5", features=["hazmat"], default-features = false }
-subtle = { version = ">=2, <2.5", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -23,7 +23,7 @@ aead = { version = "0.4", default-features = false }
 cipher = "0.3"
 cmac = "0.6"
 ctr = "0.8"
-subtle = { version = ">=2, <2.5", default-features = false }
+subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.4", features = ["dev"], default-features = false }

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["encryption", "aead"]
 [dependencies]
 aead = { version = "0.4", default-features = false }
 cipher = "0.3"
-subtle = { version = ">=2, <2.5", default-features = false }
+subtle = { version = "2", default-features = false }
 cfg-if = "1"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -19,7 +19,7 @@ aead = { version = "0.4", default-features = false }
 salsa20 = { version = "0.10", features = ["zeroize"] }
 poly1305 = "0.7"
 rand_core = { version = "0.6", optional = true }
-subtle = { version = ">=2, <2.5", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [features]


### PR DESCRIPTION
Version pinning to preserve MSRV has proven to be problematic, in that it prevents compatible combinations of crates from working due to artificial restrictions intended to preserve out-of-the-box nameplate MSRV on particular crates.

Since we're bumping MSRV in these crates anyway as part of the `cipher` upgrade, this commit removes these restrictions, which should allow more compatible combinations of crates to work.