### PR TITLE
aes-gcm v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.0-pre.2"
+version = "0.10.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2022-07-31)
+### Added
+- `getrandom` feature ([#446])
+
+### Changed
+- Bump `aes` dependency to v0.8 ([#409])
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
+- Bump `aead` dependency to v0.5 ([#444])
+- Bump `ghash` dependency to v0.5 ([#454])
+
+[#409]: https://github.com/RustCrypto/AEADs/pull/409
+[#435]: https://github.com/RustCrypto/AEADs/pull/435
+[#444]: https://github.com/RustCrypto/AEADs/pull/444
+[#446]: https://github.com/RustCrypto/AEADs/pull/446
+[#454]: https://github.com/RustCrypto/AEADs/pull/454
+
 ## 0.9.4 (2021-08-28)
 ### Changed
 - Relax `subtle` and `zeroize` requirements ([#360])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.10.0-pre.2"
+version = "0.10.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Added
- `getrandom` feature ([#446])

### Changed
- Bump `aes` dependency to v0.8 ([#409])
- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
- Bump `aead` dependency to v0.5 ([#444])
- Bump `ghash` dependency to v0.5 ([#454])

[#409]: https://github.com/RustCrypto/AEADs/pull/409
[#435]: https://github.com/RustCrypto/AEADs/pull/435
[#444]: https://github.com/RustCrypto/AEADs/pull/444
[#446]: https://github.com/RustCrypto/AEADs/pull/446
[#454]: https://github.com/RustCrypto/AEADs/pull/454