### PR TITLE
xsalsa20poly1305: deprecate in favor of `crypto_secretbox`

### DIFF
--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "xsalsa20poly1305"
 version = "0.9.0"
-description = """
-Pure Rust implementation of the XSalsa20Poly1305 (a.k.a. NaCl crypto_secretbox)
-authenticated encryption algorithm
-"""
+description = "DEPRECATED: please use the `crypto_secretbox` crate"
 authors = ["RustCrypto Developers"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/xsalsa20poly1305/README.md
+++ b/xsalsa20poly1305/README.md
@@ -7,6 +7,14 @@
 [![Project Chat][chat-image]][chat-link]
 [![Build Status][build-image]][build-link]
 
+## 🚨 DEPRECATED! 🚨
+
+Please switch to the [`crypto_secretbox`] crate.
+
+This crate is deprecated and will not receive further updates.
+
+## About
+
 **XSalsa20Poly1305** (a.k.a. NaCl [`crypto_secretbox`][1]) is an
 [authenticated encryption][2] cipher amenable to fast, constant-time
 implementations in software, based on the [Salsa20][3] stream cipher 
@@ -54,6 +62,8 @@ dual licensed as above, without any additional terms or conditions.
 [build-link]: https://github.com/RustCrypto/AEADs/actions
 
 [//]: # (general links)
+
+[`crypto_secretbox`]: https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretbox
 
 [1]: https://nacl.cr.yp.to/secretbox.html
 [2]: https://en.wikipedia.org/wiki/Authenticated_encryption


### PR DESCRIPTION
The `crypto_secretbox` crate is forked from `xsalsa20poly1305`, but modified and expanded to support the libsodium flavor of XChaCha20Poly1305 in addition to XSalsa20Poly1305.

Further updates will happen on `crypto_secretbox`:

https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretbox