### PR TITLE
xsalsa20poly1305 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.9.0-pre.2"
+version = "0.9.0"
 dependencies = [
  "aead",
  "poly1305",

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Impl `ZeroizeOnDrop` for `ChaChaPoly1305` ([#447])
 
 ### Changed
-- Bump `chacha20` to v0.9 ([#402])
+- Bump `chacha20` dependency to v0.9 ([#402])
 - Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
 - Bump `aead` dependency to v0.5 ([#444])
 - Bump `poly1305` dependency to v0.8 ([#454])

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2022-07-31)
+### Added
+- `getrandom` feature ([#446])
+
+### Changed
+- Bump `salsa20` dependency to v0.10 ([#402])
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
+- Bump `aead` dependency to v0.5 ([#444])
+- Bump `poly1305` dependency to v0.8 ([#454])
+
+[#402]: https://github.com/RustCrypto/AEADs/pull/402
+[#435]: https://github.com/RustCrypto/AEADs/pull/435
+[#444]: https://github.com/RustCrypto/AEADs/pull/444
+[#446]: https://github.com/RustCrypto/AEADs/pull/446
+[#447]: https://github.com/RustCrypto/AEADs/pull/447
+[#454]: https://github.com/RustCrypto/AEADs/pull/454
+
 ## 0.8.0 (2021-08-30)
 ### Changed
 - Bump `salsa20` dependency to v0.9 ([#366])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.9.0-pre.2"
+version = "0.9.0"
 description = """
 Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
 authenticated encryption algorithm


### PR DESCRIPTION
### Added
- `getrandom` feature ([#446])

### Changed
- Bump `salsa20` dependency to v0.10 ([#402])
- Rust 2021 edition upgrade; MSRV 1.56+ ([#435])
- Bump `aead` dependency to v0.5 ([#444])
- Bump `poly1305` dependency to v0.8 ([#454])

[#402]: https://github.com/RustCrypto/AEADs/pull/402
[#435]: https://github.com/RustCrypto/AEADs/pull/435
[#444]: https://github.com/RustCrypto/AEADs/pull/444
[#446]: https://github.com/RustCrypto/AEADs/pull/446
[#447]: https://github.com/RustCrypto/AEADs/pull/447
[#454]: https://github.com/RustCrypto/AEADs/pull/454