### PR TITLE
Insert temporary documentation hard-links as a solution to #575 until https://github.com/rust-lang/rust/issues/120983 is fixed.

### DIFF
--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -163,7 +163,7 @@ pub const C_MAX: u64 = (1 << 36) + 16;
 /// use aes_gcm::{aead::Aead, KeyInit, Key};
 ///
 /// let bad_key_for_bad_nonces = b"01234567890123456789012345678901";
-/// // Key is also a GenericArray and has the same implementations.
+/// // Key is also a GenericArray and thus has the same implementations.
 /// let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(bad_key_for_bad_nonces));
 /// cipher.encrypt(&another_empty_nonce, b"Goodbye World; I've been pwned!".as_ref()).unwrap();
 /// ```

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -131,50 +131,16 @@ pub const C_MAX: u64 = (1 << 36) + 16;
 
 /// AES-GCM nonces.
 ///
-/// Note: This crate uses
-/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
-/// to represent this type internally. See the linked documentation to see available
-/// associated functions and trait implementations.
-///
-/// Note before the examples, you probably want to use [`AeadCore::generate_nonce`] and don't
-/// need to generate nonces yourself.
-///
-/// ```rust
-/// use aes_gcm::{Aes256Gcm, AeadCore, Nonce};
-///
-/// // Generate a 0-initialized GenericArray with the right size to be used as a Nonce
-/// // for a Aes256Gcm.
-/// let empty_nonce_for_aes_256_gcm = Nonce::<<Aes256Gcm as AeadCore>::NonceSize>::default();
-///
-/// // Remember that this crate re-exports aead which re-exports generic_array at the
-/// // correct version for this crate:
-/// use aes_gcm::aead::generic_array::GenericArray;
-///
-/// // Both Aes256Gcm and Aes128Gcm use 12-byte nonces. GenericArray's support casting to and
-/// // from correctly sized arrays and slices and deref to slices similar to regular Rust arrays.
-/// let mut another_empty_nonce =
-///     GenericArray::<u8, <Aes256Gcm as AeadCore>::NonceSize>::from([0u8; 12]);
-/// for (i, byte) in another_empty_nonce.iter_mut().enumerate() {
-///     *byte = i as u8;
-/// }
-///
-/// // They work!
-///
-/// use aes_gcm::{aead::Aead, KeyInit, Key};
-///
-/// let bad_key_for_bad_nonces = b"01234567890123456789012345678901";
-/// // Key is also a GenericArray and thus has the same implementations.
-/// let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(bad_key_for_bad_nonces));
-/// cipher.encrypt(&another_empty_nonce, b"Goodbye World; I've been pwned!".as_ref()).unwrap();
-/// ```
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
 
 /// AES-GCM tags.
 ///
-/// Note: This crate uses
-/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
-/// to represent this type internally. See the linked documentation to see available
-/// associated functions and trait implementations.
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Tag<TagSize = U16> = GenericArray<u8, TagSize>;
 
 /// Trait implemented for valid tag sizes, i.e.

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -130,6 +130,43 @@ pub const P_MAX: u64 = 1 << 36;
 pub const C_MAX: u64 = (1 << 36) + 16;
 
 /// AES-GCM nonces.
+///
+/// Note: This crate uses
+/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
+/// to represent this type internally. See the linked documentation to see available
+/// associated functions and trait implementations.
+///
+/// Note before the examples, you probably want to use [`AeadCore::generate_nonce`] and don't
+/// need to generate nonces yourself.
+///
+/// ```rust
+/// use aes_gcm::{Aes256Gcm, AeadCore, Nonce};
+///
+/// // Generate a 0-initialized GenericArray with the right size to be used as a Nonce
+/// // for a Aes256Gcm.
+/// let empty_nonce_for_aes_256_gcm = Nonce::<<Aes256Gcm as AeadCore>::NonceSize>::default();
+///
+/// // Remember that this crate re-exports aead which re-exports generic_array at the
+/// // correct version for this crate:
+/// use aes_gcm::aead::generic_array::GenericArray;
+///
+/// // Both Aes256Gcm and Aes128Gcm use 12-byte nonces. GenericArray's support casting to and
+/// // from correctly sized arrays and slices and deref to slices similar to regular Rust arrays.
+/// let mut another_empty_nonce =
+///     GenericArray::<u8, <Aes256Gcm as AeadCore>::NonceSize>::from([0u8; 12]);
+/// for (i, byte) in another_empty_nonce.iter_mut().enumerate() {
+///     *byte = i as u8;
+/// }
+///
+/// // They work!
+///
+/// use aes_gcm::{aead::Aead, KeyInit, Key};
+///
+/// let bad_key_for_bad_nonces = b"01234567890123456789012345678901";
+/// // Key is also a GenericArray and has the same implementations.
+/// let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(bad_key_for_bad_nonces));
+/// cipher.encrypt(&another_empty_nonce, b"Goodbye World; I've been pwned!".as_ref()).unwrap();
+/// ```
 pub type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
 
 /// AES-GCM tags.

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -170,6 +170,11 @@ pub const C_MAX: u64 = (1 << 36) + 16;
 pub type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
 
 /// AES-GCM tags.
+///
+/// Note: This crate uses
+/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
+/// to represent this type internally. See the linked documentation to see available
+/// associated functions and trait implementations.
 pub type Tag<TagSize = U16> = GenericArray<u8, TagSize>;
 
 /// Trait implemented for valid tag sizes, i.e.

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -106,51 +106,16 @@ use pmac::Pmac;
 
 /// AES-SIV nonces
 ///
-/// Note: This crate uses
-/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
-/// to represent this type internally. See the linked documentation to see available
-/// associated functions and trait implementations.
-///
-/// Note before the examples, you probably want to use [`AeadCore::generate_nonce`] and don't
-/// need to generate nonces yourself.
-///
-/// ```rust
-/// use aes_siv::{Aes256SivAead, AeadCore, Nonce};
-///
-/// // Generate a 0-initialized GenericArray with the right size to be used as a Nonce
-/// // for a Aes256SivAead.
-/// let empty_nonce_for_aes_256_siv = Nonce::<<Aes256SivAead as AeadCore>::NonceSize>::default();
-///
-/// // Remember that this crate re-exports aead which re-exports generic_array at the
-/// // correct version for this crate:
-/// use aes_siv::aead::generic_array::GenericArray;
-///
-/// // Both Aes256SivAead and Aes128SivAead use 16-byte nonces. GenericArray's support casting to and
-/// // from correctly sized arrays and slices and deref to slices similar to regular Rust arrays.
-/// let mut another_empty_nonce =
-///     GenericArray::<u8, <Aes256SivAead as AeadCore>::NonceSize>::from([0u8; 16]);
-/// for (i, byte) in another_empty_nonce.iter_mut().enumerate() {
-///     *byte = i as u8;
-/// }
-///
-/// // They work!
-///
-/// use aes_siv::{aead::Aead, KeyInit, Key};
-///
-/// let bad_key_for_bad_nonces =
-///     b"I will not use const keys. I will not use const keys. I will not";
-/// // Key is also a GenericArray and thus has the same implementations.
-/// let cipher = Aes256SivAead::new(Key::<Aes256SivAead>::from_slice(bad_key_for_bad_nonces));
-/// cipher.encrypt(&another_empty_nonce, b"Goodbye World; I've been pwned!".as_ref()).unwrap();
-/// ```
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Nonce<NonceSize = U16> = GenericArray<u8, NonceSize>;
 
 /// AES-SIV tags (i.e. the Synthetic Initialization Vector value)
 ///
-/// Note: This crate uses
-/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
-/// to represent this type internally. See the linked documentation to see available
-/// associated functions and trait implementations.
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Tag = GenericArray<u8, U16>;
 
 /// The `SivAead` type wraps the more powerful `Siv` interface in a more

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -105,9 +105,52 @@ use digest::{FixedOutputReset, Mac};
 use pmac::Pmac;
 
 /// AES-SIV nonces
+///
+/// Note: This crate uses
+/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
+/// to represent this type internally. See the linked documentation to see available
+/// associated functions and trait implementations.
+///
+/// Note before the examples, you probably want to use [`AeadCore::generate_nonce`] and don't
+/// need to generate nonces yourself.
+///
+/// ```rust
+/// use aes_siv::{Aes256SivAead, AeadCore, Nonce};
+///
+/// // Generate a 0-initialized GenericArray with the right size to be used as a Nonce
+/// // for a Aes256SivAead.
+/// let empty_nonce_for_aes_256_siv = Nonce::<<Aes256SivAead as AeadCore>::NonceSize>::default();
+///
+/// // Remember that this crate re-exports aead which re-exports generic_array at the
+/// // correct version for this crate:
+/// use aes_siv::aead::generic_array::GenericArray;
+///
+/// // Both Aes256SivAead and Aes128SivAead use 16-byte nonces. GenericArray's support casting to and
+/// // from correctly sized arrays and slices and deref to slices similar to regular Rust arrays.
+/// let mut another_empty_nonce =
+///     GenericArray::<u8, <Aes256SivAead as AeadCore>::NonceSize>::from([0u8; 16]);
+/// for (i, byte) in another_empty_nonce.iter_mut().enumerate() {
+///     *byte = i as u8;
+/// }
+///
+/// // They work!
+///
+/// use aes_siv::{aead::Aead, KeyInit, Key};
+///
+/// let bad_key_for_bad_nonces =
+///     b"I will not use const keys. I will not use const keys. I will not";
+/// // Key is also a GenericArray and thus has the same implementations.
+/// let cipher = Aes256SivAead::new(Key::<Aes256SivAead>::from_slice(bad_key_for_bad_nonces));
+/// cipher.encrypt(&another_empty_nonce, b"Goodbye World; I've been pwned!".as_ref()).unwrap();
+/// ```
 pub type Nonce<NonceSize = U16> = GenericArray<u8, NonceSize>;
 
 /// AES-SIV tags (i.e. the Synthetic Initialization Vector value)
+///
+/// Note: This crate uses
+/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
+/// to represent this type internally. See the linked documentation to see available
+/// associated functions and trait implementations.
 pub type Tag = GenericArray<u8, U16>;
 
 /// The `SivAead` type wraps the more powerful `Siv` interface in a more

--- a/ascon-aead/src/lib.rs
+++ b/ascon-aead/src/lib.rs
@@ -178,10 +178,22 @@ impl<P: Parameters> AeadInPlace for Ascon<P> {
 /// Ascon-128
 pub struct Ascon128(Ascon<Parameters128>);
 /// Key for Ascon-128
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Ascon128Key = Key<Ascon128>;
 /// Nonce for Ascon-128
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Ascon128Nonce = Nonce<Ascon128>;
 /// Tag for Ascon-128
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Ascon128Tag = Tag<Ascon128>;
 
 impl KeySizeUser for Ascon128 {

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -59,59 +59,16 @@ mod private;
 
 /// CCM nonces
 ///
-/// Note: This crate uses
-/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
-/// to represent this type internally. See the linked documentation to see available
-/// associated functions and trait implementations.
-///
-/// Note before the examples, you probably want to use [`AeadCore::generate_nonce`] and don't
-/// need to generate nonces yourself.
-///
-/// ```rust
-/// use ccm::{consts::U13, Nonce};
-///
-/// // Generate a 0-initialized GenericArray to be used as a 13-byte Nonce.
-/// // CCM nonce sizes may be from 7 to 13 with 13 being the strongest.
-/// let empty_13_byte_nonce = Nonce::<U13>::default();
-///
-/// // Remember that this crate re-exports aead which re-exports generic_array at the
-/// // correct version for this crate:
-/// use ccm::aead::generic_array::GenericArray;
-///
-/// // GenericArray's support casting to and from correctly sized arrays and slices and
-/// // deref to slices similar to regular Rust arrays.
-/// let mut another_empty_nonce =
-///     GenericArray::<u8, U13>::from([0u8; 13]);
-/// for (i, byte) in another_empty_nonce.iter_mut().enumerate() {
-///     *byte = i as u8;
-/// }
-///
-/// // If we have a pre-defined Ccm type we want to use, we can use its implementation
-/// // of AeadCore to extract the nonce size it uses.
-/// use ccm::{aead::AeadCore, consts::U10, Ccm};
-/// // As it stands, this crate is currently BYOA (Bring Your Own AES).
-/// use aes::Aes256;
-///
-/// type Aes256Ccm = Ccm<Aes256, U10, U13>;
-/// type NonceSize = <Aes256Ccm as AeadCore>::NonceSize;
-///
-/// // They work!
-///
-/// use ccm::{aead::Aead, KeyInit, Key};
-///
-/// let bad_key_for_bad_nonces = b"01234567890123456789012345678901";
-/// // Key is also a GenericArray and thus has the same implementations.
-/// let cipher = Ccm::<Aes256, U10, U13>::new(Key::<Aes256>::from_slice(bad_key_for_bad_nonces));
-/// cipher.encrypt(&another_empty_nonce, b"Goodbye World; I've been pwned!".as_ref()).unwrap();
-/// ```
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
 
 /// CCM tags
 ///
-/// Note: This crate uses
-/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
-/// to represent this type internally. See the linked documentation to see available
-/// associated functions and trait implementations.
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Tag<TagSize> = GenericArray<u8, TagSize>;
 
 /// Trait implemented for valid tag sizes, i.e.

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -58,9 +58,60 @@ use subtle::ConstantTimeEq;
 mod private;
 
 /// CCM nonces
+///
+/// Note: This crate uses
+/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
+/// to represent this type internally. See the linked documentation to see available
+/// associated functions and trait implementations.
+///
+/// Note before the examples, you probably want to use [`AeadCore::generate_nonce`] and don't
+/// need to generate nonces yourself.
+///
+/// ```rust
+/// use ccm::{consts::U13, Nonce};
+///
+/// // Generate a 0-initialized GenericArray to be used as a 13-byte Nonce.
+/// // CCM nonce sizes may be from 7 to 13 with 13 being the strongest.
+/// let empty_13_byte_nonce = Nonce::<U13>::default();
+///
+/// // Remember that this crate re-exports aead which re-exports generic_array at the
+/// // correct version for this crate:
+/// use ccm::aead::generic_array::GenericArray;
+///
+/// // GenericArray's support casting to and from correctly sized arrays and slices and
+/// // deref to slices similar to regular Rust arrays.
+/// let mut another_empty_nonce =
+///     GenericArray::<u8, U13>::from([0u8; 13]);
+/// for (i, byte) in another_empty_nonce.iter_mut().enumerate() {
+///     *byte = i as u8;
+/// }
+///
+/// // If we have a pre-defined Ccm type we want to use, we can use its implementation
+/// // of AeadCore to extract the nonce size it uses.
+/// use ccm::{aead::AeadCore, consts::U10, Ccm};
+/// // As it stands, this crate is currently BYOA (Bring Your Own AES).
+/// use aes::Aes256;
+///
+/// type Aes256Ccm = Ccm<Aes256, U10, U13>;
+/// type NonceSize = <Aes256Ccm as AeadCore>::NonceSize;
+///
+/// // They work!
+///
+/// use ccm::{aead::Aead, KeyInit, Key};
+///
+/// let bad_key_for_bad_nonces = b"01234567890123456789012345678901";
+/// // Key is also a GenericArray and thus has the same implementations.
+/// let cipher = Ccm::<Aes256, U10, U13>::new(Key::<Aes256>::from_slice(bad_key_for_bad_nonces));
+/// cipher.encrypt(&another_empty_nonce, b"Goodbye World; I've been pwned!".as_ref()).unwrap();
+/// ```
 pub type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
 
 /// CCM tags
+///
+/// Note: This crate uses
+/// [`generic_array::GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html)
+/// to represent this type internally. See the linked documentation to see available
+/// associated functions and trait implementations.
 pub type Tag<TagSize> = GenericArray<u8, TagSize>;
 
 /// Trait implemented for valid tag sizes, i.e.

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -161,7 +161,9 @@ use chacha20::{ChaCha12, ChaCha8, XChaCha12, XChaCha8};
 
 /// Key type (256-bits/32-bytes).
 ///
-/// Implemented as an alias for [`GenericArray`].
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 ///
 /// All [`ChaChaPoly1305`] variants (including `XChaCha20Poly1305`) use this
 /// key type.
@@ -169,17 +171,23 @@ pub type Key = GenericArray<u8, U32>;
 
 /// Nonce type (96-bits/12-bytes).
 ///
-/// Implemented as an alias for [`GenericArray`].
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Nonce = GenericArray<u8, U12>;
 
 /// XNonce type (192-bits/24-bytes).
 ///
-/// Implemented as an alias for [`GenericArray`].
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type XNonce = GenericArray<u8, U24>;
 
 /// Poly1305 tag.
 ///
-/// Implemented as an alias for [`GenericArray`].
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Tag = GenericArray<u8, U16>;
 
 /// ChaCha20Poly1305 Authenticated Encryption with Additional Data (AEAD).

--- a/deoxys/src/lib.rs
+++ b/deoxys/src/lib.rs
@@ -133,9 +133,17 @@ pub type DeoxysII128 = Deoxys<modes::DeoxysII<deoxys_bc::DeoxysBc256>, deoxys_bc
 pub type DeoxysII256 = Deoxys<modes::DeoxysII<deoxys_bc::DeoxysBc384>, deoxys_bc::DeoxysBc384>;
 
 /// Deoxys nonces
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
 
 /// Deoxys tags
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Tag = GenericArray<u8, U16>;
 
 /// Deoxys encryption modes.

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -148,9 +148,17 @@ pub const P_MAX: u64 = 1 << 36;
 pub const C_MAX: u64 = (1 << 36) + 16;
 
 /// EAX nonces
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
 
 /// EAX tags
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Tag<TagSize> = GenericArray<u8, TagSize>;
 
 pub mod online;

--- a/mgm/src/lib.rs
+++ b/mgm/src/lib.rs
@@ -48,11 +48,24 @@ use sealed::Sealed;
 cpufeatures::new!(mul_intrinsics, "sse2", "ssse3", "pclmulqdq");
 
 /// MGM nonces
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
 
 /// MGM tags
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 pub type Tag<TagSize> = GenericArray<u8, TagSize>;
 
+/// MGM blocks
+///
+/// Implemented as an alias for
+/// [`GenericArray`](https://docs.rs/generic-array/0.14.5/generic_array/struct.GenericArray.html).
+/// Note that this crate re-exports aead which re-exports GenericArray.
 type Block<C> = GenericArray<u8, <C as BlockCipher>::BlockSize>;
 // cipher, nonce, aad, buffer
 type EncArgs<'a, C> = (&'a C, &'a Block<C>, &'a [u8], &'a mut [u8]);


### PR DESCRIPTION
Inserts a short doc to each typedef that involves a hard url to the docs.rs link to GenericArray for the reason outlined in the title.