### PR TITLE
Fix a typo

### DIFF
--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! # fn main() -> Result<(), aes_gcm::Error> {
 //! // Alternatively, the key can be transformed directly from a byte slice
-//! // (panicks on lenght mismatch):
+//! // (panicks on length mismatch):
 //! # let key: &[u8] = &[42; 32];
 //! let key = Key::<Aes256Gcm>::from_slice(key);
 //!


### PR DESCRIPTION
Fix a small typo in `aes-gcm/src/lib.rs`.