### PR TITLE
ocb3: fix nonce and tag size bounds

### DIFF
--- a/ocb3/README.md
+++ b/ocb3/README.md
@@ -33,31 +33,6 @@ let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref()).unwrap();
 assert_eq!(&plaintext, b"plaintext message");
 ```
 
-Note that nonce size should be in the range of `6..=15` bytes and tag size in the range of
-`0..=16` bytes. Compilation will fail otherwise:
-
-```rust,compile_fail
-use aes::Aes128;
-use ocb3::{aead::{consts::U5, KeyInit}, Ocb3};
-// Invalid nonce size equal to 5 bytes
-let cipher = ocb3::Ocb3::<Aes128, U5>::new(&[42; 16].into());
-```
-
-```rust,compile_fail
-use aes::Aes128;
-use ocb3::aead::{consts::U16, KeyInit};
-let key = [0; 16].into();
-// Invalid nonce size equal to 16 bytes
-let cipher = ocb3::Ocb3::<Aes128, U16>::new(&[42; 16].into());
-```
-
-```rust,compile_fail
-use aes::Aes128;
-use ocb3::aead::{consts::{U12, U20}, KeyInit};
-// Invalid tag size equal to 20 bytes
-let cipher = ocb3::Ocb3::<Aes128, U12, U20>::new(&[42; 16].into());
-```
-
 ## Security Notes
 
 No security audits of this crate have ever been performed, and it has not been thoroughly assessed to ensure its operation is constant-time on common CPU architectures.

--- a/ocb3/README.md
+++ b/ocb3/README.md
@@ -37,27 +37,25 @@ Note that nonce size should be in the range of `6..=15` bytes and tag size in th
 `0..=16` bytes. Compilation will fail otherwise:
 
 ```rust,compile_fail
-# use aes::Aes128;
-# use ocb3::{aead::{consts::U5, KeyInit}, Ocb3};
-# let key = [0; 16].into();
+use aes::Aes128;
+use ocb3::{aead::{consts::U5, KeyInit}, Ocb3};
 // Invalid nonce size equal to 5 bytes
-let cipher = ocb3::Ocb3::<Aes128, U5>::new(&key);
+let cipher = ocb3::Ocb3::<Aes128, U5>::new(&[42; 16].into());
 ```
 
 ```rust,compile_fail
-# use aes::Aes128;
-# use ocb3::aead::{consts::U16, KeyInit};
-# let key = [0; 16].into();
+use aes::Aes128;
+use ocb3::aead::{consts::U16, KeyInit};
+let key = [0; 16].into();
 // Invalid nonce size equal to 16 bytes
-let cipher = ocb3::Ocb3::<Aes128, U16>::new(&key);
+let cipher = ocb3::Ocb3::<Aes128, U16>::new(&[42; 16].into());
 ```
 
 ```rust,compile_fail
-# use aes::Aes128;
-# use ocb3::aead::{consts::{U12, U20}, KeyInit};
-# let key = [0; 16].into();
+use aes::Aes128;
+use ocb3::aead::{consts::{U12, U20}, KeyInit};
 // Invalid tag size equal to 20 bytes
-let cipher = ocb3::Ocb3::<Aes128, U12, U20>::new(&key);
+let cipher = ocb3::Ocb3::<Aes128, U12, U20>::new(&[42; 16].into());
 ```
 
 ## Security Notes

--- a/ocb3/README.md
+++ b/ocb3/README.md
@@ -33,6 +33,32 @@ let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref()).unwrap();
 assert_eq!(&plaintext, b"plaintext message");
 ```
 
+Note that nonce size should be in the range of `6..=15` bytes and tag size in the range of
+`0..=16` bytes. Compilation will fail otherwise:
+
+```rust,compile_fail
+# use aes::Aes128;
+# use ocb3::{aead::{consts::U5, KeyInit}, Ocb3};
+# let key = [0; 16].into();
+// Invalid nonce size equal to 5 bytes
+let cipher = ocb3::Ocb3::<Aes128, U5>::new(&key);
+```
+
+```rust,compile_fail
+# use aes::Aes128;
+# use ocb3::aead::{consts::U16, KeyInit};
+# let key = [0; 16].into();
+// Invalid nonce size equal to 16 bytes
+let cipher = ocb3::Ocb3::<Aes128, U16>::new(&key);
+```
+
+```rust,compile_fail
+# use aes::Aes128;
+# use ocb3::aead::{consts::{U12, U20}, KeyInit};
+# let key = [0; 16].into();
+// Invalid tag size equal to 20 bytes
+let cipher = ocb3::Ocb3::<Aes128, U12, U20>::new(&key);
+```
 
 ## Security Notes
 


### PR DESCRIPTION
Also adds `compile_fail` tests to check that the sizes are correctly enforced at compile time.

The first commit intentionally does not include the fix to demonstrate that `NonZero` bounds are necessary.