### PR TITLE
chacha20poly1305: add v0.9.1 release notes

### DIFF
--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1 (2022-07-07)
+### Changed
+- Unpin `zeroize` dependency ([#438])
+
+[#438]: https://github.com/RustCrypto/AEADs/pull/438
+
 ## 0.9.0 (2021-08-29)
 ### Changed
 - Bump `chacha20` to v0.9: now a hard dependency ([#365])


### PR DESCRIPTION
Adds release notes for a v0.9.1 release of `chacha20poly1305` (done on a separate branch since `master` is curently v0.10.0-pre.1)

This release unpins `zeroize`, allowing any version to be used. It was pinned to prevent MSRV breakages, however this has proven to be quite problematic and prevents compatible versions of crates from being used.