### PR TITLE
chacha20poly1305: Migrate to `universal-hash 0.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.10.0-pre"
 dependencies = [
  "aead",
  "aes 0.8.1",
@@ -130,7 +130,7 @@ dependencies = [
  "aead",
  "chacha20",
  "cipher 0.4.3",
- "poly1305",
+ "poly1305 0.7.2 (git+https://github.com/str4d/universal-hashes?rev=88eca39b494585b34d4021cefd588a9d59279357)",
  "zeroize",
 ]
 
@@ -149,7 +149,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.3",
  "inout",
  "zeroize",
 ]
@@ -178,6 +178,15 @@ name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.4"
+source = "git+https://github.com/RustCrypto/traits?rev=74ce6e7a9ab1243f574b6c37e747a6e54c01f376#74ce6e7a9ab1243f574b6c37e747a6e54c01f376"
 dependencies = [
  "generic-array",
  "typenum",
@@ -401,7 +410,17 @@ checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.7.2"
+source = "git+https://github.com/str4d/universal-hashes?rev=88eca39b494585b34d4021cefd588a9d59279357#88eca39b494585b34d4021cefd588a9d59279357"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.0",
 ]
 
 [[package]]
@@ -413,7 +432,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.1",
 ]
 
 [[package]]
@@ -484,6 +503,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "git+https://github.com/RustCrypto/traits?rev=74ce6e7a9ab1243f574b6c37e747a6e54c01f376#74ce6e7a9ab1243f574b6c37e747a6e54c01f376"
+dependencies = [
+ "crypto-common 0.1.4",
+ "subtle",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,7 +528,7 @@ name = "xsalsa20poly1305"
 version = "0.8.0"
 dependencies = [
  "aead",
- "poly1305",
+ "poly1305 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core",
  "salsa20",
  "subtle",

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["cryptography", "no-std"]
 aead = { version = "0.4", default-features = false }
 chacha20 = { version = "0.9", features = ["zeroize"] }
 cipher = "0.4"
-poly1305 = "0.7"
+poly1305 = { git = "https://github.com/str4d/universal-hashes", rev = "88eca39b494585b34d4021cefd588a9d59279357" }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -5,7 +5,7 @@ use aead::generic_array::GenericArray;
 use aead::Error;
 use core::convert::TryInto;
 use poly1305::{
-    universal_hash::{NewUniversalHash, UniversalHash},
+    universal_hash::{KeyInit, UniversalHash},
     Poly1305,
 };
 use zeroize::Zeroize;
@@ -64,7 +64,7 @@ where
         self.mac.update_padded(buffer);
 
         self.authenticate_lengths(associated_data, buffer)?;
-        Ok(self.mac.finalize().into_bytes())
+        Ok(self.mac.finalize())
     }
 
     /// Decrypt the given message, first authenticating ciphertext integrity
@@ -102,7 +102,7 @@ where
         let mut block = GenericArray::default();
         block[..8].copy_from_slice(&associated_data_len.to_le_bytes());
         block[8..].copy_from_slice(&buffer_len.to_le_bytes());
-        self.mac.update(&block);
+        self.mac.update(&[block]);
 
         Ok(())
     }


### PR DESCRIPTION
Depends on https://github.com/RustCrypto/traits/pull/965 and https://github.com/RustCrypto/universal-hashes/pull/153.