### PR TITLE
Bump `aead` to v0.5 prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,14 +5,14 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "ebd885afa9fa966b7715dc1c46bf47330b9156eec79a09d2003c5af03d153ba0"
 dependencies = [
  "blobby",
+ "crypto-common",
  "generic-array",
  "heapless",
- "rand_core",
 ]
 
 [[package]]
@@ -270,11 +270,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -318,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "deoxys"
-version = "0.0.2"
+version = "0.1.0-pre"
 dependencies = [
  "aead",
  "aes 0.7.5",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "0.4", default-features = false }
+aead = { version = "=0.5.0-pre.2", default-features = false }
 aes = { version = "0.8", optional = true }
 cipher = "0.4"
 ctr = "0.9"
@@ -26,7 +26,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.4", features = ["dev"], default-features = false }
+aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
 
 [features]
 default    = ["aes", "alloc"]
@@ -34,6 +34,7 @@ std        = ["aead/std", "alloc"]
 alloc      = ["aead/alloc"]
 armv8      = ["polyval/armv8"] # nightly-only
 force-soft = ["polyval/force-soft"]
+getrandom  = ["aead/getrandom"]
 heapless   = ["aead/heapless"]
 stream     = ["aead/stream"]
 

--- a/aes-gcm-siv/tests/aes128gcmsiv.rs
+++ b/aes-gcm-siv/tests/aes128gcmsiv.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use self::common::TestVector;
-use aes_gcm_siv::aead::{generic_array::GenericArray, Aead, NewAead, Payload};
+use aes_gcm_siv::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
 use aes_gcm_siv::Aes128GcmSiv;
 
 /// Test vectors from RFC8452 Appendix C.1: AEAD_AES_128_GCM_SIV

--- a/aes-gcm-siv/tests/aes256gcmsiv.rs
+++ b/aes-gcm-siv/tests/aes256gcmsiv.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use self::common::TestVector;
-use aes_gcm_siv::aead::{generic_array::GenericArray, Aead, NewAead, Payload};
+use aes_gcm_siv::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
 use aes_gcm_siv::Aes256GcmSiv;
 
 /// Test vectors from RFC8452 Appendix C.2. AEAD_AES_256_GCM_SIV

--- a/aes-gcm-siv/tests/ctr_wrap.rs
+++ b/aes-gcm-siv/tests/ctr_wrap.rs
@@ -7,7 +7,7 @@
 mod common;
 
 use self::common::TestVector;
-use aes_gcm_siv::aead::{generic_array::GenericArray, Aead, NewAead, Payload};
+use aes_gcm_siv::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
 use aes_gcm_siv::Aes256GcmSiv;
 
 /// Test vectors from RFC8452 Appendix C.3. Counter Wrap Tests

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "0.4", default-features = false }
+aead = { version = "=0.5.0-pre.2", default-features = false }
 aes = { version = "0.8", optional = true }
 cipher = "0.4"
 ctr = "0.9"
@@ -26,7 +26,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.4", features = ["dev"], default-features = false }
+aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
 hex-literal = "0.3"
 
 [features]
@@ -35,6 +35,7 @@ std        = ["aead/std", "alloc"]
 alloc      = ["aead/alloc"]
 armv8      = ["ghash/armv8"] # nightly-only
 force-soft = ["ghash/force-soft"]
+getrandom  = ["aead/getrandom"]
 heapless   = ["aead/heapless"]
 stream     = ["aead/stream"]
 

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! ```
 //! use aes_gcm::{Aes256Gcm, Key, Nonce}; // Or `Aes128Gcm`
-//! use aes_gcm::aead::{Aead, NewAead};
+//! use aes_gcm::aead::{Aead, KeyInit};
 //!
 //! let key = Key::<Aes256Gcm>::from_slice(b"an example very very secret key.");
 //! let cipher = Aes256Gcm::new(key);
@@ -67,7 +67,7 @@
 #![cfg_attr(feature = "heapless", doc = " ```")]
 #![cfg_attr(not(feature = "heapless"), doc = " ```ignore")]
 //! use aes_gcm::{Aes256Gcm, Key, Nonce}; // Or `Aes128Gcm`
-//! use aes_gcm::aead::{AeadInPlace, NewAead};
+//! use aes_gcm::aead::{AeadInPlace, KeyInit};
 //! use aes_gcm::aead::heapless::Vec;
 //!
 //! let key = Key::<Aes256Gcm>::from_slice(b"an example very very secret key.");
@@ -103,8 +103,7 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use aead::{self, AeadCore, AeadInPlace, Error, NewAead};
-pub use cipher::Key;
+pub use aead::{self, AeadCore, AeadInPlace, Error, Key, KeyInit, KeySizeUser};
 
 #[cfg(feature = "aes")]
 pub use aes;
@@ -112,7 +111,7 @@ pub use aes;
 use cipher::{
     consts::{U0, U16},
     generic_array::{ArrayLength, GenericArray},
-    BlockCipher, BlockEncrypt, BlockSizeUser, InnerIvInit, KeyInit, KeySizeUser, StreamCipherCore,
+    BlockCipher, BlockEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore,
 };
 use core::marker::PhantomData;
 use ghash::{
@@ -184,17 +183,15 @@ pub struct AesGcm<Aes, NonceSize> {
 
 impl<Aes, NonceSize> KeySizeUser for AesGcm<Aes, NonceSize>
 where
-    Aes: KeyInit,
+    Aes: KeySizeUser,
 {
     type KeySize = Aes::KeySize;
 }
 
-impl<Aes, NonceSize> NewAead for AesGcm<Aes, NonceSize>
+impl<Aes, NonceSize> KeyInit for AesGcm<Aes, NonceSize>
 where
     Aes: BlockSizeUser<BlockSize = U16> + BlockEncrypt + KeyInit,
 {
-    type KeySize = Aes::KeySize;
-
     fn new(key: &Key<Self>) -> Self {
         Aes::new(key).into()
     }

--- a/aes-gcm/tests/aes128gcm.rs
+++ b/aes-gcm/tests/aes128gcm.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use self::common::TestVector;
-use aes_gcm::aead::{generic_array::GenericArray, Aead, NewAead, Payload};
+use aes_gcm::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
 use aes_gcm::Aes128Gcm;
 use hex_literal::hex;
 

--- a/aes-gcm/tests/aes256gcm.rs
+++ b/aes-gcm/tests/aes256gcm.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use self::common::TestVector;
-use aes_gcm::aead::{generic_array::GenericArray, Aead, NewAead, Payload};
+use aes_gcm::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
 use aes_gcm::Aes256Gcm;
 use hex_literal::hex;
 

--- a/aes-gcm/tests/other_ivlen.rs
+++ b/aes-gcm/tests/other_ivlen.rs
@@ -5,7 +5,7 @@
 
 use aead::{
     generic_array::{typenum, GenericArray},
-    Aead, NewAead,
+    Aead, KeyInit,
 };
 use aes::Aes128;
 use aes_gcm::AesGcm;

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = "0.4"
+aead = "=0.5.0-pre.2"
 aes = "0.8"
 cipher = "0.4"
 cmac = "0.7"
@@ -37,6 +37,7 @@ hex-literal = "0.3"
 default = ["alloc"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+getrandom  = ["aead/getrandom"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
 

--- a/aes-siv/tests/aead.rs
+++ b/aes-siv/tests/aead.rs
@@ -105,7 +105,7 @@ macro_rules! tests {
 
 mod aes128cmacsivaead {
     use super::TestVector;
-    use aes_siv::aead::{generic_array::GenericArray, Aead, AeadInPlace, NewAead, Payload};
+    use aes_siv::aead::{generic_array::GenericArray, Aead, AeadInPlace, KeyInit, Payload};
     use aes_siv::Aes128SivAead;
 
     /// AES-128-CMAC-SIV test vectors
@@ -125,7 +125,7 @@ mod aes128cmacsivaead {
 #[cfg(feature = "pmac")]
 mod aes128pmacsivaead {
     use super::TestVector;
-    use aes_siv::aead::{generic_array::GenericArray, Aead, AeadInPlace, NewAead, Payload};
+    use aes_siv::aead::{generic_array::GenericArray, Aead, AeadInPlace, KeyInit, Payload};
     use aes_siv::Aes128PmacSivAead;
 
     /// AES-128-PMAC-SIV test vectors

--- a/aes-siv/tests/siv.rs
+++ b/aes-siv/tests/siv.rs
@@ -1,8 +1,5 @@
 //! AES-SIV tests for the raw SIV interface
 
-#[macro_use]
-extern crate hex_literal;
-
 use aes_siv::aead::generic_array::GenericArray;
 
 /// Test vectors
@@ -19,7 +16,7 @@ macro_rules! tests {
         #[test]
         fn encrypt() {
             for vector in $vectors {
-                let mut cipher = <$siv>::new(GenericArray::clone_from_slice(vector.key));
+                let mut cipher = <$siv>::new(GenericArray::from_slice(vector.key));
                 let ciphertext = cipher.encrypt(vector.aad, vector.plaintext).unwrap();
                 assert_eq!(vector.ciphertext, ciphertext.as_slice());
             }
@@ -28,7 +25,7 @@ macro_rules! tests {
         #[test]
         fn decrypt() {
             for vector in $vectors {
-                let mut cipher = <$siv>::new(GenericArray::clone_from_slice(vector.key));
+                let mut cipher = <$siv>::new(GenericArray::from_slice(vector.key));
                 let plaintext = cipher.decrypt(vector.aad, vector.ciphertext).unwrap();
                 assert_eq!(vector.plaintext, plaintext.as_slice());
             }
@@ -42,7 +39,7 @@ macro_rules! tests {
             // Tweak the first byte
             ciphertext[0] ^= 0xaa;
 
-            let mut cipher = <$siv>::new(GenericArray::clone_from_slice(vector.key));
+            let mut cipher = <$siv>::new(GenericArray::from_slice(vector.key));
             assert!(cipher.decrypt(vector.aad, &ciphertext).is_err());
 
             // TODO(tarcieri): test ciphertext is unmodified in in-place API
@@ -64,7 +61,7 @@ macro_rules! wycheproof_tests {
                 ct: &[u8],
                 pass: bool,
             ) -> Option<&'static str> {
-                let mut cipher = <$siv>::new(GenericArray::clone_from_slice(key));
+                let mut cipher = <$siv>::new(GenericArray::from_slice(key));
                 let ciphertext = cipher.encrypt(&[aad], pt).unwrap();
                 if pass && ct != ciphertext.as_slice() {
                     return Some("encryption mismatch");
@@ -113,7 +110,8 @@ macro_rules! wycheproof_tests {
 
 mod aes128cmacsiv {
     use super::{GenericArray, TestVector};
-    use aes_siv::siv::Aes128Siv;
+    use aes_siv::{siv::Aes128Siv, KeyInit};
+    use hex_literal::hex;
 
     /// AES-128-CMAC-SIV test vectors
     const TEST_VECTORS: &[TestVector<[u8; 32]>] = &[
@@ -154,7 +152,8 @@ mod aes128cmacsiv {
 
 mod aes256cmacsiv {
     use super::{GenericArray, TestVector};
-    use aes_siv::siv::Aes256Siv;
+    use aes_siv::{siv::Aes256Siv, KeyInit};
+    use hex_literal::hex;
 
     /// AES-256-CMAC-SIV test vectors
     const TEST_VECTORS: &[TestVector<[u8; 64]>] = &[
@@ -184,7 +183,8 @@ mod aes256cmacsiv {
 #[cfg(feature = "pmac")]
 mod aes128pmaccsiv {
     use super::{GenericArray, TestVector};
-    use aes_siv::siv::Aes128PmacSiv;
+    use aes_siv::{siv::Aes128PmacSiv, KeyInit};
+    use hex_literal::hex;
 
     /// AES-128-PMAC-SIV test vectors
     const TEST_VECTORS: &[TestVector<[u8; 32]>] = &[
@@ -224,7 +224,8 @@ mod aes128pmaccsiv {
 #[cfg(feature = "pmac")]
 mod aes256pmaccsiv {
     use super::{GenericArray, TestVector};
-    use aes_siv::siv::Aes256PmacSiv;
+    use aes_siv::{siv::Aes256PmacSiv, KeyInit};
+    use hex_literal::hex;
 
     /// AES-256-PMAC-SIV test vectors
     const TEST_VECTORS: &[TestVector<[u8; 64]>] = &[

--- a/benches/src/aes-gcm-siv.rs
+++ b/benches/src/aes-gcm-siv.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use aes_gcm_siv::aead::{Aead, NewAead};
+use aes_gcm_siv::aead::{Aead, KeyInit};
 use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 
 const KB: usize = 1024;

--- a/benches/src/aes-gcm.rs
+++ b/benches/src/aes-gcm.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use aes_gcm::aead::{Aead, NewAead};
+use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes128Gcm, Aes256Gcm};
 
 const KB: usize = 1024;

--- a/benches/src/chacha20poly1305.rs
+++ b/benches/src/chacha20poly1305.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use chacha20poly1305::aead::{Aead, NewAead};
+use chacha20poly1305::aead::{Aead, KeyInit};
 use chacha20poly1305::ChaCha20Poly1305;
 
 const KB: usize = 1024;

--- a/benches/src/deoxys.rs
+++ b/benches/src/deoxys.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use deoxys::aead::{Aead, NewAead};
+use deoxys::aead::{Aead, KeyInit};
 use deoxys::{DeoxysI128, DeoxysI256, DeoxysII128, DeoxysII256};
 
 const KB: usize = 1024;

--- a/benches/src/eax.rs
+++ b/benches/src/eax.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use eax::aead::{Aead, NewAead};
+use eax::aead::{Aead, KeyInit};
 
 type EaxAes128 = eax::Eax<aes::Aes128>;
 type EaxAes256 = eax::Eax<aes::Aes256>;

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["encryption", "aead"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "0.4", default-features = false }
+aead = { version = "=0.5.0-pre.2", default-features = false }
 cipher = { version = "0.4.3", default-features = false }
 ctr = { version = "0.9.1", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.4", features = ["dev"], default-features = false }
+aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
 aes = { version = "0.8.1" }
 hex-literal = "0.3.4"
 
@@ -28,5 +28,6 @@ hex-literal = "0.3.4"
 default = ["alloc"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+getrandom  = ["aead/getrandom"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```
 //! use ccm::{Ccm, consts::{U10, U13}};
-//! use ccm::aead::{Aead, NewAead, generic_array::GenericArray};
+//! use ccm::aead::{Aead, KeyInit, generic_array::GenericArray};
 //! use aes::Aes256;
 //!
 //! // AES-CCM type with tag and nonce size equal to 10 and 13 bytes respectively
@@ -43,17 +43,14 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use aead;
-pub use aead::consts;
+pub use aead::{self, consts, AeadCore, AeadInPlace, Error, Key, KeyInit, KeySizeUser};
 
 use aead::{
     consts::{U0, U16},
     generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
-    AeadCore, AeadInPlace, Error, Key, NewAead,
 };
 use cipher::{
-    Block, BlockCipher, BlockEncrypt, BlockSizeUser, InnerIvInit, KeyInit, StreamCipher,
-    StreamCipherSeek,
+    Block, BlockCipher, BlockEncrypt, BlockSizeUser, InnerIvInit, StreamCipher, StreamCipherSeek,
 };
 use core::marker::PhantomData;
 use ctr::{Ctr32BE, Ctr64BE, CtrCore};
@@ -186,14 +183,21 @@ where
     }
 }
 
-impl<C, M, N> NewAead for Ccm<C, M, N>
+impl<C, M, N> KeySizeUser for Ccm<C, M, N>
 where
     C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockEncrypt + KeyInit,
     M: ArrayLength<u8> + TagSize,
     N: ArrayLength<u8> + NonceSize,
 {
     type KeySize = C::KeySize;
+}
 
+impl<C, M, N> KeyInit for Ccm<C, M, N>
+where
+    C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockEncrypt + KeyInit,
+    M: ArrayLength<u8> + TagSize,
+    N: ArrayLength<u8> + NonceSize,
+{
     fn new(key: &Key<Self>) -> Self {
         Self::from(C::new(key))
     }

--- a/ccm/tests/mod.rs
+++ b/ccm/tests/mod.rs
@@ -1,4 +1,4 @@
-use aead::{generic_array::GenericArray, Aead, AeadInPlace, NewAead, Payload};
+use aead::{generic_array::GenericArray, Aead, AeadInPlace, KeyInit, Payload};
 use aes::{Aes128, Aes192, Aes256};
 use ccm::{
     consts::{U10, U11, U12, U13, U14, U16, U4, U6, U7, U8, U9},

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -18,19 +18,20 @@ keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "0.4", default-features = false }
+aead = { version = "=0.5.0-pre.2", default-features = false }
 chacha20 = { version = "0.9", features = ["zeroize"] }
 cipher = "0.4"
 poly1305 = "0.7"
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.4", features = ["dev"], default-features = false }
+aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
 
 [features]
 default = ["alloc"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+getrandom  = ["aead/getrandom"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
 reduced-round = []

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -36,6 +36,7 @@ where
         // Derive Poly1305 key from the first 32-bytes of the ChaCha20 keystream
         let mut mac_key = poly1305::Key::default();
         cipher.apply_keystream(&mut *mac_key);
+
         let mac = Poly1305::new(GenericArray::from_slice(&*mac_key));
         mac_key.zeroize();
 

--- a/chacha20poly1305/tests/lib.rs
+++ b/chacha20poly1305/tests/lib.rs
@@ -97,7 +97,7 @@ const PLAINTEXT: &[u8] = b"Ladies and Gentlemen of the class of '99: \
 mod chacha20 {
     use super::{AAD, KEY, PLAINTEXT};
     use chacha20poly1305::aead::generic_array::GenericArray;
-    use chacha20poly1305::aead::{Aead, NewAead, Payload};
+    use chacha20poly1305::aead::{Aead, KeyInit, Payload};
     use chacha20poly1305::ChaCha20Poly1305;
 
     const NONCE: &[u8; 12] = &[
@@ -142,7 +142,7 @@ mod chacha20 {
 mod xchacha20 {
     use super::{AAD, KEY, PLAINTEXT};
     use chacha20poly1305::aead::generic_array::GenericArray;
-    use chacha20poly1305::aead::{Aead, NewAead, Payload};
+    use chacha20poly1305::aead::{Aead, KeyInit, Payload};
     use chacha20poly1305::XChaCha20Poly1305;
 
     const NONCE: &[u8; 24] = &[

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deoxys"
-version = "0.0.2"
+version = "0.1.0-pre"
 description = """
 Pure Rust implementation of the Deoxys Authenticated Encryption with Associated
 Data (AEAD) cipher, including the Deoxys-II variant which was selected by the
@@ -18,19 +18,20 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "0.4", default-features = false }
+aead = { version = "=0.5.0-pre.2", default-features = false }
 aes = { version = "0.7.5", features=["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.4", features = ["dev"], default-features = false }
+aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
 hex-literal = "0.3"
 
 [features]
 default = ["alloc"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+getrandom  = ["aead/getrandom"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
 

--- a/deoxys/tests/deoxys_i_128.rs
+++ b/deoxys/tests/deoxys_i_128.rs
@@ -1,6 +1,6 @@
 // Uses the official test vectors.
 use deoxys::aead::generic_array::GenericArray;
-use deoxys::aead::{Aead, NewAead, Payload};
+use deoxys::aead::{Aead, KeyInit, Payload};
 use deoxys::DeoxysI128;
 
 use hex_literal::hex;

--- a/deoxys/tests/deoxys_i_256.rs
+++ b/deoxys/tests/deoxys_i_256.rs
@@ -1,6 +1,6 @@
 // Uses the official test vectors.
 use deoxys::aead::generic_array::GenericArray;
-use deoxys::aead::{Aead, NewAead, Payload};
+use deoxys::aead::{Aead, KeyInit, Payload};
 use deoxys::DeoxysI256;
 
 use hex_literal::hex;

--- a/deoxys/tests/deoxys_ii_128.rs
+++ b/deoxys/tests/deoxys_ii_128.rs
@@ -1,6 +1,6 @@
 // Uses the official test vectors.
 use deoxys::aead::generic_array::GenericArray;
-use deoxys::aead::{Aead, NewAead, Payload};
+use deoxys::aead::{Aead, KeyInit, Payload};
 use deoxys::DeoxysII128;
 
 use hex_literal::hex;

--- a/deoxys/tests/deoxys_ii_256.rs
+++ b/deoxys/tests/deoxys_ii_256.rs
@@ -1,6 +1,6 @@
 // Uses the official test vectors.
 use deoxys::aead::generic_array::GenericArray;
-use deoxys::aead::{Aead, NewAead, Payload};
+use deoxys::aead::{Aead, KeyInit, Payload};
 use deoxys::DeoxysII256;
 
 use hex_literal::hex;

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -20,20 +20,21 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "0.4", default-features = false }
+aead = { version = "=0.5.0-pre.2", default-features = false }
 cipher = "0.3"
 cmac = "0.6"
 ctr = "0.8"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.4", features = ["dev"], default-features = false }
-aes = { version = "0.7", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
+aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
+aes = "0.7"
 
 [features]
 default = ["alloc"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+getrandom  = ["aead/getrandom"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
 

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```
 //! use aes::Aes256;
 //! use eax::Eax;
-//! use eax::aead::{Aead, NewAead, generic_array::GenericArray};
+//! use eax::aead::{Aead, KeyInit, generic_array::GenericArray};
 //!
 //! let key = GenericArray::from_slice(b"an example very very secret key.");
 //! let cipher = Eax::<Aes256>::new(key);
@@ -44,7 +44,7 @@
 //! # {
 //! use aes::Aes256;
 //! use eax::Eax;
-//! use eax::aead::{AeadInPlace, NewAead, generic_array::GenericArray};
+//! use eax::aead::{AeadInPlace, KeyInit, generic_array::GenericArray};
 //! use eax::aead::heapless::Vec;
 //!
 //! let key = GenericArray::from_slice(b"an example very very secret key.");
@@ -77,7 +77,7 @@
 //! # {
 //! use aes::Aes256;
 //! use eax::Eax;
-//! use eax::aead::{AeadInPlace, NewAead, generic_array::GenericArray};
+//! use eax::aead::{AeadInPlace, KeyInit, generic_array::GenericArray};
 //! use eax::aead::heapless::Vec;
 //! use eax::aead::consts::{U8, U128};
 //!
@@ -115,7 +115,7 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use aead::{self, AeadCore, AeadInPlace, Error, NewAead};
+pub use aead::{self, AeadCore, AeadInPlace, Error, KeyInit, KeySizeUser};
 pub use cipher;
 
 use cipher::{
@@ -171,18 +171,25 @@ where
     _tag_size: PhantomData<M>,
 }
 
-impl<Cipher, M> NewAead for Eax<Cipher, M>
+impl<Cipher, M> KeySizeUser for Eax<Cipher, M>
 where
     Cipher: BlockCipher<BlockSize = U16> + BlockEncrypt + NewBlockCipher + Clone,
     Cipher::ParBlocks: ArrayLength<Block<Cipher>>,
     M: TagSize,
 {
     type KeySize = Cipher::KeySize;
+}
 
+impl<Cipher, M> KeyInit for Eax<Cipher, M>
+where
+    Cipher: BlockCipher<BlockSize = U16> + BlockEncrypt + NewBlockCipher + Clone,
+    Cipher::ParBlocks: ArrayLength<Block<Cipher>>,
+    M: TagSize,
+{
     fn new(key: &BlockCipherKey<Cipher>) -> Self {
         Self {
             key: key.clone(),
-            _tag_size: Default::default(),
+            _tag_size: PhantomData,
         }
     }
 }

--- a/eax/tests/aes128eax.rs
+++ b/eax/tests/aes128eax.rs
@@ -1,5 +1,6 @@
 //! Test vectors from Appendix G:
 //! https://web.cs.ucdavis.edu/~rogaway/papers/eax.pdf
+
 use aes::Aes128;
 use eax::Eax;
 

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["encryption", "aead"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "0.4", default-features = false }
+aead = { version = "=0.5.0-pre.2", default-features = false }
 cipher = "0.3"
 subtle = { version = "2", default-features = false }
 cfg-if = "1"
@@ -23,7 +23,7 @@ cfg-if = "1"
 cpufeatures = "0.2"
 
 [dev-dependencies]
-aead = { version = "0.4", features = ["dev"], default-features = false }
+aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
 kuznyechik = "0.7"
 magma = "0.7"
 hex-literal = "0.2"
@@ -32,6 +32,7 @@ hex-literal = "0.2"
 default = ["alloc"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+getrandom  = ["aead/getrandom"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
 force-soft = [] # Disable support for hardware intrinsics

--- a/mgm/benches/mod.rs
+++ b/mgm/benches/mod.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use aead::{generic_array::GenericArray, AeadInPlace, NewAead};
+use aead::{generic_array::GenericArray, AeadInPlace, KeyInit};
 use hex_literal::hex;
 use kuznyechik::Kuznyechik;
 use mgm::Mgm;

--- a/mgm/src/lib.rs
+++ b/mgm/src/lib.rs
@@ -6,7 +6,7 @@
 //! # {
 //! use mgm::Mgm;
 //! use kuznyechik::Kuznyechik;
-//! use mgm::aead::{Aead, NewAead, generic_array::GenericArray};
+//! use mgm::aead::{Aead, KeyInit, generic_array::GenericArray};
 //!
 //! let key = GenericArray::from_slice(b"very secret key very secret key ");
 //! let cipher = Mgm::<Kuznyechik>::new(key);
@@ -27,13 +27,18 @@
 //!
 //! [1]: https://eprint.iacr.org/2019/123.pdf
 //! [AEAD]: https://en.wikipedia.org/wiki/Authenticated_encryption
+
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
-use aead::{consts::U0, generic_array::GenericArray, AeadCore, AeadInPlace, Error, Key, NewAead};
+
+use aead::{
+    consts::U0, generic_array::GenericArray, AeadCore, AeadInPlace, Error, Key, KeyInit,
+    KeySizeUser,
+};
 use cfg_if::cfg_if;
 use cipher::{BlockCipher, BlockEncrypt, NewBlockCipher};
 
@@ -86,13 +91,19 @@ where
     }
 }
 
-impl<C> NewAead for Mgm<C>
+impl<C> KeySizeUser for Mgm<C>
 where
     C: BlockEncrypt + NewBlockCipher,
     C::BlockSize: MgmBlockSize,
 {
     type KeySize = C::KeySize;
+}
 
+impl<C> KeyInit for Mgm<C>
+where
+    C: BlockEncrypt + NewBlockCipher,
+    C::BlockSize: MgmBlockSize,
+{
     fn new(key: &Key<Self>) -> Self {
         Self::from(C::new(key))
     }

--- a/mgm/tests/bad_nonce.rs
+++ b/mgm/tests/bad_nonce.rs
@@ -1,5 +1,5 @@
 //! Tests for nonce validity checks
-use aead::{generic_array::GenericArray, Aead, NewAead};
+use aead::{generic_array::GenericArray, Aead, KeyInit};
 use mgm::Mgm;
 
 #[test]

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "0.4", default-features = false }
+aead = { version = "=0.5.0-pre.2", default-features = false }
 salsa20 = { version = "0.10", features = ["zeroize"] }
 poly1305 = "0.7"
 rand_core = { version = "0.6", optional = true }
@@ -27,6 +27,7 @@ zeroize = { version = "1", default-features = false }
 default = ["alloc", "rand_core", "aead/rand_core"]
 std = ["aead/std", "alloc", "rand_core/std"]
 alloc = ["aead/alloc"]
+getrandom  = ["aead/getrandom"]
 heapless = ["aead/heapless"]
 stream = ["aead/stream"]
 

--- a/xsalsa20poly1305/tests/lib.rs
+++ b/xsalsa20poly1305/tests/lib.rs
@@ -3,7 +3,7 @@
 //! Adapted from NaCl's `tests/secretbox.c` and `tests/secretbox.out`
 
 use xsalsa20poly1305::aead::generic_array::GenericArray;
-use xsalsa20poly1305::aead::{Aead, NewAead};
+use xsalsa20poly1305::aead::{Aead, KeyInit};
 use xsalsa20poly1305::XSalsa20Poly1305;
 
 const KEY: &[u8; 32] = &[


### PR DESCRIPTION
This (pre)release migrates to using `crypto-common` traits in place of the former `NewAead` trait, namely `KeySizeUser` and `KeyInit`.

See: https://github.com/RustCrypto/traits/pull/1033