### PR TITLE
Cut `-pre.2` releases of crates which use UHFs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.0-pre.1"
+version = "0.10.0-pre.2"
 dependencies = [
  "aead",
  "aes 0.8.1",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 dependencies = [
  "aead",
  "aes 0.8.1",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.0-pre.1"
+version = "0.10.0-pre.2"
 dependencies = [
  "aead",
  "chacha20",
@@ -743,7 +743,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.9.0-pre.1"
+version = "0.9.0-pre.2"
 dependencies = [
  "aead",
  "poly1305",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.10.0-pre.1"
+version = "0.10.0-pre.2"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.10.0-pre.1"
+version = "0.10.0-pre.2"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.9.0-pre.1"
+version = "0.9.0-pre.2"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
These prereleases use updated universal hash implementations based on `universal-hash` v0.5.0-pre.1.

See #439, #440