### PR TITLE
aes-siv v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.7.0-pre.1"
+version = "0.7.0"
 dependencies = [
  "aead",
  "aes 0.8.1",

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2022-07-30)
+### Added
+- `getrandom` feature ([#446])
+
+### Changed
+- Relax `zeroize` requirement to `^1` ([#360], [#401])
+- Bump `aes` crate to v0.8 ([#431])
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
+- Bump `aead` crate dependency to v0.5 ([#444])
+
+[#360]: https://github.com/RustCrypto/AEADs/pull/360
+[#401]: https://github.com/RustCrypto/AEADs/pull/401
+[#431]: https://github.com/RustCrypto/AEADs/pull/431
+[#435]: https://github.com/RustCrypto/AEADs/pull/435
+[#444]: https://github.com/RustCrypto/AEADs/pull/444
+[#446]: https://github.com/RustCrypto/AEADs/pull/446
+
 ## 0.6.2 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 ([#349])

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.7.0-pre.1"
+version = "0.7.0"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific


### PR DESCRIPTION
### Added
- `getrandom` feature ([#446])

### Changed
- Relax `zeroize` requirement to `^1` ([#360], [#401])
- Bump `aes` crate to v0.8 ([#431])
- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
- Bump `aead` crate dependency to v0.5 ([#444])

[#360]: https://github.com/RustCrypto/AEADs/pull/360
[#401]: https://github.com/RustCrypto/AEADs/pull/401
[#431]: https://github.com/RustCrypto/AEADs/pull/431
[#435]: https://github.com/RustCrypto/AEADs/pull/435
[#444]: https://github.com/RustCrypto/AEADs/pull/444
[#446]: https://github.com/RustCrypto/AEADs/pull/446