### PR TITLE
Make `ChaChaPoly1305` implement `ZeroizeOnDrop`

### DIFF
--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -22,7 +22,7 @@ aead = { version = "0.5", default-features = false }
 chacha20 = { version = "0.9", features = ["zeroize"] }
 cipher = "0.4"
 poly1305 = "=0.8.0-pre.2"
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.5", features = ["dev"], default-features = false }

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -171,7 +171,7 @@ use aead::{
     generic_array::{ArrayLength, GenericArray},
 };
 use core::marker::PhantomData;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use chacha20::{ChaCha20, XChaCha20};
 
@@ -321,3 +321,5 @@ where
         self.key.as_mut_slice().zeroize();
     }
 }
+
+impl<C, N: ArrayLength<u8>> ZeroizeOnDrop for ChaChaPoly1305<C, N> {}


### PR DESCRIPTION
The zeroize-on-drop code was present before, but this PR announces that explicitly in the public API.

Some notes:
- To keep changes to the minimum, I did not add a `Zeroize` impl (probably not a good idea anyway)
- Had to restrict `zeroize` to `>=1.5`, hopefully that's ok.

