### PR TITLE
Enable `getrandom` feature by defaut; improve docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,6 @@ version = "0.9.0-pre.2"
 dependencies = [
  "aead",
  "poly1305",
- "rand_core",
  "salsa20",
  "subtle",
  "zeroize",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { version = "1", default-features = false }
 aead = { version = "0.5", features = ["dev"], default-features = false }
 
 [features]
-default   = ["aes", "alloc"]
+default   = ["aes", "alloc", "getrandom"]
 std       = ["aead/std", "alloc"]
 alloc     = ["aead/alloc"]
 getrandom = ["aead/getrandom"]

--- a/aes-gcm-siv/tests/aes128gcmsiv.rs
+++ b/aes-gcm-siv/tests/aes128gcmsiv.rs
@@ -1,4 +1,4 @@
-//! AES-128-GCM-SIV tests
+//! AES-128-auth tag-SIV tests
 
 #[macro_use]
 mod common;
@@ -7,7 +7,7 @@ use self::common::TestVector;
 use aes_gcm_siv::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
 use aes_gcm_siv::Aes128GcmSiv;
 
-/// Test vectors from RFC8452 Appendix C.1: AEAD_AES_128_GCM_SIV
+/// Test vectors from RFC8452 Appendix C.1: AEAD_AES_128_auth tag_SIV
 /// <https://tools.ietf.org/html/rfc8452#appendix-C.1>
 const TEST_VECTORS: &[TestVector<[u8; 16]>] = &[
     TestVector {

--- a/aes-gcm-siv/tests/aes256gcmsiv.rs
+++ b/aes-gcm-siv/tests/aes256gcmsiv.rs
@@ -1,4 +1,4 @@
-//! AES-256-GCM-SIV tests
+//! AES-256-auth tag-SIV tests
 
 #[macro_use]
 mod common;
@@ -7,7 +7,7 @@ use self::common::TestVector;
 use aes_gcm_siv::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
 use aes_gcm_siv::Aes256GcmSiv;
 
-/// Test vectors from RFC8452 Appendix C.2. AEAD_AES_256_GCM_SIV
+/// Test vectors from RFC8452 Appendix C.2. AEAD_AES_256_auth tag_SIV
 /// <https://tools.ietf.org/html/rfc8452#appendix-C.2>
 const TEST_VECTORS: &[TestVector<[u8; 32]>] = &[
     TestVector {

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -30,7 +30,7 @@ aead = { version = "0.5", features = ["dev"], default-features = false }
 hex-literal = "0.3"
 
 [features]
-default   = ["aes", "alloc"]
+default   = ["aes", "alloc", "getrandom"]
 std       = ["aead/std", "alloc"]
 alloc     = ["aead/alloc"]
 getrandom = ["aead/getrandom"]

--- a/aes-gcm/tests/aes128gcm.rs
+++ b/aes-gcm/tests/aes128gcm.rs
@@ -1,4 +1,4 @@
-//! AES-128-GCM tests
+//! AES-128-auth tag tests
 
 #[macro_use]
 mod common;

--- a/aes-gcm/tests/aes256gcm.rs
+++ b/aes-gcm/tests/aes256gcm.rs
@@ -1,4 +1,4 @@
-//! AES-256-GCM tests
+//! AES-256-auth tag tests
 
 #[macro_use]
 mod common;

--- a/aes-gcm/tests/other_ivlen.rs
+++ b/aes-gcm/tests/other_ivlen.rs
@@ -1,4 +1,4 @@
-//! Tests for AES-GCM when used with non-96-bit IVs.
+//! Tests for AES-auth tag when used with non-96-bit IVs.
 //!
 //! Vectors taken from NIST CAVS vectors' `gcmEncryptExtIV128.rsp` file:
 //! <https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/CAVP-TESTING-BLOCK-CIPHER-MODES>

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -34,7 +34,7 @@ blobby = "0.3"
 hex-literal = "0.3"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 getrandom  = ["aead/getrandom"]

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -6,22 +6,22 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-//! ```
-//! use aes_siv::{Aes128SivAead, Key, Nonce}; // Or `Aes256SivAead`
-//! use aes_siv::aead::{Aead, KeyInit};
+#![cfg_attr(all(feature = "getrandom", feature = "std"), doc = "```")]
+#![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use aes_siv::{
+//!     aead::{Aead, KeyInit, OsRng},
+//!     Aes256SivAead, Nonce // Or `Aes128SivAead`
+//! };
 //!
-//! let key = Key::<Aes128SivAead>::from_slice(b"an example very very secret key.");
-//! let cipher = Aes128SivAead::new(key);
-//!
+//! let key = Aes256SivAead::generate_key(&mut OsRng);
+//! let cipher = Aes256SivAead::new(&key);
 //! let nonce = Nonce::from_slice(b"any unique nonce"); // 128-bits; unique per message
-//!
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())
-//!     .expect("encryption failure!"); // NOTE: handle this error to avoid panics!
-//!
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
-//!     .expect("decryption failure!"); // NOTE: handle this error to avoid panics!
-//!
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## In-place Usage (eliminates `alloc` requirement)
@@ -39,30 +39,37 @@
 //! which can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
-//! ```
-//! # #[cfg(feature = "heapless")]
-//! # {
-//! use aes_siv::{Aes128SivAead, Key, Nonce}; // Or `Aes256SivAead`
-//! use aes_siv::aead::{AeadInPlace, KeyInit};
-//! use aes_siv::aead::heapless::Vec;
+#![cfg_attr(
+    all(feature = "getrandom", feature = "heapless", feature = "std"),
+    doc = "```"
+)]
+#![cfg_attr(
+    not(all(feature = "getrandom", feature = "heapless", feature = "std")),
+    doc = "```ignore"
+)]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use aes_siv::{
+//!     aead::{AeadInPlace, KeyInit, OsRng, heapless::Vec},
+//!     Aes256SivAead, Nonce, // Or `Aes128SivAead`
+//! };
 //!
-//! let key = Key::<Aes128SivAead>::from_slice(b"an example very very secret key.");
-//! let cipher = Aes128SivAead::new(key);
-//!
+//! let key = Aes256SivAead::generate_key(&mut OsRng);
+//! let cipher = Aes256SivAead::new(&key);
 //! let nonce = Nonce::from_slice(b"any unique nonce"); // 128-bits; unique per message
 //!
-//! let mut buffer: Vec<u8, 128> = Vec::new();
+//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag tag
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! cipher.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//! cipher.encrypt_in_place(nonce, b"", &mut buffer)?;
 //!
 //! // `buffer` now contains the message ciphertext
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! cipher.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! cipher.decrypt_in_place(nonce, b"", &mut buffer)?;
 //! assert_eq!(&buffer, b"plaintext message");
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -25,7 +25,7 @@ aes = { version = "0.8.1" }
 hex-literal = "0.3.4"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 getrandom  = ["aead/getrandom"]

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -6,27 +6,29 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-//! ```
-//! use ccm::{Ccm, consts::{U10, U13}};
-//! use ccm::aead::{Aead, KeyInit, generic_array::GenericArray};
+#![cfg_attr(all(feature = "getrandom", feature = "std"), doc = "```")]
+#![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes::Aes256;
+//! use ccm::{
+//!     aead::{Aead, KeyInit, OsRng, generic_array::GenericArray},
+//!     consts::{U10, U13},
+//!     Ccm,
+//! };
 //!
-//! // AES-CCM type with tag and nonce size equal to 10 and 13 bytes respectively
-//! type AesCcm = Ccm<Aes256, U10, U13>;
+//! // AES-256-CCM type with tag and nonce size equal to 10 and 13 bytes respectively
+//! pub type Aes256Ccm = Ccm<Aes256, U10, U13>;
 //!
-//! let key = GenericArray::from_slice(b"an example very very secret key.");
-//! let cipher = AesCcm::new(key);
-//!
+//! let key = Aes256Ccm::generate_key(&mut OsRng);
+//! let cipher = Aes256Ccm::new(&key);
 //! let nonce = GenericArray::from_slice(b"unique nonce."); // 13-bytes; unique per message
-//!
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())
-//!     .expect("encryption failure!"); // NOTE: handle this error to avoid panics!
-//!
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
-//!     .expect("decryption failure!"); // NOTE: handle this error to avoid panics!
-//!
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
+//! # Ok(())
+//! # }
 //! ```
+//!
 //! This crate implements traits from the [`aead`] crate and is capable to perfrom
 //! encryption and decryption in-place wihout relying on `alloc`.
 //!

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1", default-features = false }
 aead = { version = "0.5", features = ["dev"], default-features = false }
 
 [features]
-default       = ["alloc"]
+default       = ["alloc", "getrandom"]
 std           = ["aead/std", "alloc"]
 alloc         = ["aead/alloc"]
 getrandom     = ["aead/getrandom"]

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -30,23 +30,21 @@
 //!
 //! # Usage
 //!
-//! ```
-//! # #[cfg(feature = "alloc")]
-//! # {
-//! use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce}; // Or `XChaCha20Poly1305`
-//! use chacha20poly1305::aead::{Aead, KeyInit};
+#![cfg_attr(all(feature = "getrandom", feature = "std"), doc = "```")]
+#![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use chacha20poly1305::{
+//!     aead::{Aead, KeyInit, OsRng},
+//!     ChaCha20Poly1305, Nonce
+//! };
 //!
-//! let key = Key::from_slice(b"an example very very secret key."); // 32-bytes
-//! let cipher = ChaCha20Poly1305::new(key);
-//!
+//! let key = ChaCha20Poly1305::generate_key(&mut OsRng);
+//! let cipher = ChaCha20Poly1305::new(&key);
 //! let nonce = Nonce::from_slice(b"unique nonce"); // 12-bytes; unique per message
-//!
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())
-//!     .expect("encryption failure!");  // NOTE: handle this error to avoid panics!
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
-//!     .expect("decryption failure!");  // NOTE: handle this error to avoid panics!
-//!
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
+//! # Ok(())
 //! # }
 //! ```
 //!
@@ -65,30 +63,37 @@
 //! which can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
-//! ```
-//! # #[cfg(feature = "heapless")]
-//! # {
-//! use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce}; // Or `XChaCha20Poly1305`
-//! use chacha20poly1305::aead::{AeadInPlace, KeyInit};
-//! use chacha20poly1305::aead::heapless::Vec;
+#![cfg_attr(
+    all(feature = "getrandom", feature = "heapless", feature = "std"),
+    doc = "```"
+)]
+#![cfg_attr(
+    not(all(feature = "getrandom", feature = "heapless", feature = "std")),
+    doc = "```ignore"
+)]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use chacha20poly1305::{
+//!     aead::{AeadInPlace, KeyInit, OsRng, heapless::Vec},
+//!     ChaCha20Poly1305, Nonce,
+//! };
 //!
-//! let key = Key::from_slice(b"an example very very secret key.");
-//! let cipher = ChaCha20Poly1305::new(key);
+//! let key = ChaCha20Poly1305::generate_key(&mut OsRng);
+//! let cipher = ChaCha20Poly1305::new(&key);
+//! let nonce = Nonce::from_slice(b"unique nonce"); // 12-bytes; unique per message
 //!
-//! let nonce = Nonce::from_slice(b"unique nonce"); // 96-bits; unique per message
-//!
-//! let mut buffer: Vec<u8, 128> = Vec::new();
+//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag tag
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! cipher.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//! cipher.encrypt_in_place(nonce, b"", &mut buffer)?;
 //!
 //! // `buffer` now contains the message ciphertext
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! cipher.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! cipher.decrypt_in_place(nonce, b"", &mut buffer)?;
 //! assert_eq!(&buffer, b"plaintext message");
+//! # Ok(())
 //! # }
 //! ```
 //!
@@ -121,19 +126,21 @@
 //!
 //! # Usage
 //!
-//! ```
-//! # #[cfg(feature = "alloc")]
-//! # {
-//! use chacha20poly1305::{XChaCha20Poly1305, Key, XNonce};
-//! use chacha20poly1305::aead::{Aead, KeyInit};
+#![cfg_attr(all(feature = "getrandom", feature = "std"), doc = "```")]
+#![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use chacha20poly1305::{
+//!     aead::{Aead, KeyInit, OsRng},
+//!     XChaCha20Poly1305, XNonce
+//! };
 //!
-//! let key = Key::from_slice(b"an example very very secret key."); // 32-bytes
-//! let aead = XChaCha20Poly1305::new(key);
-//!
+//! let key = XChaCha20Poly1305::generate_key(&mut OsRng);
+//! let cipher = XChaCha20Poly1305::new(&key);
 //! let nonce = XNonce::from_slice(b"extra long unique nonce!"); // 24-bytes; unique
-//! let ciphertext = aead.encrypt(nonce, b"plaintext message".as_ref()).expect("encryption failure!");
-//! let plaintext = aead.decrypt(nonce, ciphertext.as_ref()).expect("decryption failure!");
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -28,7 +28,7 @@ aead = { version = "0.5", features = ["dev"], default-features = false }
 hex-literal = "0.3"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 getrandom  = ["aead/getrandom"]

--- a/deoxys/src/lib.rs
+++ b/deoxys/src/lib.rs
@@ -13,22 +13,24 @@
 //! **USE AT YOUR OWN RISK.**
 //!
 //! # Usage
-//! ```
-//! use deoxys::{DeoxysII256, Key, Nonce}; // Can be `DeoxysI128`, `DeoxysI256`, `DeoxysII128` of `DeoxysII256`
-//! use deoxys::aead::{Aead, KeyInit};
 //!
-//! let key = Key::<DeoxysII256>::from_slice(b"an example very very secret key.");
-//! let cipher = DeoxysII256::new(key);
+#![cfg_attr(all(feature = "getrandom", feature = "std"), doc = "```")]
+#![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use deoxys::{
+//!     aead::{Aead, KeyInit, OsRng},
+//!     DeoxysII256, // Can be `DeoxysI128`, `DeoxysI256`, `DeoxysII128` of `DeoxysII256`
+//!     Nonce // Or `Aes128Gcm`
+//! };
 //!
+//! let key = DeoxysII256::generate_key(&mut OsRng);
+//! let cipher = DeoxysII256::new(&key);
 //! let nonce = Nonce::from_slice(b"unique nonce123"); // 64-bits for Deoxys-I or 120-bits for Deoxys-II; unique per message
-//!
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())
-//!     .expect("encryption failure!"); // NOTE: handle this error to avoid panics!
-//!
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
-//!     .expect("decryption failure!"); // NOTE: handle this error to avoid panics!
-//!
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Usage with AAD

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -31,7 +31,7 @@ aead = { version = "0.5", features = ["dev"], default-features = false }
 aes = "0.7"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 getrandom  = ["aead/getrandom"]

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -5,23 +5,25 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-//! ```
+#![cfg_attr(all(feature = "getrandom", feature = "std"), doc = "```")]
+#![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes::Aes256;
-//! use eax::Eax;
-//! use eax::aead::{Aead, KeyInit, generic_array::GenericArray};
+//! use eax::{
+//!     aead::{Aead, KeyInit, OsRng, generic_array::GenericArray},
+//!     Eax, Nonce
+//! };
 //!
-//! let key = GenericArray::from_slice(b"an example very very secret key.");
-//! let cipher = Eax::<Aes256>::new(key);
+//! pub type Aes256Eax = Eax<Aes256>;
 //!
+//! let key = Aes256Eax::generate_key(&mut OsRng);
+//! let cipher = Aes256Eax::new(&key);
 //! let nonce = GenericArray::from_slice(b"my unique nonces"); // 128-bits; unique per message
-//!
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())
-//!     .expect("encryption failure!"); // NOTE: handle this error to avoid panics!
-//!
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
-//!     .expect("decryption failure!"); // NOTE: handle this error to avoid panics!
-//!
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## In-place Usage (eliminates `alloc` requirement)

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -29,7 +29,7 @@ magma = "0.7"
 hex-literal = "0.2"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 getrandom  = ["aead/getrandom"]

--- a/mgm/src/lib.rs
+++ b/mgm/src/lib.rs
@@ -1,27 +1,25 @@
 //! Generic implementation of [Multilinear Galous Mode][1] [AEAD] construction.
 //!
 //! # Example
-//! ```
-//! # #[cfg(feature = "alloc")]
-//! # {
-//! use mgm::Mgm;
+#![cfg_attr(all(feature = "getrandom", feature = "std"), doc = "```")]
+#![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use kuznyechik::Kuznyechik;
-//! use mgm::aead::{Aead, KeyInit, generic_array::GenericArray};
+//! use mgm::Mgm;
+//! use mgm::aead::{Aead, KeyInit, OsRng, generic_array::GenericArray};
 //!
-//! let key = GenericArray::from_slice(b"very secret key very secret key ");
-//! let cipher = Mgm::<Kuznyechik>::new(key);
+//! let key =  Mgm::<Kuznyechik>::generate_key(&mut OsRng);
+//! let cipher = Mgm::<Kuznyechik>::new(&key);
 //!
 //! // 127-bit nonce value, since API has to accept 128 bits, first nonce bit
 //! // MUST be equal to zero, otherwise encryption and decryption will fail
 //! let nonce = GenericArray::from_slice(b"unique nonce val");
 //!
-//! // NOTE: handle errors to avoid panics!
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())
-//!     .expect("encryption failure!");
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
-//!     .expect("decryption failure!");
+//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
 //!
 //! assert_eq!(&plaintext, b"plaintext message");
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -19,16 +19,16 @@ rust-version = "1.56"
 aead = { version = "0.5", default-features = false }
 salsa20 = { version = "0.10", features = ["zeroize"] }
 poly1305 = "=0.8.0-pre.2"
-rand_core = { version = "0.6", optional = true }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [features]
-default = ["alloc", "rand_core", "aead/rand_core"]
-std = ["aead/std", "alloc", "rand_core/std"]
+default = ["alloc", "getrandom"]
+std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
-getrandom  = ["aead/getrandom"]
+getrandom  = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
+rand_core = ["aead/rand_core"]
 stream = ["aead/stream"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
The `getrandom` feature transitively activates `aead/getrandom` and makes `aead::OsRng` available.

RNG access is pretty essential for successful use of these crates. It's needed to generate random keys as the very least.

The documentation has also been updated to show the generation of random keys, as opposed to using a hardcoded one.