### PR TITLE
Prereleases with `aead` v0.5 prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.0-pre"
+version = "0.10.0-pre.1"
 dependencies = [
  "aead",
  "aes 0.8.1",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.11.0-pre"
+version = "0.11.0-pre.1"
 dependencies = [
  "aead",
  "aes 0.8.1",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.7.0-pre"
+version = "0.7.0-pre.1"
 dependencies = [
  "aead",
  "aes 0.8.1",
@@ -156,7 +156,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "ccm"
-version = "0.5.0-pre"
+version = "0.5.0-pre.1"
 dependencies = [
  "aead",
  "aes 0.8.1",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.0-pre"
+version = "0.10.0-pre.1"
 dependencies = [
  "aead",
  "chacha20",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "deoxys"
-version = "0.1.0-pre"
+version = "0.1.0-pre.1"
 dependencies = [
  "aead",
  "aes 0.7.5",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.5.0-pre"
+version = "0.5.0-pre.1"
 dependencies = [
  "aead",
  "aes 0.7.5",
@@ -497,7 +497,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mgm"
-version = "0.5.0-pre"
+version = "0.5.0-pre.1"
 dependencies = [
  "aead",
  "cfg-if",
@@ -743,7 +743,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.9.0-pre"
+version = "0.9.0-pre.1"
 dependencies = [
  "aead",
  "poly1305",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.11.0-pre"
+version = "0.11.0-pre.1"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.10.0-pre"
+version = "0.10.0-pre.1"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.7.0-pre"
+version = "0.7.0-pre.1"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.5.0-pre"
+version = "0.5.0-pre.1"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2021"

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.10.0-pre"
+version = "0.10.0-pre.1"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deoxys"
-version = "0.1.0-pre"
+version = "0.1.0-pre.1"
 description = """
 Pure Rust implementation of the Deoxys Authenticated Encryption with Associated
 Data (AEAD) cipher, including the Deoxys-II variant which was selected by the

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.5.0-pre"
+version = "0.5.0-pre.1"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mgm"
-version = "0.5.0-pre"
+version = "0.5.0-pre.1"
 description = "Generic implementation of the Multilinear Galois Mode (MGM) cipher"
 authors = ["RustCrypto Developers"]
 edition = "2021"

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.9.0-pre"
+version = "0.9.0-pre.1"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
Cuts prereleases of all crates with an updated `aead` dependency