### PR TITLE
ascon-aead: Add ascon sponge Zeroize feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,9 @@ name = "ascon"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e716048a18530cce4684daf98a7563a499d710e1ed8ef35567fcb43a7c5f1"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "ascon-aead"

--- a/ascon-aead/Cargo.toml
+++ b/ascon-aead/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.56"
 [dependencies]
 aead = { version = "0.5", default-features = false }
 subtle = { version = "2", default-features = false }
-zeroize = { version = "1.6", optional = true, default-features = false, features = [
+zeroize_crate = { package = "zeroize", version = "1.6", optional = true, default-features = false, features = [
     "derive",
 ] }
 ascon = "0.4"
@@ -27,7 +27,7 @@ hex-literal = "0.3"
 aead = { version = "0.5", features = ["alloc"] }
 
 [features]
-default = ["alloc", "getrandom", "zeroize"]
+default = ["alloc", "getrandom"]
 std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
@@ -35,6 +35,7 @@ getrandom = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]
 stream = ["aead/stream"]
+zeroize = ["zeroize_crate", "ascon/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ascon-aead/src/lib.rs
+++ b/ascon-aead/src/lib.rs
@@ -98,6 +98,9 @@
 //! Similarly, enabling the `arrayvec` feature of this crate will provide an impl of
 //! [`aead::Buffer`] for `arrayvec::ArrayVec`.
 
+#[cfg(feature = "zeroize")]
+extern crate zeroize_crate as zeroize;
+
 pub use aead::{self, Error, Key, Nonce, Tag};
 use aead::{
     consts::{U0, U16, U20},


### PR DESCRIPTION
Not zeroizing the state may expose the private key.

As the MSRV is below 1.60 the `dep:` syntax is not available. Hence, the second feature `sponge-zeroize`. Any other suggestions to handle it better are welcome.

This relies on https://github.com/RustCrypto/sponges/pull/57 and a new release of the `ascon` crate.