### PR TITLE
Bump UHF crates to `universal-hash` v0.5.0-pre.2 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882de19ccb8adbd3e2b6d208c8e06246a61e7f02cea9fe15591e72c6bf1968f5"
+checksum = "abab2b5051cf1a759aaa5c16a6dcd8f990d48c7f34687422f958b44a693e57a9"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.8.0-pre.1"
+version = "0.8.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387528277972ee66b5957001b0665b4f8bc36c175a409808ae7b4eed3c61ad75"
+checksum = "ef34d6b4979c0015f018504a06ec657289be099aed5b8dd8c2ed0756996ac3f9"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3095aefad57389bc4c9535342296879488848c6526d4da2bdf9709459f98e30"
+checksum = "ab119066ca6dd9247a1adf7d83faf33b344b727460e0bafeadbdc83133b691a5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -700,9 +700,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddf84cbf3ff76dc1546cd2d7fb8e98f3fecb4de9a4ef68243bc76c14244f557"
+checksum = "9411a446a0bdf07b404c359da8fe71919391662c857a13f6f19e8bd53ad01750"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -21,7 +21,7 @@ aead = { version = "0.5", default-features = false }
 aes = { version = "0.8", optional = true }
 cipher = "0.4"
 ctr = "0.9"
-polyval = { version = "=0.6.0-pre.1", default-features = false }
+polyval = { version = "=0.6.0-pre.2", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
@@ -29,14 +29,12 @@ zeroize = { version = "1", default-features = false }
 aead = { version = "0.5", features = ["dev"], default-features = false }
 
 [features]
-default    = ["aes", "alloc"]
-std        = ["aead/std", "alloc"]
-alloc      = ["aead/alloc"]
-armv8      = ["polyval/armv8"] # nightly-only
-force-soft = ["polyval/force-soft"]
-getrandom  = ["aead/getrandom"]
-heapless   = ["aead/heapless"]
-stream     = ["aead/stream"]
+default   = ["aes", "alloc"]
+std       = ["aead/std", "alloc"]
+alloc     = ["aead/alloc"]
+getrandom = ["aead/getrandom"]
+heapless  = ["aead/heapless"]
+stream    = ["aead/stream"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -21,7 +21,7 @@ aead = { version = "0.5", default-features = false }
 aes = { version = "0.8", optional = true }
 cipher = "0.4"
 ctr = "0.9"
-ghash = { version = "=0.5.0-pre.1", default-features = false }
+ghash = { version = "=0.5.0-pre.2", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -30,14 +30,12 @@ aead = { version = "0.5", features = ["dev"], default-features = false }
 hex-literal = "0.3"
 
 [features]
-default    = ["aes", "alloc"]
-std        = ["aead/std", "alloc"]
-alloc      = ["aead/alloc"]
-armv8      = ["ghash/armv8"] # nightly-only
-force-soft = ["ghash/force-soft"]
-getrandom  = ["aead/getrandom"]
-heapless   = ["aead/heapless"]
-stream     = ["aead/stream"]
+default   = ["aes", "alloc"]
+std       = ["aead/std", "alloc"]
+alloc     = ["aead/alloc"]
+getrandom = ["aead/getrandom"]
+heapless  = ["aead/heapless"]
+stream    = ["aead/stream"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -21,21 +21,20 @@ categories = ["cryptography", "no-std"]
 aead = { version = "0.5", default-features = false }
 chacha20 = { version = "0.9", features = ["zeroize"] }
 cipher = "0.4"
-poly1305 = "=0.8.0-pre.1"
+poly1305 = "=0.8.0-pre.2"
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.5", features = ["dev"], default-features = false }
 
 [features]
-default = ["alloc"]
-std = ["aead/std", "alloc"]
-alloc = ["aead/alloc"]
-getrandom  = ["aead/getrandom"]
-heapless = ["aead/heapless"]
-stream = ["aead/stream"]
+default       = ["alloc"]
+std           = ["aead/std", "alloc"]
+alloc         = ["aead/alloc"]
+getrandom     = ["aead/getrandom"]
+heapless      = ["aead/heapless"]
 reduced-round = []
-force-soft = ["poly1305/force-soft"]
+stream        = ["aead/stream"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.56"
 [dependencies]
 aead = { version = "0.5", default-features = false }
 salsa20 = { version = "0.10", features = ["zeroize"] }
-poly1305 = "=0.8.0-pre.1"
+poly1305 = "=0.8.0-pre.2"
 rand_core = { version = "0.6", optional = true }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }


### PR DESCRIPTION
Upgrades the following UHF crates:

- `ghash` v0.5.0-pre.2
- `poly13095` v0.8.0-pre.2
- `polyval` v0.6.0-pre.2