### PR TITLE
chacha20poly1305: add `ChaChaPoly1305::generate_nonce`

### DIFF
--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -33,6 +33,7 @@ std           = ["aead/std", "alloc"]
 alloc         = ["aead/alloc"]
 getrandom     = ["aead/getrandom"]
 heapless      = ["aead/heapless"]
+rand_core     = ["aead/rand_core"]
 reduced-round = []
 stream        = ["aead/stream"]
 


### PR DESCRIPTION
Adds a helper for generating random nonces, which is particularly useful with `XChaCha20Poly1305`.

Provides similar functionality to `XSalsa20Poly1305`.