### PR TITLE
aes-gcm v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.1 (2022-07-31)
+### Fixed
+- rustdoc typos and formatting ([#461], [#462])
+
+[#461]: https://github.com/RustCrypto/AEADs/pull/461
+[#462]: https://github.com/RustCrypto/AEADs/pull/462
+
 ## 0.10.0 (2022-07-31)
 ### Added
 - `getrandom` feature ([#446])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.10.0"
+version = "0.10.1"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Fixed
- rustdoc typos and formatting ([#461], [#462])

[#461]: https://github.com/RustCrypto/AEADs/pull/461
[#462]: https://github.com/RustCrypto/AEADs/pull/462