### PR TITLE
ArrayVec support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "arrayvec",
  "blobby",
  "crypto-common",
  "generic-array",
@@ -69,6 +70,12 @@ dependencies = [
  "pmac",
  "zeroize",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ascon"

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -32,6 +32,7 @@ aead = { version = "0.5", features = ["dev"], default-features = false }
 default   = ["aes", "alloc", "getrandom"]
 std       = ["aead/std", "alloc"]
 alloc     = ["aead/alloc"]
+arrayvec  = ["aead/arrayvec"]
 getrandom = ["aead/getrandom", "rand_core"]
 heapless  = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -77,6 +77,10 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! Similarly, enabling the `arrayvec` feature of this crate will provide an impl of
+//! [`aead::Buffer`] for `arrayvec::ArrayVec` (re-exported from the [`aead`] crate as
+//! [`aead::arrayvec::ArrayVec`]).
 
 pub use aead::{self, AeadCore, AeadInPlace, Error, Key, KeyInit, KeySizeUser};
 

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -33,6 +33,7 @@ hex-literal = "0.3"
 default   = ["aes", "alloc", "getrandom"]
 std       = ["aead/std", "alloc"]
 alloc     = ["aead/alloc"]
+arrayvec  = ["aead/arrayvec"]
 getrandom = ["aead/getrandom", "rand_core"]
 heapless  = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -96,6 +96,10 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! Similarly, enabling the `arrayvec` feature of this crate will provide an impl of
+//! [`aead::Buffer`] for `arrayvec::ArrayVec` (re-exported from the [`aead`] crate as
+//! [`aead::arrayvec::ArrayVec`]).
 
 pub use aead::{self, AeadCore, AeadInPlace, Error, Key, KeyInit, KeySizeUser};
 

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -37,6 +37,7 @@ hex-literal = "0.3"
 default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+arrayvec = ["aead/arrayvec"]
 getrandom  = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -77,6 +77,10 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! Similarly, enabling the `arrayvec` feature of this crate will provide an impl of
+//! [`aead::Buffer`] for `arrayvec::ArrayVec` (re-exported from the [`aead`] crate as
+//! [`aead::arrayvec::ArrayVec`]).
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -28,6 +28,7 @@ hex-literal = "0.3.4"
 default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+arrayvec = ["aead/arrayvec"]
 getrandom  = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -31,6 +31,7 @@ aead = { version = "0.5", features = ["dev"], default-features = false }
 default       = ["alloc", "getrandom"]
 std           = ["aead/std", "alloc"]
 alloc         = ["aead/alloc"]
+arrayvec      = ["aead/arrayvec"]
 getrandom     = ["aead/getrandom", "rand_core"]
 heapless      = ["aead/heapless"]
 rand_core     = ["aead/rand_core"]

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -90,6 +90,10 @@
 //! # }
 //! ```
 //!
+//! Similarly, enabling the `arrayvec` feature of this crate will provide an impl of
+//! [`aead::Buffer`] for `arrayvec::ArrayVec` (re-exported from the [`aead`] crate as
+//! [`aead::arrayvec::ArrayVec`]).
+//!
 //! ## [`XChaCha20Poly1305`]
 //!
 //! ChaCha20Poly1305 variant with an extended 192-bit (24-byte) nonce.

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -31,6 +31,7 @@ hex-literal = "0.3"
 default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+arrayvec = ["aead/arrayvec"]
 getrandom  = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/deoxys/src/lib.rs
+++ b/deoxys/src/lib.rs
@@ -97,6 +97,10 @@
 //! assert_eq!(&buffer, b"plaintext message");
 //! # }
 //! ```
+//!
+//! Similarly, enabling the `arrayvec` feature of this crate will provide an impl of
+//! [`aead::Buffer`] for `arrayvec::ArrayVec` (re-exported from the [`aead`] crate as
+//! [`aead::arrayvec::ArrayVec`]).
 
 /// Deoxys-BC implementations.
 mod deoxys_bc;

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -34,6 +34,7 @@ aes = "0.8"
 default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+arrayvec = ["aead/arrayvec"]
 getrandom  = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -81,6 +81,10 @@
 //! # }
 //! ```
 //!
+//! Similarly, enabling the `arrayvec` feature of this crate will provide an impl of
+//! [`aead::Buffer`] for `arrayvec::ArrayVec` (re-exported from the [`aead`] crate as
+//! [`aead::arrayvec::ArrayVec`]).
+//!
 //! ## Custom Tag Length
 //!
 //! The tag for eax is usually 16 bytes long but it can be shortened if needed.

--- a/mgm/Cargo.toml
+++ b/mgm/Cargo.toml
@@ -32,6 +32,7 @@ hex-literal = "0.2"
 default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+arrayvec = ["aead/arrayvec"]
 getrandom  = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -26,6 +26,7 @@ zeroize = { version = "1", default-features = false }
 default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
+arrayvec = ["aead/arrayvec"]
 getrandom  = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -104,6 +104,10 @@
 //! # }
 //! ```
 //!
+//! Similarly, enabling the `arrayvec` feature of this crate will provide an impl of
+//! [`aead::Buffer`] for `arrayvec::ArrayVec` (re-exported from the [`aead`] crate as
+//! [`aead::arrayvec::ArrayVec`]).
+//!
 //! [1]: https://nacl.cr.yp.to/secretbox.html
 //! [2]: https://en.wikipedia.org/wiki/Authenticated_encryption
 //! [3]: https://docs.rs/salsa20


### PR DESCRIPTION
Added support for `arrayvec::ArrayVec` as per changes in https://github.com/RustCrypto/traits/pull/1219. Marked as draft for now until a new release of `aead` is published.