### PR TITLE
Support `no_unroll` for Ascon

### DIFF
--- a/ascon-aead/Cargo.toml
+++ b/ascon-aead/Cargo.toml
@@ -36,6 +36,7 @@ heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]
 stream = ["aead/stream"]
 zeroize = ["zeroize_crate", "ascon/zeroize"]
+no_unroll = ["ascon/no_unroll"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This helps when used on resource constrained systems, e.g. MCUs, to keep the binary size small.