### PR TITLE
Cargo.toml: enable `resolver = "2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ members = [
     "eax",
     "mgm",
 ]
+resolver = "2"


### PR DESCRIPTION
Gets rid of the warning:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Also prevents spurious feature activation between dependencies/dev-dependencies/build-dependencies