### PR TITLE
aes-gcm-siv v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.11.0-pre.2"
+version = "0.11.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2022-07-31)
+### Added
+- `getrandom` feature ([#446])
+
+### Changed
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
+- Bump `aead` dependency to v0.5 ([#444])
+- Bump `polyval` dependency to v0.6 ([#454])
+
+[#435]: https://github.com/RustCrypto/AEADs/pull/435
+[#444]: https://github.com/RustCrypto/AEADs/pull/444
+[#446]: https://github.com/RustCrypto/AEADs/pull/446
+[#454]: https://github.com/RustCrypto/AEADs/pull/454
+
 ## 0.10.3 (2021-08-28)
 ### Changed
 - Relax `subtle` and `zeroize` requirements ([#360])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.11.0-pre.2"
+version = "0.11.0"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -9,12 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `getrandom` feature ([#446])
 
 ### Changed
-- Bump `aes` dependency to v0.8 ([#409])
+- Bump `aes` dependency to v0.8 ([#430])
 - Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
 - Bump `aead` dependency to v0.5 ([#444])
 - Bump `ghash` dependency to v0.5 ([#454])
 
-[#409]: https://github.com/RustCrypto/AEADs/pull/409
 [#435]: https://github.com/RustCrypto/AEADs/pull/435
 [#444]: https://github.com/RustCrypto/AEADs/pull/444
 [#446]: https://github.com/RustCrypto/AEADs/pull/446


### PR DESCRIPTION
### Added
- `getrandom` feature ([#446])

### Changed
- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
- Bump `aead` dependency to v0.5 ([#444])
- Bump `polyval` dependency to v0.6 ([#454])

[#435]: https://github.com/RustCrypto/AEADs/pull/435
[#444]: https://github.com/RustCrypto/AEADs/pull/444
[#446]: https://github.com/RustCrypto/AEADs/pull/446
[#454]: https://github.com/RustCrypto/AEADs/pull/454