### PR TITLE
Bump UHF crates to `universal-hash` v0.5.0-pre.1 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
  "aead",
  "chacha20",
  "cipher 0.4.3",
- "poly1305",
+ "poly1305 0.8.0-pre.1",
  "zeroize",
 ]
 
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.4"
+version = "0.5.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+checksum = "882de19ccb8adbd3e2b6d208c8e06246a61e7f02cea9fe15591e72c6bf1968f5"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -549,19 +549,30 @@ checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387528277972ee66b5957001b0665b4f8bc36c175a409808ae7b4eed3c61ad75"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.0-pre.1",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "d3095aefad57389bc4c9535342296879488848c6526d4da2bdf9709459f98e30"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.0-pre.1",
 ]
 
 [[package]]
@@ -709,6 +720,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.5.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddf84cbf3ff76dc1546cd2d7fb8e98f3fecb4de9a4ef68243bc76c14244f557"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,7 +767,7 @@ name = "xsalsa20poly1305"
 version = "0.9.0-pre.1"
 dependencies = [
  "aead",
- "poly1305",
+ "poly1305 0.7.2",
  "rand_core",
  "salsa20",
  "subtle",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -21,7 +21,7 @@ aead = { version = "=0.5.0-pre.2", default-features = false }
 aes = { version = "0.8", optional = true }
 cipher = "0.4"
 ctr = "0.9"
-polyval = { version = "0.5.1", default-features = false }
+polyval = { version = "=0.6.0-pre.1", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -21,7 +21,7 @@ aead = { version = "=0.5.0-pre.2", default-features = false }
 aes = { version = "0.8", optional = true }
 cipher = "0.4"
 ctr = "0.9"
-ghash = { version = "0.4.2", default-features = false }
+ghash = { version = "=0.5.0-pre.1", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -114,10 +114,7 @@ use cipher::{
     BlockCipher, BlockEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore,
 };
 use core::marker::PhantomData;
-use ghash::{
-    universal_hash::{NewUniversalHash, UniversalHash},
-    GHash,
-};
+use ghash::{universal_hash::UniversalHash, GHash};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -304,8 +301,8 @@ where
             let mut block = ghash::Block::default();
             let nonce_bits = (NonceSize::to_usize() as u64) * 8;
             block[8..].copy_from_slice(&nonce_bits.to_be_bytes());
-            ghash.update(&block);
-            ghash.finalize().into_bytes()
+            ghash.update(&[block]);
+            ghash.finalize()
         };
 
         let mut ctr = Ctr32BE::inner_iv_init(&self.cipher, &j0);
@@ -326,9 +323,9 @@ where
         let mut block = ghash::Block::default();
         block[..8].copy_from_slice(&associated_data_bits.to_be_bytes());
         block[8..].copy_from_slice(&buffer_bits.to_be_bytes());
-        ghash.update(&block);
+        ghash.update(&[block]);
 
-        let mut tag = ghash.finalize().into_bytes();
+        let mut tag = ghash.finalize();
         for (a, b) in tag.as_mut_slice().iter_mut().zip(mask.as_slice()) {
             *a ^= *b;
         }

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["cryptography", "no-std"]
 aead = { version = "=0.5.0-pre.2", default-features = false }
 chacha20 = { version = "0.9", features = ["zeroize"] }
 cipher = "0.4"
-poly1305 = "0.7"
+poly1305 = "=0.8.0-pre.1"
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -4,7 +4,7 @@ use ::cipher::{StreamCipher, StreamCipherSeek};
 use aead::generic_array::GenericArray;
 use aead::Error;
 use poly1305::{
-    universal_hash::{NewUniversalHash, UniversalHash},
+    universal_hash::{KeyInit, UniversalHash},
     Poly1305,
 };
 use zeroize::Zeroize;
@@ -64,7 +64,7 @@ where
         self.mac.update_padded(buffer);
 
         self.authenticate_lengths(associated_data, buffer)?;
-        Ok(self.mac.finalize().into_bytes())
+        Ok(self.mac.finalize())
     }
 
     /// Decrypt the given message, first authenticating ciphertext integrity
@@ -102,7 +102,7 @@ where
         let mut block = GenericArray::default();
         block[..8].copy_from_slice(&associated_data_len.to_le_bytes());
         block[8..].copy_from_slice(&buffer_len.to_le_bytes());
-        self.mac.update(&block);
+        self.mac.update(&[block]);
 
         Ok(())
     }


### PR DESCRIPTION
Upgrades the following UHF crates:

- `ghash` v0.5.0-pre.1
- `poly13095` v0.8.0-pre.1
- `polyval` v0.6.0-pre.1