### PR TITLE
xsalsa20poly1305 v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aead",
  "poly1305",

--- a/xsalsa20poly1305/CHANGELOG.md
+++ b/xsalsa20poly1305/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1 (2023-05-16)
+
+Deprecate `xsalsa20poly1305` in favor of `crypto_secretbox` ([#525])
+
+[#525]: https://github.com/RustCrypto/AEADs/pull/525
+
 ## 0.9.0 (2022-07-31)
 ### Added
 - `getrandom` feature ([#446])

--- a/xsalsa20poly1305/Cargo.toml
+++ b/xsalsa20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsalsa20poly1305"
-version = "0.9.0"
+version = "0.9.1"
 description = "DEPRECATED: please use the `crypto_secretbox` crate"
 authors = ["RustCrypto Developers"]
 edition = "2021"


### PR DESCRIPTION
Deprecate `xsalsa20poly1305` in favor of `crypto_secretbox` ([#525])

[#525]: https://github.com/RustCrypto/AEADs/pull/525