### PR TITLE
ocb3: restrict minimum `NonceSize` to `U6`

### DIFF
--- a/ocb3/README.md
+++ b/ocb3/README.md
@@ -7,7 +7,8 @@
 [![Project Chat][chat-image]][chat-link]
 [![Build Status][build-image]][build-link]
 
-Pure Rust implementation of **OCB3** ([RFC 7253][rfc7253])[Authenticated Encryption with Associated Data (AEAD)][aead] cipher.
+Pure Rust implementation of the Offset Codebook Mode v3 (OCB3)
+[Authenticated Encryption with Associated Data (AEAD)][aead] cipher as described in [RFC7253].
 
 [Documentation][docs-link]
 


### PR DESCRIPTION
Based on the recommendations of the following paper, which describes an attack against OCB3 mode:

https://eprint.iacr.org/2023/326.pdf

> In the case of OCB3, it is easy to fix the algorithm’s specification
> in order to avoid the weakness and abide to the full assumptions of
> the security proof. If the description is unchanged, the requirement
> N ≥ 6 must become an absolute requirement.

Furthermore, this restricts the minimum tag size to 1-byte, up from the former 0-bytes. This is a questionable choice of minimum but reflects the wording in the RFC:

> The TAGLEN parameter specifies the length of authentication tag used
> by OCB and may be any value up to 128

Closes #592