### PR TITLE
aes-gcm: avoid exposing plaintext on tag verification failure

### DIFF
--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -300,10 +300,10 @@ where
         // TODO(tarcieri): interleave encryption with GHASH
         // See: <https://github.com/RustCrypto/AEADs/issues/74>
         let expected_tag = self.compute_tag(mask, associated_data, buffer);
-        ctr.apply_keystream_partial(buffer.into());
 
         use subtle::ConstantTimeEq;
         if expected_tag[..TagSize::to_usize()].ct_eq(tag).into() {
+            ctr.apply_keystream_partial(buffer.into());
             Ok(())
         } else {
             Err(Error)

--- a/aes-gcm/tests/aes128gcm.rs
+++ b/aes-gcm/tests/aes128gcm.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use self::common::TestVector;
-use aes_gcm::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
+use aes_gcm::aead::{generic_array::GenericArray, Aead, AeadInPlace, KeyInit, Payload};
 use aes_gcm::Aes128Gcm;
 use hex_literal::hex;
 

--- a/aes-gcm/tests/aes256gcm.rs
+++ b/aes-gcm/tests/aes256gcm.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use self::common::TestVector;
-use aes_gcm::aead::{generic_array::GenericArray, Aead, KeyInit, Payload};
+use aes_gcm::aead::{generic_array::GenericArray, Aead, AeadInPlace, KeyInit, Payload};
 use aes_gcm::Aes256Gcm;
 use hex_literal::hex;
 


### PR DESCRIPTION
In #409, for whatever reason I moved the application of the keystream from after the tag check to before. This means the keystream is applied unilaterally, instead of only when tag verification is successful.

Sadly, there was a TODO to test for this. A test has been added to ensure the buffer is unmodified on tag verification failure. It was red/green tested to ensure it caught the previous bug, and that the fix corrects it.

This is being tracked as GHSA-423w-p2w9-r7vq (currently embargoed).