### PR TITLE
aes-gcm-siv v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.1 (2022-07-31)
+### Fixed
+- rustdoc typos and formatting ([#460], [#461], [#462])
+
+[#460]: https://github.com/RustCrypto/AEADs/pull/460
+[#461]: https://github.com/RustCrypto/AEADs/pull/461
+[#462]: https://github.com/RustCrypto/AEADs/pull/462
+
 ## 0.11.0 (2022-07-31)
 ### Added
 - `getrandom` feature ([#446])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.11.0"
+version = "0.11.1"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific


### PR DESCRIPTION
### Fixed
- rustdoc typos and formatting ([#460], [#461], [#462])

[#460]: https://github.com/RustCrypto/AEADs/pull/460
[#461]: https://github.com/RustCrypto/AEADs/pull/461
[#462]: https://github.com/RustCrypto/AEADs/pull/462