### PR TITLE
Fix `clippy::needless_borrow` and `clippy::explicit_auto_deref`

### DIFF
--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -220,7 +220,7 @@ where
         // final component -- i.e., the string immediately preceding the
         // plaintext in the vector input to S2V -- is used for the nonce."
         // https://tools.ietf.org/html/rfc5297#section-3
-        Siv::<C, M>::new(&self.key).encrypt_in_place(&[associated_data, nonce.as_slice()], buffer)
+        Siv::<C, M>::new(&self.key).encrypt_in_place([associated_data, nonce.as_slice()], buffer)
     }
 
     fn encrypt_in_place_detached(
@@ -230,7 +230,7 @@ where
         buffer: &mut [u8],
     ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
         Siv::<C, M>::new(&self.key)
-            .encrypt_in_place_detached(&[associated_data, nonce.as_slice()], buffer)
+            .encrypt_in_place_detached([associated_data, nonce.as_slice()], buffer)
     }
 
     fn decrypt_in_place(
@@ -239,7 +239,7 @@ where
         associated_data: &[u8],
         buffer: &mut dyn Buffer,
     ) -> Result<(), Error> {
-        Siv::<C, M>::new(&self.key).decrypt_in_place(&[associated_data, nonce.as_slice()], buffer)
+        Siv::<C, M>::new(&self.key).decrypt_in_place([associated_data, nonce.as_slice()], buffer)
     }
 
     fn decrypt_in_place_detached(
@@ -250,7 +250,7 @@ where
         tag: &GenericArray<u8, Self::TagSize>,
     ) -> Result<(), Error> {
         Siv::<C, M>::new(&self.key).decrypt_in_place_detached(
-            &[associated_data, nonce.as_slice()],
+            [associated_data, nonce.as_slice()],
             buffer,
             tag,
         )

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -35,9 +35,9 @@ where
     pub(crate) fn new(mut cipher: C) -> Self {
         // Derive Poly1305 key from the first 32-bytes of the ChaCha20 keystream
         let mut mac_key = poly1305::Key::default();
-        cipher.apply_keystream(&mut *mac_key);
+        cipher.apply_keystream(&mut mac_key);
 
-        let mac = Poly1305::new(GenericArray::from_slice(&*mac_key));
+        let mac = Poly1305::new(GenericArray::from_slice(&mac_key));
         mac_key.zeroize();
 
         // Set ChaCha20 counter to 1

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -284,8 +284,8 @@ where
     pub(crate) fn new(mut cipher: C) -> Self {
         // Derive Poly1305 key from the first 32-bytes of the Salsa20 keystream
         let mut mac_key = poly1305::Key::default();
-        cipher.apply_keystream(&mut *mac_key);
-        let mac = Poly1305::new(GenericArray::from_slice(&*mac_key));
+        cipher.apply_keystream(&mut mac_key);
+        let mac = Poly1305::new(GenericArray::from_slice(&mac_key));
         mac_key.zeroize();
 
         Self { cipher, mac }


### PR DESCRIPTION
Fixes warnings on `clippy::needless_borrow` and `clippy::explicit_auto_deref`.