### PR TITLE
benches: fix compilation

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.56"
 
 [dependencies]
 criterion = "0.4.0"
+rand = "0.8.5"
 aes = "0.8.2"
 aes-gcm = { path = "../aes-gcm/" }
 aes-gcm-siv = { path = "../aes-gcm-siv/" }

--- a/benches/src/aes-gcm-siv.rs
+++ b/benches/src/aes-gcm-siv.rs
@@ -50,7 +50,7 @@ criterion_group!(
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
-    config = Criterion::default().with_measurement(CyclesPerByte);
+    config = Criterion::default().with_measurement(criterion_cycles_per_byte::CyclesPerByte);
     targets = bench
 );
 

--- a/benches/src/aes-gcm.rs
+++ b/benches/src/aes-gcm.rs
@@ -50,7 +50,7 @@ criterion_group!(
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
-    config = Criterion::default().with_measurement(CyclesPerByte);
+    config = Criterion::default().with_measurement(criterion_cycles_per_byte::CyclesPerByte);
     targets = bench
 );
 

--- a/benches/src/chacha20poly1305.rs
+++ b/benches/src/chacha20poly1305.rs
@@ -41,7 +41,7 @@ criterion_group!(
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
-    config = Criterion::default().with_measurement(CyclesPerByte);
+    config = Criterion::default().with_measurement(criterion_cycles_per_byte::CyclesPerByte);
     targets = bench
 );
 

--- a/benches/src/deoxys.rs
+++ b/benches/src/deoxys.rs
@@ -36,7 +36,6 @@ fn bench(c: &mut Benchmarker) {
             b.iter(|| cipher.decrypt(&Default::default(), &*buf))
         });
 
-
         group.bench_function(BenchmarkId::new("encrypt-II-128", size), |b| {
             let cipher = DeoxysII128::new(&Default::default());
             b.iter(|| cipher.encrypt(&Default::default(), &*buf))
@@ -69,7 +68,7 @@ criterion_group!(
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
-    config = Criterion::default().with_measurement(CyclesPerByte);
+    config = Criterion::default().with_measurement(criterion_cycles_per_byte::CyclesPerByte);
     targets = bench
 );
 

--- a/benches/src/eax.rs
+++ b/benches/src/eax.rs
@@ -52,7 +52,7 @@ criterion_group!(
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 criterion_group!(
     name = benches;
-    config = Criterion::default().with_measurement(CyclesPerByte);
+    config = Criterion::default().with_measurement(criterion_cycles_per_byte::CyclesPerByte);
     targets = bench
 );
 


### PR DESCRIPTION
I must apologize - it appears my PR from the other day (#515) broke benchmarks on `x86_64` and `x86`.

I didn't realize as I was developing on `Aarch64`, but I'm not too sure why CI didn't pick it up.

The benchmark crate also refused to compile due to the `ascon-aead` benches - they attempt to use `rand` as a dependency but it wasn't specified.