### PR TITLE
chacha20poly1305 v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.0-pre.2"
+version = "0.10.0"
 dependencies = [
  "aead",
  "chacha20",

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2022-07-31)
+### Added
+- `getrandom` feature ([#446])
+- Impl `ZeroizeOnDrop` for `ChaChaPoly1305` ([#447])
+
+### Changed
+- Bump `chacha20` to v0.9 ([#402])
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
+- Bump `aead` dependency to v0.5 ([#444])
+- Bump `poly1305` dependency to v0.8 ([#454])
+
+[#402]: https://github.com/RustCrypto/AEADs/pull/402
+[#435]: https://github.com/RustCrypto/AEADs/pull/435
+[#444]: https://github.com/RustCrypto/AEADs/pull/444
+[#446]: https://github.com/RustCrypto/AEADs/pull/446
+[#447]: https://github.com/RustCrypto/AEADs/pull/447
+[#454]: https://github.com/RustCrypto/AEADs/pull/454
+
 ## 0.9.1 (2022-07-07)
 ### Changed
 - Unpin `zeroize` dependency ([#438])
@@ -12,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9.0 (2021-08-29)
 ### Changed
-- Bump `chacha20` to v0.9: now a hard dependency ([#365])
+- Bump `chacha20` to v0.8: now a hard dependency ([#365])
 - MSRV 1.51+ ([#365])
 
 ### Removed

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.10.0-pre.2"
+version = "0.10.0"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific


### PR DESCRIPTION
### Added
- `getrandom` feature ([#446])
- Impl `ZeroizeOnDrop` for `ChaChaPoly1305` ([#447])

### Changed
- Bump `chacha20` to v0.9 ([#402])
- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
- Bump `aead` dependency to v0.5 ([#444])
- Bump `poly1305` dependency to v0.8 ([#454])

[#402]: https://github.com/RustCrypto/AEADs/pull/402
[#435]: https://github.com/RustCrypto/AEADs/pull/435
[#444]: https://github.com/RustCrypto/AEADs/pull/444
[#446]: https://github.com/RustCrypto/AEADs/pull/446
[#447]: https://github.com/RustCrypto/AEADs/pull/447
[#454]: https://github.com/RustCrypto/AEADs/pull/454