### PR TITLE
eax v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.5.0-pre.1"
+version = "0.5.0"
 dependencies = [
  "aead",
  "aes",

--- a/eax/CHANGELOG.md
+++ b/eax/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2022-07-30)
+### Added
+- `getrandom` feature ([#446])
+
+### Changed
+- Relax `subtle` and `zeroize` requirements ([#360])
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
+- Bump `aead` crate dependency to v0.5 ([#444])
+- Bump `cipher` to v0.4 ([#451])
+
+[#360]: https://github.com/RustCrypto/AEADs/pull/360
+[#435]: https://github.com/RustCrypto/AEADs/pull/435
+[#444]: https://github.com/RustCrypto/AEADs/pull/444
+[#446]: https://github.com/RustCrypto/AEADs/pull/446
+[#451]: https://github.com/RustCrypto/AEADs/pull/451
+
 ## 0.4.1 (2021-07-20)
 ### Changed
 - Pin `subtle` dependency to v2.4 ([#349])

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.5.0-pre.1"
+version = "0.5.0"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -122,11 +122,10 @@ pub use cipher;
 
 use cipher::{
     consts::{U0, U16},
-    crypto_common::OutputSizeUser,
     generic_array::{functional::FunctionalSequence, GenericArray},
     BlockCipher, BlockEncrypt, InnerIvInit, StreamCipherCore,
 };
-use cmac::{Cmac, Mac};
+use cmac::{digest::Output, Cmac, Mac};
 use core::marker::PhantomData;
 
 mod traits;
@@ -299,7 +298,7 @@ where
         key: &GenericArray<u8, Cipher::KeySize>,
         iv: u8,
         data: &[u8],
-    ) -> GenericArray<u8, <Cmac<Cipher> as OutputSizeUser>::OutputSize> {
+    ) -> Output<Cmac<Cipher>> {
         let mut mac = <Cmac<Cipher> as Mac>::new(key);
         mac.update(&[0; 15]);
         mac.update(&[iv]);


### PR DESCRIPTION
### Added
- `getrandom` feature ([#446])

### Changed
- Relax `subtle` and `zeroize` requirements ([#360])
- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
- Bump `aead` crate dependency to v0.5 ([#444])
- Bump `cipher` to v0.4 ([#451])

[#360]: https://github.com/RustCrypto/AEADs/pull/360
[#435]: https://github.com/RustCrypto/AEADs/pull/435
[#444]: https://github.com/RustCrypto/AEADs/pull/444
[#446]: https://github.com/RustCrypto/AEADs/pull/446
[#451]: https://github.com/RustCrypto/AEADs/pull/451