### PR TITLE
fix: `missing_debug_implementations`

### DIFF
--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -5,7 +5,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 //! # Usage
 //!
@@ -123,7 +123,7 @@ pub type Aes256GcmSiv = AesGcmSiv<Aes256>;
 type Ctr32LE<Aes> = ctr::CtrCore<Aes, ctr::flavors::Ctr32LE>;
 
 /// AES-GCM-SIV: Misuse-Resistant Authenticated Encryption Cipher (RFC 8452).
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AesGcmSiv<Aes> {
     /// Key generating key used to derive AES-GCM-SIV subkeys.
     key_generating_key: Aes,

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -6,7 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 //! # Usage
 //!
@@ -189,7 +189,7 @@ type Ctr32BE<Aes> = ctr::CtrCore<Aes, ctr::flavors::Ctr32BE>;
 /// the default of 128-bits.
 ///
 /// If in doubt, use the built-in [`Aes128Gcm`] and [`Aes256Gcm`] type aliases.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AesGcm<Aes, NonceSize, TagSize = U16>
 where
     TagSize: self::TagSize,

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -5,7 +5,12 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications
+)]
 
 //! # Usage
 //!
@@ -113,6 +118,7 @@ pub type Tag = GenericArray<u8, U16>;
 /// The `SivAead` type wraps the more powerful `Siv` interface in a more
 /// commonly used Authenticated Encryption with Associated Data (AEAD) API,
 /// which accepts a key, nonce, and associated data when encrypting/decrypting.
+#[derive(Debug)]
 pub struct SivAead<C, M>
 where
     Self: KeySizeUser,

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -220,7 +220,7 @@ where
         // final component -- i.e., the string immediately preceding the
         // plaintext in the vector input to S2V -- is used for the nonce."
         // https://tools.ietf.org/html/rfc5297#section-3
-        Siv::<C, M>::new(&self.key).encrypt_in_place(&[associated_data, nonce.as_slice()], buffer)
+        Siv::<C, M>::new(&self.key).encrypt_in_place([associated_data, nonce.as_slice()], buffer)
     }
 
     fn encrypt_in_place_detached(
@@ -230,7 +230,7 @@ where
         buffer: &mut [u8],
     ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
         Siv::<C, M>::new(&self.key)
-            .encrypt_in_place_detached(&[associated_data, nonce.as_slice()], buffer)
+            .encrypt_in_place_detached([associated_data, nonce.as_slice()], buffer)
     }
 
     fn decrypt_in_place(
@@ -239,7 +239,7 @@ where
         associated_data: &[u8],
         buffer: &mut dyn Buffer,
     ) -> Result<(), Error> {
-        Siv::<C, M>::new(&self.key).decrypt_in_place(&[associated_data, nonce.as_slice()], buffer)
+        Siv::<C, M>::new(&self.key).decrypt_in_place([associated_data, nonce.as_slice()], buffer)
     }
 
     fn decrypt_in_place_detached(
@@ -250,7 +250,7 @@ where
         tag: &GenericArray<u8, Self::TagSize>,
     ) -> Result<(), Error> {
         Siv::<C, M>::new(&self.key).decrypt_in_place_detached(
-            &[associated_data, nonce.as_slice()],
+            [associated_data, nonce.as_slice()],
             buffer,
             tag,
         )

--- a/aes-siv/src/siv.rs
+++ b/aes-siv/src/siv.rs
@@ -38,6 +38,7 @@ pub type KeySize<C> = <<C as KeySizeUser>::KeySize as Add>::Output;
 
 /// Synthetic Initialization Vector (SIV) mode, providing misuse-resistant
 /// authenticated encryption (MRAE).
+#[derive(Debug)]
 pub struct Siv<C, M>
 where
     C: BlockCipher<BlockSize = U16> + BlockEncryptMut + KeyInit + KeySizeUser,

--- a/ascon-aead/src/asconcore.rs
+++ b/ascon-aead/src/asconcore.rs
@@ -56,7 +56,7 @@ pub(crate) trait InternalKey<KS: ArrayLength<u8>>:
     fn get_k2(&self) -> u64;
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub(crate) struct InternalKey16(u64, u64);
 
@@ -83,7 +83,7 @@ impl From<&GenericArray<u8, U16>> for InternalKey16 {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub(crate) struct InternalKey20(u64, u64, u32);
 
@@ -134,6 +134,7 @@ pub(crate) trait Parameters {
 }
 
 /// Parameters for Ascon-128
+#[derive(Debug)]
 pub(crate) struct Parameters128;
 
 impl Parameters for Parameters128 {
@@ -145,6 +146,7 @@ impl Parameters for Parameters128 {
 }
 
 /// Parameters for Ascon-128a
+#[derive(Debug)]
 pub(crate) struct Parameters128a;
 
 impl Parameters for Parameters128a {
@@ -156,6 +158,7 @@ impl Parameters for Parameters128a {
 }
 
 /// Parameters for Ascon-80pq
+#[derive(Debug)]
 pub(crate) struct Parameters80pq;
 
 impl Parameters for Parameters80pq {

--- a/ascon-aead/src/lib.rs
+++ b/ascon-aead/src/lib.rs
@@ -8,7 +8,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![warn(missing_docs)]
+#![warn(missing_debug_implementations, missing_docs)]
 
 //! ## Usage
 //!
@@ -112,7 +112,7 @@ use asconcore::{AsconCore, Parameters, Parameters128, Parameters128a, Parameters
 ///
 /// This type is generic to support substituting various Ascon parameter sets. It is not intended to
 /// be uses directly. Use the [`Ascon128`], [`Ascon128a`], [`Ascon80pq`] type aliases instead.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct Ascon<P: Parameters> {
     key: P::InternalKey,
 }
@@ -173,6 +173,7 @@ impl<P: Parameters> AeadInPlace for Ascon<P> {
 }
 
 /// Ascon-128
+#[derive(Debug)]
 pub struct Ascon128(Ascon<Parameters128>);
 /// Key for Ascon-128
 pub type Ascon128Key = Key<Ascon128>;
@@ -223,6 +224,7 @@ impl AeadInPlace for Ascon128 {
 }
 
 /// Ascon-128a
+#[derive(Debug)]
 pub struct Ascon128a(Ascon<Parameters128a>);
 
 /// Key for Ascon-128a
@@ -274,6 +276,7 @@ impl AeadInPlace for Ascon128a {
 }
 
 /// Ascon-80pq
+#[derive(Debug)]
 pub struct Ascon80pq(Ascon<Parameters80pq>);
 /// Key for Ascon-80pq
 pub type Ascon80pqKey = Key<Ascon80pq>;

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -5,7 +5,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 //! # Usage
 //!
@@ -91,7 +91,7 @@ impl<T: private::SealedNonce> NonceSize for T {}
 /// [`U7`][consts::U7], [`U8`][consts::U8], [`U9`][consts::U9],
 /// [`U10`][consts::U10], [`U11`][consts::U11], [`U12`][consts::U12],
 /// [`U13`][consts::U13].
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Ccm<C, M, N>
 where
     C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockEncrypt,

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -35,9 +35,9 @@ where
     pub(crate) fn new(mut cipher: C) -> Self {
         // Derive Poly1305 key from the first 32-bytes of the ChaCha20 keystream
         let mut mac_key = poly1305::Key::default();
-        cipher.apply_keystream(&mut *mac_key);
+        cipher.apply_keystream(&mut mac_key);
 
-        let mac = Poly1305::new(GenericArray::from_slice(&*mac_key));
+        let mac = Poly1305::new(GenericArray::from_slice(&mac_key));
         mac_key.zeroize();
 
         // Set ChaCha20 counter to 1

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -5,7 +5,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 //! ## Supported Algorithms
 //!
@@ -211,6 +211,7 @@ pub type XChaCha12Poly1305 = ChaChaPoly1305<XChaCha12, U24>;
 /// Generic ChaCha+Poly1305 Authenticated Encryption with Additional Data (AEAD) construction.
 ///
 /// See the [toplevel documentation](index.html) for a usage example.
+#[derive(Debug)]
 pub struct ChaChaPoly1305<C, N: ArrayLength<u8> = U12> {
     /// Secret key.
     key: Key,

--- a/deoxys/src/deoxys_bc.rs
+++ b/deoxys/src/deoxys_bc.rs
@@ -36,9 +36,11 @@ const RCON: [[u8; 16]; 17] = [
 ];
 
 /// Implementation of the Deoxys-BC256 block cipher
+#[derive(Debug)]
 pub struct DeoxysBc256;
 
 /// Implementation of the Deoxys-BC384 block cipher
+#[derive(Debug)]
 pub struct DeoxysBc384;
 
 pub trait DeoxysBcInternal {

--- a/deoxys/src/lib.rs
+++ b/deoxys/src/lib.rs
@@ -4,7 +4,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 //! # Usage
 //!
@@ -223,6 +223,7 @@ pub trait DeoxysBcType: deoxys_bc::DeoxysBcInternal {
 /// Generic Deoxys implementation.
 ///
 /// This type is generic to support multiple Deoxys modes(namely Deoxys-I and Deoxys-II) and key size.
+#[derive(Debug)]
 pub struct Deoxys<M, B>
 where
     M: DeoxysMode<B>,

--- a/deoxys/src/modes.rs
+++ b/deoxys/src/modes.rs
@@ -14,12 +14,14 @@ const TWEAK_M_LAST: u8 = 0x40;
 const TWEAK_CHKSUM: u8 = 0x50;
 
 /// Implementation of the Deoxys-I mode of operation.
+#[derive(Debug)]
 pub struct DeoxysI<B> {
     _ptr: PhantomData<B>,
 }
 
 /// Implementation of the Deoxys-II mode of operation.
 #[allow(clippy::upper_case_acronyms)]
+#[derive(Debug)]
 pub struct DeoxysII<B> {
     _ptr: PhantomData<B>,
 }

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -6,7 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 //! # Usage
 //!
@@ -166,7 +166,7 @@ type Ctr128BE<C> = ctr::CtrCore<C, ctr::flavors::Ctr128BE>;
 /// ## Type parameters
 /// - `Cipher`: block cipher.
 /// - `M`: size of MAC tag, valid values: up to `U16`.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Eax<Cipher, M = U16>
 where
     Cipher: BlockCipher<BlockSize = U16> + BlockEncrypt + Clone + KeyInit,

--- a/eax/src/online.rs
+++ b/eax/src/online.rs
@@ -72,10 +72,12 @@ pub use Eax as EaxOnline;
 pub trait CipherOp {}
 
 /// Marker struct for EAX stream used in encryption mode.
+#[derive(Debug)]
 pub struct Encrypt;
 impl CipherOp for Encrypt {}
 
 /// Marker struct for EAX stream used in decryption mode.
+#[derive(Debug)]
 pub struct Decrypt;
 impl CipherOp for Decrypt {}
 
@@ -148,6 +150,7 @@ impl CipherOp for Decrypt {}
 /// [`Eax`]: ../struct.Eax.html
 /// [`Decrypt`]: struct.Decrypt.html
 /// [`finish`]: #method.finish
+#[derive(Debug)]
 pub struct Eax<Cipher, Op, M = U16>
 where
     Cipher: BlockCipher<BlockSize = U16> + BlockEncrypt + Clone + KeyInit,
@@ -263,6 +266,7 @@ where
 /// Main reason behind extracting the logic to a single, separate type is to
 /// facilitate testing of the internal logic.
 #[doc(hidden)]
+#[derive(Debug)]
 struct EaxImpl<Cipher, M>
 where
     Cipher: BlockCipher<BlockSize = U16> + BlockEncrypt + Clone + KeyInit,

--- a/xsalsa20poly1305/src/lib.rs
+++ b/xsalsa20poly1305/src/lib.rs
@@ -284,8 +284,8 @@ where
     pub(crate) fn new(mut cipher: C) -> Self {
         // Derive Poly1305 key from the first 32-bytes of the Salsa20 keystream
         let mut mac_key = poly1305::Key::default();
-        cipher.apply_keystream(&mut *mac_key);
-        let mac = Poly1305::new(GenericArray::from_slice(&*mac_key));
+        cipher.apply_keystream(&mut mac_key);
+        let mac = Poly1305::new(GenericArray::from_slice(&mac_key));
         mac_key.zeroize();
 
         Self { cipher, mac }


### PR DESCRIPTION
Sets `missing_debug_implementations` to warn and adds missing `std::fmt::Debug` implementations.

When tracing/logging/debugging a program it is common to debug print inputs and outputs of function, to do this generally dependencies need to offer `std::fmt::Debug` implementations.

I won't repeat what is written under [`missing_debug_implementations`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations) which gives some more explanation.