### PR TITLE
Use `AeadCore::generate_nonce` in rustdoc examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae06cea71059b6b79d879afcdd237a33ac61afc052fdd605815e6f3916254abf"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
 dependencies = [
  "blobby",
  "crypto-common",

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -15,15 +15,15 @@
 #![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes_gcm_siv::{
-//!     aead::{Aead, KeyInit, OsRng},
+//!     aead::{Aead, AeadCore, KeyInit, OsRng},
 //!     Aes256GcmSiv, Nonce // Or `Aes128GcmSiv`
 //! };
 //!
 //! let key = Aes256GcmSiv::generate_key(&mut OsRng);
 //! let cipher = Aes256GcmSiv::new(&key);
-//! let nonce = Nonce::from_slice(b"unique nonce"); // 96-bits; unique per message
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
+//! let nonce = Aes256GcmSiv::generate_nonce(&mut OsRng); // 96-bits; unique per message
+//! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
 //! # }
@@ -62,7 +62,7 @@
 //! let cipher = Aes256GcmSiv::new(&key);
 //! let nonce = Nonce::from_slice(b"unique nonce"); // 96-bits; unique per message
 //!
-//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag tag
+//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -16,15 +16,15 @@
 #![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes_gcm::{
-//!     aead::{Aead, KeyInit, OsRng},
+//!     aead::{Aead, AeadCore, KeyInit, OsRng},
 //!     Aes256Gcm, Nonce // Or `Aes128Gcm`
 //! };
 //!
 //! let key = Aes256Gcm::generate_key(&mut OsRng);
 //! let cipher = Aes256Gcm::new(&key);
-//! let nonce = Nonce::from_slice(b"unique nonce"); // 96-bits; unique per message
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
+//! let nonce = Aes256Gcm::generate_nonce(&mut OsRng); // 96-bits; unique per message
+//! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
 //! # }
@@ -55,25 +55,25 @@
 )]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes_gcm::{
-//!     aead::{AeadInPlace, KeyInit, OsRng, heapless::Vec},
+//!     aead::{AeadCore, AeadInPlace, KeyInit, OsRng, heapless::Vec},
 //!     Aes256Gcm, Nonce, // Or `Aes128Gcm`
 //! };
 //!
 //! let key = Aes256Gcm::generate_key(&mut OsRng);
 //! let cipher = Aes256Gcm::new(&key);
-//! let nonce = Nonce::from_slice(b"unique nonce"); // 96-bits; unique per message
+//! let nonce = Aes256Gcm::generate_nonce(&mut OsRng); // 96-bits; unique per message
 //!
-//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag tag
+//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! cipher.encrypt_in_place(nonce, b"", &mut buffer)?;
+//! cipher.encrypt_in_place(&nonce, b"", &mut buffer)?;
 //!
 //! // `buffer` now contains the message ciphertext
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! cipher.decrypt_in_place(nonce, b"", &mut buffer)?;
+//! cipher.decrypt_in_place(&nonce, b"", &mut buffer)?;
 //! assert_eq!(&buffer, b"plaintext message");
 //! # Ok(())
 //! # }

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -15,15 +15,15 @@
 #![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes_siv::{
-//!     aead::{Aead, KeyInit, OsRng},
+//!     aead::{Aead, AeadCore, KeyInit, OsRng},
 //!     Aes256SivAead, Nonce // Or `Aes128SivAead`
 //! };
 //!
 //! let key = Aes256SivAead::generate_key(&mut OsRng);
 //! let cipher = Aes256SivAead::new(&key);
-//! let nonce = Nonce::from_slice(b"any unique nonce"); // 128-bits; unique per message
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
+//! let nonce = Aes256SivAead::generate_nonce(&mut OsRng); // 128-bits; unique per message
+//! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
 //! # }
@@ -54,25 +54,25 @@
 )]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes_siv::{
-//!     aead::{AeadInPlace, KeyInit, OsRng, heapless::Vec},
+//!     aead::{AeadCore, AeadInPlace, KeyInit, OsRng, heapless::Vec},
 //!     Aes256SivAead, Nonce, // Or `Aes128SivAead`
 //! };
 //!
 //! let key = Aes256SivAead::generate_key(&mut OsRng);
 //! let cipher = Aes256SivAead::new(&key);
-//! let nonce = Nonce::from_slice(b"any unique nonce"); // 128-bits; unique per message
+//! let nonce = Aes256SivAead::generate_nonce(&mut OsRng); // 128-bits; unique per message
 //!
-//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag tag
+//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! cipher.encrypt_in_place(nonce, b"", &mut buffer)?;
+//! cipher.encrypt_in_place(&nonce, b"", &mut buffer)?;
 //!
 //! // `buffer` now contains the message ciphertext
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! cipher.decrypt_in_place(nonce, b"", &mut buffer)?;
+//! cipher.decrypt_in_place(&nonce, b"", &mut buffer)?;
 //! assert_eq!(&buffer, b"plaintext message");
 //! # Ok(())
 //! # }

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -16,7 +16,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes::Aes256;
 //! use ccm::{
-//!     aead::{Aead, KeyInit, OsRng, generic_array::GenericArray},
+//!     aead::{Aead, AeadCore, KeyInit, OsRng, generic_array::GenericArray},
 //!     consts::{U10, U13},
 //!     Ccm,
 //! };
@@ -26,9 +26,9 @@
 //!
 //! let key = Aes256Ccm::generate_key(&mut OsRng);
 //! let cipher = Aes256Ccm::new(&key);
-//! let nonce = GenericArray::from_slice(b"unique nonce."); // 13-bytes; unique per message
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
+//! let nonce = Aes256Ccm::generate_nonce(&mut OsRng); // 13-bytes; unique per message
+//! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
 //! # }

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -26,15 +26,15 @@
 #![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use chacha20poly1305::{
-//!     aead::{Aead, KeyInit, OsRng},
+//!     aead::{Aead, AeadCore, KeyInit, OsRng},
 //!     ChaCha20Poly1305, Nonce
 //! };
 //!
 //! let key = ChaCha20Poly1305::generate_key(&mut OsRng);
 //! let cipher = ChaCha20Poly1305::new(&key);
-//! let nonce = Nonce::from_slice(b"unique nonce"); // 12-bytes; unique per message
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
+//! let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng); // 96-bits; unique per message
+//! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
 //! # }
@@ -65,25 +65,25 @@
 )]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use chacha20poly1305::{
-//!     aead::{AeadInPlace, KeyInit, OsRng, heapless::Vec},
+//!     aead::{AeadCore, AeadInPlace, KeyInit, OsRng, heapless::Vec},
 //!     ChaCha20Poly1305, Nonce,
 //! };
 //!
 //! let key = ChaCha20Poly1305::generate_key(&mut OsRng);
 //! let cipher = ChaCha20Poly1305::new(&key);
-//! let nonce = Nonce::from_slice(b"unique nonce"); // 12-bytes; unique per message
+//! let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng); // 96-bits; unique per message
 //!
-//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag tag
+//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! cipher.encrypt_in_place(nonce, b"", &mut buffer)?;
+//! cipher.encrypt_in_place(&nonce, b"", &mut buffer)?;
 //!
 //! // `buffer` now contains the message ciphertext
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! cipher.decrypt_in_place(nonce, b"", &mut buffer)?;
+//! cipher.decrypt_in_place(&nonce, b"", &mut buffer)?;
 //! assert_eq!(&buffer, b"plaintext message");
 //! # Ok(())
 //! # }
@@ -122,15 +122,15 @@
 #![cfg_attr(not(all(feature = "getrandom", feature = "std")), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use chacha20poly1305::{
-//!     aead::{Aead, KeyInit, OsRng},
+//!     aead::{Aead, AeadCore, KeyInit, OsRng},
 //!     XChaCha20Poly1305, XNonce
 //! };
 //!
 //! let key = XChaCha20Poly1305::generate_key(&mut OsRng);
 //! let cipher = XChaCha20Poly1305::new(&key);
-//! let nonce = XNonce::from_slice(b"extra long unique nonce!"); // 24-bytes; unique
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
+//! let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng); // 192-bits; unique per message
+//! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
 //! # }

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -17,7 +17,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use aes::Aes256;
 //! use eax::{
-//!     aead::{Aead, KeyInit, OsRng, generic_array::GenericArray},
+//!     aead::{Aead, AeadCore, KeyInit, OsRng, generic_array::GenericArray},
 //!     Eax, Nonce
 //! };
 //!
@@ -25,9 +25,9 @@
 //!
 //! let key = Aes256Eax::generate_key(&mut OsRng);
 //! let cipher = Aes256Eax::new(&key);
-//! let nonce = GenericArray::from_slice(b"my unique nonces"); // 128-bits; unique per message
-//! let ciphertext = cipher.encrypt(nonce, b"plaintext message".as_ref())?;
-//! let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())?;
+//! let nonce = Aes256Eax::generate_nonce(&mut OsRng); // 128-bits; unique per message
+//! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
 //! # }
@@ -53,25 +53,30 @@
 //! # {
 //! use aes::Aes256;
 //! use eax::Eax;
-//! use eax::aead::{AeadInPlace, KeyInit, generic_array::GenericArray};
-//! use eax::aead::heapless::Vec;
+//! use eax::aead::{
+//!     generic_array::GenericArray,
+//!     heapless::Vec,
+//!     AeadCore, AeadInPlace, KeyInit, OsRng
+//! };
 //!
-//! let key = GenericArray::from_slice(b"an example very very secret key.");
-//! let cipher = Eax::<Aes256>::new(key);
+//! pub type Aes256Eax = Eax<Aes256>;
 //!
-//! let nonce = GenericArray::from_slice(b"my unique nonces"); // 128-bits; unique per message
+//! let key = Aes256Eax::generate_key(&mut OsRng);
+//! let cipher = Aes256Eax::new(&key);
+//!
+//! let nonce = Aes256Eax::generate_nonce(&mut OsRng); // 128-bits; unique per message
 //!
 //! let mut buffer: Vec<u8, 128> = Vec::new();
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! cipher.encrypt_in_place(nonce, b"", &mut buffer).expect("encryption failure!");
+//! cipher.encrypt_in_place(&nonce, b"", &mut buffer).expect("encryption failure!");
 //!
 //! // `buffer` now contains the message ciphertext
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! cipher.decrypt_in_place(nonce, b"", &mut buffer).expect("decryption failure!");
+//! cipher.decrypt_in_place(&nonce, b"", &mut buffer).expect("decryption failure!");
 //! assert_eq!(&buffer, b"plaintext message");
 //! # }
 //! ```

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -61,7 +61,7 @@
 //! let cipher = XSalsa20Poly1305::new(&key);
 //! let nonce = XSalsa20Poly1305::generate_nonce(&mut OsRng); // unique per message
 //!
-//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag tag
+//! let mut buffer: Vec<u8, 128> = Vec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
@@ -153,6 +153,7 @@ impl XSalsa20Poly1305 {
     /// Generate a random nonce: every message MUST have a unique nonce!
     ///
     /// Do *NOT* ever reuse the same nonce for two messages!
+    // TODO(tarcieri): remove this in favor of `AeadCore::generate_nonce`
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     pub fn generate_nonce<T>(csprng: &mut T) -> Nonce


### PR DESCRIPTION
This provides a better example closer to real-world code.

See: https://docs.rs/aead/0.5.1/aead/trait.AeadCore.html#method.generate_nonce