### PR TITLE
ccm v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "ccm"
-version = "0.5.0-pre.1"
+version = "0.5.0"
 dependencies = [
  "aead",
  "aes 0.8.1",

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2022-07-30)
+### Added
+- `getrandom` feature ([#446])
+
+### Changed
+- Relax `zeroize` requirement to `^1` ([#360])
+- Bump `ctr`, `cipher`, annd `hex-literal` dependencies ([#432])
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
+- Bump `aead` crate dependency to v0.5 ([#444])
+
+### Removed
+- `subtle` pinning ([#408])
+
+[#360]: https://github.com/RustCrypto/AEADs/pull/360
+[#408]: https://github.com/RustCrypto/AEADs/pull/408
+[#432]: https://github.com/RustCrypto/AEADs/pull/432
+[#435]: https://github.com/RustCrypto/AEADs/pull/435
+[#444]: https://github.com/RustCrypto/AEADs/pull/444
+[#446]: https://github.com/RustCrypto/AEADs/pull/446
+
 ## 0.4.4 (2021-07-20)
 ### Changed
 - Pin `subtle` dependency to v2.4 ([#349])

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.5.0-pre.1"
+version = "0.5.0"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2021"


### PR DESCRIPTION
### Added
- `getrandom` feature ([#446])

### Changed
- Relax `zeroize` requirement to `^1` ([#360])
- Bump `ctr`, `cipher`, annd `hex-literal` dependencies ([#432])
- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
- Bump `aead` crate dependency to v0.5 ([#444])

### Removed
- `subtle` pinning ([#408])

[#360]: https://github.com/RustCrypto/AEADs/pull/360
[#408]: https://github.com/RustCrypto/AEADs/pull/408
[#432]: https://github.com/RustCrypto/AEADs/pull/432
[#435]: https://github.com/RustCrypto/AEADs/pull/435
[#444]: https://github.com/RustCrypto/AEADs/pull/444
[#446]: https://github.com/RustCrypto/AEADs/pull/446