### PR TITLE
aes-gcm v0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2023-09-21)
+### Security
+- Avoid exposing plaintext on tag verification failure ([#551])
+
+[#551]: https://github.com/RustCrypto/AEADs/pull/551
+
 ## 0.10.2 (2023-05-20)
 ### Added
 - `rand_core` feature to all crates ([#467])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher


### PR DESCRIPTION
### Security
- Avoid exposing plaintext on tag verification failure ([#551])

[#551]: https://github.com/RustCrypto/AEADs/pull/551