### PR TITLE
CI: fix security audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,3 +1,5 @@
 [advisories]
-ignore = ["RUSTSEC-2019-0029", "RUSTSEC-2020-0145", "RUSTSEC-2020-0146"]
+ignore = [
+    "RUSTSEC-2023-0037", # xsalsa20poly1305 unmaintained
+]
 informational_warnings = ["unmaintained", "unsound"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,9 +533,9 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "spin"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
We're getting flagged for our own `xsalsa20poly1305` crate.

Also bumps `spin` to a non-vulnerable version.