### PR TITLE
feat(aes-gcm-siv): re-export `aes` crate

### DIFF
--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -84,6 +84,9 @@
 
 pub use aead::{self, AeadCore, AeadInPlace, Error, Key, KeyInit, KeySizeUser};
 
+#[cfg(feature = "aes")]
+pub use aes;
+
 use cipher::{
     array::Array,
     consts::{U0, U12, U16},


### PR DESCRIPTION
added to ensure consistency with it's sister `aes-gcm` crate, which also re-exports `aes` ([aes-gcm/src/lib.rs:114](https://github.com/gstand/AEADs/blob/master/aes-gcm/src/lib.rs#L114)).

finds specific use in defining a `Key` generic for example; it takes a `KeySizeUser` which are a majority `Aes*` structs from `aes`, such as: `Key<Aes256>`. 

this change allows the consumer to just reference the re-export as opposed to pulling in the entire `aes` crate to their own crate. i was pivoting from `aes-gcm` to `aes-gcm-siv` myself when i came across this and took it upon myself to smooth out the discrepancy.