### PR TITLE
ccm: Mention AES-CCM in README

### DIFF
--- a/ccm/README.md
+++ b/ccm/README.md
@@ -11,6 +11,9 @@ Pure Rust implementation of the Counter with CBC-MAC ([CCM]) mode ([RFC 3610]): 
 Authenticated Encryption with Associated Data ([AEAD]) algorithm generic over
 block ciphers with block size equal to 128 bits.
 
+For example, it can be combined with AES into the various parametrizations of
+AES-CCM.
+
 [Documentation][docs-link]
 
 ## Security Notes


### PR DESCRIPTION
This adds a mention of AES-CCM in CCM's README as an example.

AES-CCM is the most prominent use case of CCM, as evidenced by the wikipedia articles both of CCM and its users always listing that combination.

Practically, this ensures that users looking for `aes-ccm` at crates.io find this, especially if https://github.com/martindisch/aes-ccm/issues/9 is not followed up on. (Concrete example: I was a few steps short of starting to update the aes-ccm crate to recent traits when I found that issue which pointed me here; the present fix would have spared me that detour).