### PR TITLE
ocb3: use `Ocb3` as the type name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hex-literal-impl"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,7 +432,7 @@ dependencies = [
  "aes",
  "cipher 0.4.4",
  "ctr",
- "hex-literal 0.3.4",
+ "hex-literal 0.4.1",
  "subtle",
  "zeroize",
 ]

--- a/ocb3/README.md
+++ b/ocb3/README.md
@@ -18,10 +18,10 @@ use aes::Aes128;
 use ocb3::{
     aead::{Aead, AeadCore, KeyInit, OsRng, generic_array::GenericArray},
     consts::U12,
-    AesOcb3,
+    Ocb3,
 };
 
-type Aes128Ocb3 = AesOcb3<Aes128, U12>;
+type Aes128Ocb3 = Ocb3<Aes128, U12>;
 
 let key = Aes128::generate_key(&mut OsRng);
 let cipher = Aes128Ocb3::new(&key);

--- a/ocb3/tests/kats.rs
+++ b/ocb3/tests/kats.rs
@@ -6,7 +6,7 @@ use aead::{
 };
 use aes::{Aes128, Aes192, Aes256};
 use hex_literal::hex;
-use ocb3::{AesOcb3, GenericArray};
+use ocb3::{GenericArray, Ocb3};
 
 // Test vectors from https://www.rfc-editor.org/rfc/rfc7253.html#appendix-A
 aead::new_test!(rfc7253_ocb_aes, "rfc7253_ocb_aes", Aes128Ocb3);
@@ -83,15 +83,15 @@ macro_rules! rfc7253_wider_variety {
 }
 
 // More types for testing
-type Aes192Ocb3 = AesOcb3<Aes192, U12>;
-type Aes128Ocb3Tag96 = AesOcb3<Aes128, U12, U12>;
-type Aes192Ocb3Tag96 = AesOcb3<Aes192, U12, U12>;
-type Aes256Ocb3Tag96 = AesOcb3<Aes256, U12, U12>;
-type Aes128Ocb3Tag64 = AesOcb3<Aes128, U12, U8>;
-type Aes192Ocb3Tag64 = AesOcb3<Aes192, U12, U8>;
-type Aes256Ocb3Tag64 = AesOcb3<Aes256, U12, U8>;
-type Aes128Ocb3 = AesOcb3<aes::Aes128, U12>;
-type Aes256Ocb3 = AesOcb3<aes::Aes256, U12>;
+type Aes192Ocb3 = Ocb3<Aes192, U12>;
+type Aes128Ocb3Tag96 = Ocb3<Aes128, U12, U12>;
+type Aes192Ocb3Tag96 = Ocb3<Aes192, U12, U12>;
+type Aes256Ocb3Tag96 = Ocb3<Aes256, U12, U12>;
+type Aes128Ocb3Tag64 = Ocb3<Aes128, U12, U8>;
+type Aes192Ocb3Tag64 = Ocb3<Aes192, U12, U8>;
+type Aes256Ocb3Tag64 = Ocb3<Aes256, U12, U8>;
+type Aes128Ocb3 = Ocb3<aes::Aes128, U12>;
+type Aes256Ocb3 = Ocb3<aes::Aes256, U12>;
 
 /// Test vectors from Page 18 of https://www.rfc-editor.org/rfc/rfc7253.html#appendix-A
 #[test]


### PR DESCRIPTION
Renames `AesOcb3` to `Ocb3`.

Unlike AES-GCM, AES-GCM-SIV, and AES-SIV, in which AES is the de facto cipher for that mode, OCB is defined in a more cipher-agnostic way similar to CCM or EAX modes (which, as it were, is reflected in our choice of crate names).

This renames the type to reflect that, and as it were, match the crate name as well.