### PR TITLE
Add correct link to Too much crypto

### DIFF
--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! - [`XChaCha20Poly1305`] - ChaCha20Poly1305 variant with an extended 192-bit (24-byte) nonce.
 //! - [`ChaCha8Poly1305`] / [`ChaCha12Poly1305`] - non-standard, reduced-round variants
-//!   (gated under the `reduced-round` Cargo feature). See the 
+//!   (gated under the `reduced-round` Cargo feature). See the
 //!   [Too Much Crypto](https://eprint.iacr.org/2019/1492.pdf)
 //!   paper for background and rationale on when these constructions could be used.
 //!   When in doubt, prefer [`ChaCha20Poly1305`].

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -14,7 +14,8 @@
 //!
 //! - [`XChaCha20Poly1305`] - ChaCha20Poly1305 variant with an extended 192-bit (24-byte) nonce.
 //! - [`ChaCha8Poly1305`] / [`ChaCha12Poly1305`] - non-standard, reduced-round variants
-//!   (gated under the `reduced-round` Cargo feature). See the [Too Much Crypto][5]
+//!   (gated under the `reduced-round` Cargo feature). See the 
+//!   [Too Much Crypto](https://eprint.iacr.org/2019/1492.pdf)
 //!   paper for background and rationale on when these constructions could be used.
 //!   When in doubt, prefer [`ChaCha20Poly1305`].
 //! - [`XChaCha8Poly1305`] / [`XChaCha12Poly1305`] - same as above,


### PR DESCRIPTION
Currently at https://docs.rs/chacha20poly1305/latest/chacha20poly1305/#supported-algorithms it renders link to audit from <https://github.com/RustCrypto/AEADs/blob/57956bf2d8273e7b3fddd127aa7116ad5ef1c5ad/chacha20poly1305/README.md?plain=1#L82>.