### PR TITLE
Bump `aead` crate dependency to v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd885afa9fa966b7715dc1c46bf47330b9156eec79a09d2003c5af03d153ba0"
+checksum = "ae06cea71059b6b79d879afcdd237a33ac61afc052fdd605815e6f3916254abf"
 dependencies = [
  "blobby",
  "crypto-common",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", default-features = false }
+aead = { version = "0.5", default-features = false }
 aes = { version = "0.8", optional = true }
 cipher = "0.4"
 ctr = "0.9"
@@ -26,7 +26,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
+aead = { version = "0.5", features = ["dev"], default-features = false }
 
 [features]
 default    = ["aes", "alloc"]

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", default-features = false }
+aead = { version = "0.5", default-features = false }
 aes = { version = "0.8", optional = true }
 cipher = "0.4"
 ctr = "0.9"
@@ -26,7 +26,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
+aead = { version = "0.5", features = ["dev"], default-features = false }
 hex-literal = "0.3"
 
 [features]

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = "=0.5.0-pre.2"
+aead = "0.5"
 aes = "0.8"
 cipher = "0.4"
 cmac = "0.7"

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["encryption", "aead"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", default-features = false }
+aead = { version = "0.5", default-features = false }
 cipher = { version = "0.4.3", default-features = false }
 ctr = { version = "0.9.1", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
+aead = { version = "0.5", features = ["dev"], default-features = false }
 aes = { version = "0.8.1" }
 hex-literal = "0.3.4"
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -18,14 +18,14 @@ keywords = ["aead", "chacha20", "poly1305", "xchacha20", "xchacha20poly1305"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", default-features = false }
+aead = { version = "0.5", default-features = false }
 chacha20 = { version = "0.9", features = ["zeroize"] }
 cipher = "0.4"
 poly1305 = "=0.8.0-pre.1"
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
+aead = { version = "0.5", features = ["dev"], default-features = false }
 
 [features]
 default = ["alloc"]

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", default-features = false }
+aead = { version = "0.5", default-features = false }
 aes = { version = "0.7.5", features=["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
+aead = { version = "0.5", features = ["dev"], default-features = false }
 hex-literal = "0.3"
 
 [features]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", default-features = false }
+aead = { version = "0.5", default-features = false }
 cipher = "0.3"
 cmac = "0.6"
 ctr = "0.8"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
+aead = { version = "0.5", features = ["dev"], default-features = false }
 aes = "0.7"
 
 [features]

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["encryption", "aead"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", default-features = false }
+aead = { version = "0.5", default-features = false }
 cipher = "0.3"
 subtle = { version = "2", default-features = false }
 cfg-if = "1"
@@ -23,7 +23,7 @@ cfg-if = "1"
 cpufeatures = "0.2"
 
 [dev-dependencies]
-aead = { version = "=0.5.0-pre.2", features = ["dev"], default-features = false }
+aead = { version = "0.5", features = ["dev"], default-features = false }
 kuznyechik = "0.7"
 magma = "0.7"
 hex-literal = "0.2"

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.56"
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", default-features = false }
+aead = { version = "0.5", default-features = false }
 salsa20 = { version = "0.10", features = ["zeroize"] }
 poly1305 = "=0.8.0-pre.1"
 rand_core = { version = "0.6", optional = true }


### PR DESCRIPTION
Release PR: https://github.com/RustCrypto/traits/pull/1058