### PR TITLE
benches: only use criterion CPB measurements on x86_64 and x86 targets

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,14 +11,16 @@ rust-version = "1.56"
 [workspace]
 
 [dependencies]
-criterion = "0.3"
-criterion-cycles-per-byte = "0.1"
-aes = "0.7.0-pre"
+criterion = "0.4.0"
+aes = "0.8.2"
 aes-gcm = { path = "../aes-gcm/" }
 aes-gcm-siv = { path = "../aes-gcm-siv/" }
 chacha20poly1305 = { path = "../chacha20poly1305/" }
 deoxys = { path = "../deoxys/" }
 eax = { path = "../eax/" }
+
+[target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
+criterion-cycles-per-byte = "0.4.0"
 
 [[bench]]
 name = "aes-gcm"

--- a/benches/src/aes-gcm-siv.rs
+++ b/benches/src/aes-gcm-siv.rs
@@ -1,12 +1,16 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use criterion_cycles_per_byte::CyclesPerByte;
 
 use aes_gcm_siv::aead::{Aead, KeyInit};
 use aes_gcm_siv::{Aes128GcmSiv, Aes256GcmSiv};
 
 const KB: usize = 1024;
 
-fn bench(c: &mut Criterion<CyclesPerByte>) {
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+type Benchmarker = Criterion;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+type Benchmarker = Criterion<criterion_cycles_per_byte::CyclesPerByte>;
+
+fn bench(c: &mut Benchmarker) {
     let mut group = c.benchmark_group("aes-gcm-siv");
 
     for size in &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
@@ -36,9 +40,18 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     group.finish();
 }
 
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench
+);
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
     config = Criterion::default().with_measurement(CyclesPerByte);
     targets = bench
 );
+
 criterion_main!(benches);

--- a/benches/src/chacha20poly1305.rs
+++ b/benches/src/chacha20poly1305.rs
@@ -1,12 +1,16 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use criterion_cycles_per_byte::CyclesPerByte;
 
 use chacha20poly1305::aead::{Aead, KeyInit};
 use chacha20poly1305::ChaCha20Poly1305;
 
 const KB: usize = 1024;
 
-fn bench(c: &mut Criterion<CyclesPerByte>) {
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+type Benchmarker = Criterion;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+type Benchmarker = Criterion<criterion_cycles_per_byte::CyclesPerByte>;
+
+fn bench(c: &mut Benchmarker) {
     let mut group = c.benchmark_group("chacha20poly1305");
 
     for size in &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
@@ -27,9 +31,18 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     group.finish();
 }
 
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench
+);
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
     config = Criterion::default().with_measurement(CyclesPerByte);
     targets = bench
 );
+
 criterion_main!(benches);

--- a/benches/src/deoxys.rs
+++ b/benches/src/deoxys.rs
@@ -1,12 +1,16 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use criterion_cycles_per_byte::CyclesPerByte;
 
 use deoxys::aead::{Aead, KeyInit};
 use deoxys::{DeoxysI128, DeoxysI256, DeoxysII128, DeoxysII256};
 
 const KB: usize = 1024;
 
-fn bench(c: &mut Criterion<CyclesPerByte>) {
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+type Benchmarker = Criterion;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+type Benchmarker = Criterion<criterion_cycles_per_byte::CyclesPerByte>;
+
+fn bench(c: &mut Benchmarker) {
     let mut group = c.benchmark_group("deoxys");
 
     for size in &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
@@ -55,9 +59,18 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     group.finish();
 }
 
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench
+);
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
     config = Criterion::default().with_measurement(CyclesPerByte);
     targets = bench
 );
+
 criterion_main!(benches);

--- a/benches/src/eax.rs
+++ b/benches/src/eax.rs
@@ -1,5 +1,4 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use criterion_cycles_per_byte::CyclesPerByte;
 
 use eax::aead::{Aead, KeyInit};
 
@@ -8,7 +7,12 @@ type EaxAes256 = eax::Eax<aes::Aes256>;
 
 const KB: usize = 1024;
 
-fn bench(c: &mut Criterion<CyclesPerByte>) {
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+type Benchmarker = Criterion;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+type Benchmarker = Criterion<criterion_cycles_per_byte::CyclesPerByte>;
+
+fn bench(c: &mut Benchmarker) {
     let mut group = c.benchmark_group("eax");
 
     for size in &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
@@ -38,9 +42,18 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     group.finish();
 }
 
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench
+);
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
     config = Criterion::default().with_measurement(CyclesPerByte);
     targets = bench
 );
+
 criterion_main!(benches);


### PR DESCRIPTION
This also bumps the versions of `criterion`, `aes` and `criterion-cycles-per-byte`.

I'm not sure how verbose I should've been with the `cfg`s, let me know if there's a preferred style and I'd be happy to change them!