### PR TITLE
Use new prerelease dependencies; fix hybrid-array deprecations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.6.0-pre.0"
+version = "0.6.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de53f67567d2692f69357ee20fef7ddf7969d1dff34acefc05db91873aee0ce"
+checksum = "b5f451b77e2f92932dc411da6ef9f3d33efad68a6f14a7a83e559453458e85ac"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -17,9 +17,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-pre"
+version = "0.9.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25512cae539ab9089dcbd69c4f704e787fdc8c1cea8d9daa68a9d89b02b0501f"
+checksum = "183b3b4639f8f7237857117abb74f3dc8648b77e67ff78d9cb6959fd7e76f387"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -104,18 +104,18 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
+checksum = "17092d478f4fadfb35a7e082f62e49f0907fdf048801d9d706277e34f9df8a78"
 dependencies = [
  "crypto-common",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-pre.4"
+version = "0.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ab21a8964437caf2e83a92a1221ce65e356a2a9b8b52d58bece04005fe114e"
+checksum = "0d7992d59cd95a984bde8833d4d025886eec3718777971ad15c58df0b070254a"
 dependencies = [
  "hybrid-array",
 ]
@@ -146,12 +146,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#fea3dd013ee9c35fba56903ad44b411957de8cb2"
+version = "0.10.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6a99ac5abed8864eaedd3b95efdab3e10f41f008f0967bb9c53b093eeb3c62"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "zeroize",
 ]
 
 [[package]]
@@ -167,19 +169,19 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.4"
+version = "0.5.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fba98785cecd0e308818a87c817576a40f99d8bab6405bf422bacd3efb6c1f"
+checksum = "c71c893d5a1e8257048dbb29954d2e1f85f091a150304f1defe4ca2806da5d3f"
 dependencies = [
  "crypto-common",
  "inout",
- "zeroize",
 ]
 
 [[package]]
 name = "cmac"
-version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/MACs.git#43cc597a8881d6924ae56bb22edf19600e981e3e"
+version = "0.8.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16deb366a100cbd9ecd84d1ec674168385f769c95ec3841179663b0f2e6ff4b1"
 dependencies = [
  "cipher",
  "dbl",
@@ -197,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.5"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
+checksum = "8c070b79a496dccd931229780ad5bbedd535ceff6c3565605a8e440e18e1aa2b"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -208,18 +210,18 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-pre.0"
+version = "0.10.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d153f259d848d742d829e332f32466d415e2b9dc247c0ea471e68da953f5e1"
+checksum = "7f1637b299862a663dd5af70ee109d53555eff68b99b454fe535ed6599b0e9b3"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "dbl"
-version = "0.4.0-pre.4"
+version = "0.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977125a36bcb9fcf23cec295ffd25a7499046d5ae95603cd536d4ec1e39bd673"
+checksum = "bb19b576f7e885fac6667774f906b150c9e4df82ed8974d5a99a82bdbee946a8"
 dependencies = [
  "hybrid-array",
 ]
@@ -237,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.8"
+version = "0.11.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
+checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -271,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-pre.0"
+version = "0.6.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f25097bbd647ae1fdd2fd6bcf100b77c5151e26af9cc2d2e81742c2cac27b7"
+checksum = "3b92860fda25ab571512af210134cde2c42732cd53253bcee3f21b288b7afbc4"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -306,18 +308,18 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c2311a0adecbffff284aabcf1249b1485193b16e685f9ef171b1ba82979cff"
+checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "inout"
-version = "0.2.0-pre.4"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2cc35b920cc3b344af824e64e508ffc2c819fc2368ed4d253244446194d2fe"
+checksum = "bbc33218cf9ce7b927426ee4ad3501bcc5d8c26bf5fb4a82849a083715aca427"
 dependencies = [
  "block-padding",
  "hybrid-array",
@@ -351,8 +353,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "pmac"
-version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/MACs.git#43cc597a8881d6924ae56bb22edf19600e981e3e"
+version = "0.8.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b944724c703d6337fd6fe54f72a24e56565efcf64a67b77364eaeabfe7a4c10c"
 dependencies = [
  "cipher",
  "dbl",
@@ -361,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-pre"
+version = "0.9.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c08e786072ace4e4498d7e477e9f8f9ea1a64f1a981ca17be7dc4df1361011"
+checksum = "72844372b6c796d771899186be2c255818fdc21c68d6e2be2c7ffa509ade9df4"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -372,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-pre.0"
+version = "0.7.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3e1736974839c02569293a43b332c95269ccf635391bb7bbc75b41bef249b4"
+checksum = "b01cbf5c028f9f862c6f7f5a5544307d7858634df190488d432ec470c8fbc063"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -446,9 +449,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-pre.0"
+version = "0.6.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05336f34009f6bb1c24794e2c04df87f4a0ced7a091692e395119f34fd3f4c5"
+checksum = "3517d72c5ca6d60f9f2e85d2c772e2652830062a685105a528d19dd823cf87d5"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,3 @@ members = [
     "ocb3",
 ]
 resolver = "2"
-
-[patch.crates-io]
-# https://github.com/RustCrypto/MACs/pull/158
-cmac = { git = "https://github.com/RustCrypto/MACs.git" }
-pmac = { git = "https://github.com/RustCrypto/MACs.git" }
-
-# https://github.com/RustCrypto/stream-ciphers/pull/345
-chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,16 +17,16 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-aead = { version = "=0.6.0-pre.0", default-features = false }
-aes = { version = "=0.9.0-pre", optional = true }
-cipher = "=0.5.0-pre.4"
-ctr = "=0.10.0-pre.0"
-polyval = { version = "=0.7.0-pre.0", default-features = false }
+aead = { version = "0.6.0-rc.0", default-features = false }
+aes = { version = "=0.9.0-pre.1", optional = true }
+cipher = "=0.5.0-pre.6"
+ctr = "=0.10.0-pre.1"
+polyval = { version = "0.7.0-rc.0", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.6.0-pre.0", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
 
 [features]
 default = ["aes", "alloc", "getrandom"]

--- a/aes-gcm-siv/tests/common/mod.rs
+++ b/aes-gcm-siv/tests/common/mod.rs
@@ -16,15 +16,15 @@ macro_rules! tests {
         #[test]
         fn encrypt() {
             for vector in $vectors {
-                let key = Array::from_slice(vector.key);
-                let nonce = Array::from_slice(vector.nonce);
+                let key = Array(*vector.key);
+                let nonce = Array(*vector.nonce);
                 let payload = Payload {
                     msg: vector.plaintext,
                     aad: vector.aad,
                 };
 
-                let cipher = <$aead>::new(key);
-                let ciphertext = cipher.encrypt(nonce, payload).unwrap();
+                let cipher = <$aead>::new(&key);
+                let ciphertext = cipher.encrypt(&nonce, payload).unwrap();
 
                 assert_eq!(vector.ciphertext, ciphertext.as_slice());
             }
@@ -33,16 +33,16 @@ macro_rules! tests {
         #[test]
         fn decrypt() {
             for vector in $vectors {
-                let key = Array::from_slice(vector.key);
-                let nonce = Array::from_slice(vector.nonce);
+                let key = Array(*vector.key);
+                let nonce = Array(*vector.nonce);
 
                 let payload = Payload {
                     msg: vector.ciphertext,
                     aad: vector.aad,
                 };
 
-                let cipher = <$aead>::new(key);
-                let plaintext = cipher.decrypt(nonce, payload).unwrap();
+                let cipher = <$aead>::new(&key);
+                let plaintext = cipher.decrypt(&nonce, payload).unwrap();
 
                 assert_eq!(vector.plaintext, plaintext.as_slice());
             }
@@ -51,8 +51,8 @@ macro_rules! tests {
         #[test]
         fn decrypt_modified() {
             let vector = &$vectors[1];
-            let key = Array::from_slice(vector.key);
-            let nonce = Array::from_slice(vector.nonce);
+            let key = Array(*vector.key);
+            let nonce = Array(*vector.nonce);
 
             let mut ciphertext = Vec::from(vector.ciphertext);
 
@@ -64,8 +64,8 @@ macro_rules! tests {
                 aad: vector.aad,
             };
 
-            let cipher = <$aead>::new(key);
-            assert!(cipher.decrypt(nonce, payload).is_err());
+            let cipher = <$aead>::new(&key);
+            assert!(cipher.decrypt(&nonce, payload).is_err());
 
             // TODO(tarcieri): test ciphertext is unmodified in in-place API
         }

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,16 +17,16 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-aead = { version = "=0.6.0-pre.0", default-features = false }
-aes = { version = "=0.9.0-pre", optional = true }
-cipher = "=0.5.0-pre.4"
-ctr = "=0.10.0-pre.0"
-ghash = { version = "=0.6.0-pre.0", default-features = false }
+aead = { version = "0.6.0-rc.0", default-features = false }
+aes = { version = "=0.9.0-pre.1", optional = true }
+cipher = "=0.5.0-pre.6"
+ctr = "=0.10.0-pre.1"
+ghash = { version = "0.6.0-rc.0", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.6.0-pre.0", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
 hex-literal = "0.4"
 
 [features]

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -287,7 +287,7 @@ where
         ctr.apply_keystream_partial(buffer.into());
 
         let full_tag = self.compute_tag(mask, associated_data, buffer);
-        Ok(Tag::clone_from_slice(&full_tag[..TagSize::to_usize()]))
+        Ok(Tag::try_from(&full_tag[..TagSize::to_usize()]).expect("tag size mismatch"))
     }
 
     fn decrypt_in_place_detached(

--- a/aes-gcm/tests/other_ivlen.rs
+++ b/aes-gcm/tests/other_ivlen.rs
@@ -34,7 +34,7 @@ mod ivlen8 {
         let plaintext = hex!("8cfa255530c6fbc19d51bd4aeb39c91b");
 
         let ciphertext = Aes128GcmWith8BitNonce::new(&key.into())
-            .encrypt(Array::from_slice(&nonce), &plaintext[..])
+            .encrypt(&Array(nonce), &plaintext[..])
             .unwrap();
 
         let (ct, tag) = ciphertext.split_at(ciphertext.len() - 16);
@@ -69,7 +69,7 @@ mod ivlen1024 {
         let plaintext = hex!("705da82292143d2c949dc4ba014f6396");
 
         let ciphertext = Aes128GcmWith1024BitNonce::new(&key.into())
-            .encrypt(Array::from_slice(&nonce), &plaintext[..])
+            .encrypt(&Array(nonce), &plaintext[..])
             .unwrap();
 
         let (ct, tag) = ciphertext.split_at(ciphertext.len() - 16);

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -17,13 +17,13 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.72"
 
 [dependencies]
-aead = "=0.6.0-pre.0"
-aes = "=0.9.0-pre"
-cipher = "=0.5.0-pre.4"
-cmac = "0.8.0-pre"
-ctr = "=0.10.0-pre.0"
-dbl = "0.4.0-pre.4"
-digest = { version = "0.11.0-pre.8", features = ["mac"] }
+aead = "0.6.0-rc.0"
+aes = "=0.9.0-pre.1"
+cipher = "=0.5.0-pre.6"
+cmac = "=0.8.0-pre.1"
+ctr = "=0.10.0-pre.1"
+dbl = "0.4.0-rc.0"
+digest = { version = "=0.11.0-pre.9", features = ["mac"] }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies

--- a/aes-siv/src/siv.rs
+++ b/aes-siv/src/siv.rs
@@ -93,9 +93,10 @@ where
         // Use the first half of the key as the MAC key and
         // the second one as the encryption key
         let (mac_key, enc_key) = key.split_at(M::key_size());
+
         Self {
-            encryption_key: Array::clone_from_slice(enc_key),
-            mac: <M as KeyInit>::new(Array::from_slice(mac_key)),
+            encryption_key: enc_key.try_into().expect("encryption key size mismatch"),
+            mac: <M as KeyInit>::new(mac_key.try_into().expect("MAC key size mismatch")),
         }
     }
 }
@@ -203,7 +204,7 @@ where
             return Err(Error);
         }
 
-        let siv_tag = Tag::clone_from_slice(&buffer.as_ref()[..IV_SIZE]);
+        let siv_tag = Tag::try_from(&buffer.as_ref()[..IV_SIZE]).expect("tag size mismatch");
         self.decrypt_in_place_detached(headers, &mut buffer.as_mut()[IV_SIZE..], &siv_tag)?;
 
         let pt_len = buffer.len() - IV_SIZE;

--- a/aes-siv/tests/siv.rs
+++ b/aes-siv/tests/siv.rs
@@ -18,7 +18,7 @@ macro_rules! tests {
         #[test]
         fn encrypt() {
             for vector in $vectors {
-                let mut cipher = <$siv>::new(Array::from_slice(vector.key));
+                let mut cipher = <$siv>::new(&Array(*vector.key));
                 let ciphertext = cipher.encrypt(vector.aad, vector.plaintext).unwrap();
                 assert_eq!(vector.ciphertext, ciphertext.as_slice());
             }
@@ -27,7 +27,7 @@ macro_rules! tests {
         #[test]
         fn decrypt() {
             for vector in $vectors {
-                let mut cipher = <$siv>::new(Array::from_slice(vector.key));
+                let mut cipher = <$siv>::new(&Array(*vector.key));
                 let plaintext = cipher.decrypt(vector.aad, vector.ciphertext).unwrap();
                 assert_eq!(vector.plaintext, plaintext.as_slice());
             }
@@ -41,7 +41,7 @@ macro_rules! tests {
             // Tweak the first byte
             ciphertext[0] ^= 0xaa;
 
-            let mut cipher = <$siv>::new(Array::from_slice(vector.key));
+            let mut cipher = <$siv>::new(&Array(*vector.key));
             assert!(cipher.decrypt(vector.aad, &ciphertext).is_err());
 
             // TODO(tarcieri): test ciphertext is unmodified in in-place API
@@ -63,7 +63,7 @@ macro_rules! wycheproof_tests {
                 ct: &[u8],
                 pass: bool,
             ) -> Option<&'static str> {
-                let mut cipher = <$siv>::new(Array::from_slice(key));
+                let mut cipher = <$siv>::new(key.try_into().expect("key size mismatch"));
                 let ciphertext = cipher.encrypt(&[aad], pt).unwrap();
                 if pass && ct != ciphertext.as_slice() {
                     return Some("encryption mismatch");

--- a/ascon-aead/Cargo.toml
+++ b/ascon-aead/Cargo.toml
@@ -15,16 +15,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-aead = { version = "=0.6.0-pre.0", default-features = false }
+aead = { version = "0.6.0-rc.0", default-features = false }
 subtle = { version = "2", default-features = false }
-zeroize_crate = { package = "zeroize", version = "1.6", optional = true, default-features = false, features = [
-    "derive",
-] }
+zeroize = { version = "1.6", optional = true, default-features = false, features = ["derive"] }
 ascon = "0.4"
 
 [dev-dependencies]
 hex-literal = "0.4"
-aead = { version = "=0.6.0-pre.0", features = ["alloc"] }
+aead = { version = "0.6.0-rc.0", features = ["alloc"] }
 
 [features]
 default = ["alloc", "getrandom"]
@@ -35,7 +33,7 @@ getrandom = ["aead/getrandom", "rand_core"]
 heapless = ["aead/heapless"]
 rand_core = ["aead/rand_core"]
 stream = ["aead/stream"]
-zeroize = ["zeroize_crate", "ascon/zeroize"]
+zeroize = ["dep:zeroize", "ascon/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ascon-aead/src/lib.rs
+++ b/ascon-aead/src/lib.rs
@@ -99,7 +99,7 @@
 //! [`aead::Buffer`] for `arrayvec::ArrayVec`.
 
 #[cfg(feature = "zeroize")]
-extern crate zeroize_crate as zeroize;
+pub use zeroize;
 
 pub use aead::{self, Error, Key, Nonce, Tag};
 use aead::{

--- a/ascon-aead/tests/kats_test.rs
+++ b/ascon-aead/tests/kats_test.rs
@@ -3,7 +3,7 @@
 
 use ascon_aead::{
     aead::{Aead, AeadInPlace, KeyInit, Payload},
-    Ascon128, Ascon128a, Ascon80pq, Key, Nonce,
+    Ascon128, Ascon128a, Ascon80pq,
 };
 use hex_literal::hex;
 
@@ -14,10 +14,10 @@ fn run_tv<A: KeyInit + AeadInPlace>(
     associated_data: &[u8],
     ciphertext: &[u8],
 ) {
-    let core = A::new(Key::<A>::from_slice(key));
+    let core = A::new(key.try_into().unwrap());
     let ctxt = core
         .encrypt(
-            Nonce::<A>::from_slice(nonce),
+            nonce.try_into().unwrap(),
             Payload {
                 msg: plaintext,
                 aad: associated_data,
@@ -28,7 +28,7 @@ fn run_tv<A: KeyInit + AeadInPlace>(
 
     let ptxt = core
         .decrypt(
-            Nonce::<A>::from_slice(nonce),
+            nonce.try_into().unwrap(),
             Payload {
                 msg: ciphertext,
                 aad: associated_data,

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -14,14 +14,14 @@ keywords = ["encryption", "aead"]
 rust-version = "1.65"
 
 [dependencies]
-aead = { version = "=0.6.0-pre.0", default-features = false }
-cipher = { version = "=0.5.0-pre.4", default-features = false }
-ctr = { version = "=0.10.0-pre.0", default-features = false }
+aead = { version = "0.6.0-rc.0", default-features = false }
+cipher = { version = "=0.5.0-pre.6", default-features = false }
+ctr = { version = "=0.10.0-pre.1", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.6.0-pre.0", features = ["dev"], default-features = false }
-aes = { version = "=0.9.0-pre" }
+aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
+aes = { version = "=0.9.0-pre.1" }
 hex-literal = "0.4.1"
 
 [features]

--- a/ccm/tests/mod.rs
+++ b/ccm/tests/mod.rs
@@ -14,16 +14,16 @@ fn test_data_len_check() {
     let nonce = hex!("2F1DBD38CE3EDA7C23F04DD650");
 
     type Cipher = Ccm<aes::Aes128, U10, U13>;
-    let key = Array::from_slice(&key);
-    let nonce = Array::from_slice(&nonce);
-    let c = Cipher::new(key);
+    let key = Array(key);
+    let nonce = Array(nonce);
+    let c = Cipher::new(&key);
 
     let mut buf1 = [1; core::u16::MAX as usize];
-    let res = c.encrypt_in_place_detached(nonce, &[], &mut buf1);
+    let res = c.encrypt_in_place_detached(&nonce, &[], &mut buf1);
     assert!(res.is_ok());
 
     let mut buf2 = [1; core::u16::MAX as usize + 1];
-    let res = c.encrypt_in_place_detached(nonce, &[], &mut buf2);
+    let res = c.encrypt_in_place_detached(&nonce, &[], &mut buf2);
     assert!(res.is_err());
 }
 
@@ -36,13 +36,13 @@ fn sp800_38c_examples() {
             $key:expr, $m:ty, $n:ty,
             nonce: $nonce:expr, adata: $adata:expr, pt: $pt:expr, ct: $ct:expr,
         ) => {
-            let key = Array::from_slice(&$key);
-            let c = Ccm::<aes::Aes128, $m, $n>::new(key);
-            let nonce = Array::from_slice(&$nonce);
-            let res = c.encrypt(nonce, Payload { aad: &$adata, msg: &$pt })
+            let key = Array($key);
+            let c = Ccm::<aes::Aes128, $m, $n>::new(&key);
+            let nonce = Array($nonce);
+            let res = c.encrypt(&nonce, Payload { aad: &$adata, msg: &$pt })
                 .unwrap();
             assert_eq!(res, &$ct);
-            let res = c.decrypt(nonce, Payload { aad: &$adata, msg: &$ct })
+            let res = c.decrypt(&nonce, Payload { aad: &$adata, msg: &$ct })
                 .unwrap();
             assert_eq!(res, &$pt);
         };

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -20,25 +20,25 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-aead = { version = "=0.6.0-pre.0", default-features = false }
-chacha20 = { version = "=0.10.0-pre", features = ["zeroize"] }
-cipher = "=0.5.0-pre.4"
-poly1305 = "=0.9.0-pre"
+aead = { version = "0.6.0-rc.0", default-features = false }
+chacha20 = { version = "=0.10.0-pre.1", default-features = false, features = ["xchacha", "zeroize"] }
+cipher = "=0.5.0-pre.6"
+poly1305 = "0.9.0-rc.0"
 zeroize = { version = "1.8", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.6.0-pre.0", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
 
 [features]
-default       = ["alloc", "getrandom"]
-std           = ["aead/std", "alloc"]
-alloc         = ["aead/alloc"]
-arrayvec      = ["aead/arrayvec"]
-getrandom     = ["aead/getrandom", "rand_core"]
-heapless      = ["aead/heapless"]
-rand_core     = ["aead/rand_core"]
+default = ["alloc", "getrandom"]
+std = ["aead/std", "alloc"]
+alloc = ["aead/alloc"]
+arrayvec = ["aead/arrayvec"]
+getrandom = ["aead/getrandom", "rand_core"]
+heapless = ["aead/heapless"]
+rand_core = ["aead/rand_core"]
 reduced-round = []
-stream        = ["aead/stream"]
+stream = ["aead/stream"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -37,7 +37,7 @@ where
         let mut mac_key = poly1305::Key::default();
         cipher.apply_keystream(&mut mac_key);
 
-        let mac = Poly1305::new(Array::from_slice(&mac_key));
+        let mac = Poly1305::new(&mac_key);
         mac_key.zeroize();
 
         // Set ChaCha20 counter to 1

--- a/chacha20poly1305/tests/lib.rs
+++ b/chacha20poly1305/tests/lib.rs
@@ -21,14 +21,14 @@ macro_rules! impl_tests {
     ($cipher:ty, $key:expr, $nonce:expr, $aad:expr, $plaintext:expr, $ciphertext:expr, $tag:expr) => {
         #[test]
         fn encrypt() {
-            let key = Array::from_slice($key);
-            let nonce = Array::from_slice($nonce);
+            let key = Array(*$key);
+            let nonce = Array(*$nonce);
             let payload = Payload {
                 msg: $plaintext,
                 aad: $aad,
             };
 
-            let ciphertext = <$cipher>::new(key).encrypt(nonce, payload).unwrap();
+            let ciphertext = <$cipher>::new(&key).encrypt(&nonce, payload).unwrap();
 
             let tag_begins = ciphertext.len() - 16;
             assert_eq!($ciphertext, &ciphertext[..tag_begins]);
@@ -37,8 +37,8 @@ macro_rules! impl_tests {
 
         #[test]
         fn decrypt() {
-            let key = Array::from_slice($key);
-            let nonce = Array::from_slice($nonce);
+            let key = Array(*$key);
+            let nonce = Array(*$nonce);
 
             let mut ciphertext = Vec::from($ciphertext);
             ciphertext.extend_from_slice($tag);
@@ -47,15 +47,15 @@ macro_rules! impl_tests {
                 aad: $aad,
             };
 
-            let plaintext = <$cipher>::new(key).decrypt(nonce, payload).unwrap();
+            let plaintext = <$cipher>::new(&key).decrypt(&nonce, payload).unwrap();
 
             assert_eq!($plaintext, plaintext.as_slice());
         }
 
         #[test]
         fn decrypt_modified() {
-            let key = Array::from_slice($key);
-            let nonce = Array::from_slice($nonce);
+            let key = Array(*$key);
+            let nonce = Array(*$nonce);
 
             let mut ciphertext = Vec::from($ciphertext);
             ciphertext.extend_from_slice($tag);
@@ -68,8 +68,8 @@ macro_rules! impl_tests {
                 aad: $aad,
             };
 
-            let cipher = <$cipher>::new(key);
-            assert!(cipher.decrypt(nonce, payload).is_err());
+            let cipher = <$cipher>::new(&key);
+            assert!(cipher.decrypt(&nonce, payload).is_err());
         }
     };
 }
@@ -132,7 +132,7 @@ mod chacha20 {
 
     #[test]
     fn clone_impl() {
-        let _ = ChaCha20Poly1305::new(Array::from_slice(KEY)).clone();
+        let _ = ChaCha20Poly1305::new(KEY.into()).clone();
     }
 }
 

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-aead = { version = "=0.6.0-pre.0", default-features = false }
-aes = { version = "=0.9.0-pre", features = ["hazmat"], default-features = false }
+aead = { version = "0.6.0-rc.0", default-features = false }
+aes = { version = "=0.9.0-pre.1", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.6.0-pre.0", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
 hex-literal = "0.4"
 
 [features]

--- a/deoxys/tests/deoxys_i_128.rs
+++ b/deoxys/tests/deoxys_i_128.rs
@@ -20,16 +20,16 @@ fn test_deoxys_i_128_1() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("eec87dce98d29d4078598abd16d550ff");
 
-    let encrypted = DeoxysI128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -40,7 +40,7 @@ fn test_deoxys_i_128_1() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -57,16 +57,16 @@ fn test_deoxys_i_128_2() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("b507e4aee5f9d7cb9eaebd8370f25a98");
 
-    let encrypted = DeoxysI128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -77,7 +77,7 @@ fn test_deoxys_i_128_2() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -94,16 +94,16 @@ fn test_deoxys_i_128_3() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("fbb9c589e3a54df11e8573d94e6b1000");
 
-    let encrypted = DeoxysI128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -114,7 +114,7 @@ fn test_deoxys_i_128_3() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -131,16 +131,16 @@ fn test_deoxys_i_128_4() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext = hex!("4bf8c5ecec375b25acabd687aa605f1a8bb296face74f82527d4944dbb11b757");
 
     let tag: [u8; 16] = hex!("f32754de1727da4909413815a64e6a69");
 
-    let encrypted = DeoxysI128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -151,7 +151,7 @@ fn test_deoxys_i_128_4() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -168,16 +168,16 @@ fn test_deoxys_i_128_5() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext = hex!("cded5a43d3c76e942277c2a1517530ad66037897c985305ede345903ed7585a626");
 
     let tag: [u8; 16] = hex!("cbf5faa6b8398c47f4278d2019161776");
 
-    let encrypted = DeoxysI128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -188,7 +188,7 @@ fn test_deoxys_i_128_5() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -205,17 +205,17 @@ fn test_deoxys_i_128_6() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: [u8; 32] =
         hex!("4bf8c5ecec375b25acabd687aa605f1a8bb296face74f82527d4944dbb11b757");
 
     let tag: [u8; 16] = hex!("a1b897f1901e5d98e17936ec1b4d85b3");
 
-    let encrypted = DeoxysI128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -226,7 +226,7 @@ fn test_deoxys_i_128_6() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -243,17 +243,17 @@ fn test_deoxys_i_128_7() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: [u8; 33] =
         hex!("09af865850abc0bce7d35f664a63e41b1475d0385e31a6551edf69ea9f2f8b8ed4");
 
     let tag: [u8; 16] = hex!("9326c6c2a0b7f065e591eb9050169603");
 
-    let encrypted = DeoxysI128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -264,7 +264,7 @@ fn test_deoxys_i_128_7() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -281,17 +281,17 @@ fn test_deoxys_i_128_8() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext=
         hex!("f86ecad0d69d2c573cdeee96c90f37ac3c861bd5f4d82ac7396dda102adfa7a94f1daab1e537f03b2a6665eaa8ee057eee403db7ced61adbd77b5c286b7afc5ec23f3f9333773f02d533b0c49ecfc6bcd359bc8a3db6ab16b423efc93e2591e5485a5b21a8cf9312a10d76c840bd1a7e9f5a9954cb636b01ebc8e91a550a0123a50883627d5535f0f6a7960f005d5f340e054ea145dd756e37efd91bc774f93d385da7135372bc51d0401e6499784618da55c31e0b7ad1aa09a3e002f3021ce02926c79741992d9d0252761a7ca6667a56f78e81eaf08cf36d4117d9b2349262d411bef955d7408562ed040e1ea85e3aa3dcf942ea5205edec164dbd6304f90da59b9fb4f8fdeb2c2df473f90494cf09c6af69d191abd7baf97058a3694872d01f63afc225e3796251375a7520a5f755b24b8fd153f362ff09c7e85f02e789ed8cf8adabfcde4c764ebdd703dee39b4e90a91ab0377e0bebc61b2ec9b3c4e3ac7fd893e13c5d0e303e7e625281c988a48dcfd9ee4b698a1c2a82927168e754c99338ea24d24b9bba11cdb4472badc038ab01f250d359c4ade703329062c6260d8fcfda3a6b50b641f9e1e5f2107fd6ca77140dba9048919cab4ea21e4178fde08e7213bf0b730c0415331775039e99f11146b0ebb99a8f5f2d2c4e1767b6fed9c7140dfcf01c793e88889cf34b4ecb044fc740f3d4a2cad1f93455cc36b9a0c6");
 
     let tag: [u8; 16] = hex!("5c89d78dbef3d727013b59af859f17da");
 
-    let encrypted = DeoxysI128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -302,7 +302,7 @@ fn test_deoxys_i_128_8() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }

--- a/deoxys/tests/deoxys_i_256.rs
+++ b/deoxys/tests/deoxys_i_256.rs
@@ -20,16 +20,16 @@ fn test_deoxys_i_256_1() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("0001020304050607");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("50b0deaa3c3129d1ea1ef96b7c8db67f");
 
-    let encrypted = DeoxysI256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -40,7 +40,7 @@ fn test_deoxys_i_256_1() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -57,16 +57,16 @@ fn test_deoxys_i_256_2() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("0001020304050607");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("0e641b45bcffb3c07fa7f7d31edc37d2");
 
-    let encrypted = DeoxysI256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -77,7 +77,7 @@ fn test_deoxys_i_256_2() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -94,16 +94,16 @@ fn test_deoxys_i_256_3() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("0001020304050607");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("f343b91c303180ae2ae4f379022087fa");
 
-    let encrypted = DeoxysI256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -114,7 +114,7 @@ fn test_deoxys_i_256_3() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -131,16 +131,16 @@ fn test_deoxys_i_256_4() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("0001020304050607");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext = hex!("2c36c041fa3b1436c5153214131d493be9d014689a6a1e93e4a50989f0342941");
 
     let tag: [u8; 16] = hex!("ae66f78a3abf1bb7608c6fe949effb57");
 
-    let encrypted = DeoxysI256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -151,7 +151,7 @@ fn test_deoxys_i_256_4() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -168,16 +168,16 @@ fn test_deoxys_i_256_5() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("0001020304050607");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext = hex!("fd1ea6745fb5b435751d92be58f5973b84c7589501fcfaff6ce07e2a0e9a72c23e");
 
     let tag: [u8; 16] = hex!("e957add57b7c5924d9a22db6fe03cce7");
 
-    let encrypted = DeoxysI256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -188,7 +188,7 @@ fn test_deoxys_i_256_5() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -205,17 +205,17 @@ fn test_deoxys_i_256_6() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("0001020304050607");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: [u8; 32] =
         hex!("2c36c041fa3b1436c5153214131d493be9d014689a6a1e93e4a50989f0342941");
 
     let tag: [u8; 16] = hex!("6da67607bad9cdd34d702325d52abcdd");
 
-    let encrypted = DeoxysI256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -226,7 +226,7 @@ fn test_deoxys_i_256_6() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -243,17 +243,17 @@ fn test_deoxys_i_256_7() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("0001020304050607");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext: [u8; 33] =
         hex!("705f9db5d50ec6ff0ae28557a5640d32b19504833d5fc6de3baf638cef4cda50bc");
 
     let tag: [u8; 16] = hex!("88f06bac360362824401c8f1385073a8");
 
-    let encrypted = DeoxysI256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -264,7 +264,7 @@ fn test_deoxys_i_256_7() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -281,17 +281,17 @@ fn test_deoxys_i_256_8() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("0001020304050607");
-    let nonce = Array::from_slice(&nonce[..8]);
+    let nonce = Array::try_from(&nonce[..8]).unwrap();
 
     let ciphertext =
         hex!("e94c5c6df7c19474bbdd292baa2555fdbd5e90a35fb94627cdd7dd3b424ca47d6779f3e6997809204263bdbd4825b7d6510995b1c371e582942bd7f6ab909f993cd5b7db5f95e8b8b56e4cdf016f5cab37f662329b32801fda4403f731fa61f7aa16b9a23f2637b1f75fa0b36ced90ce6a1f73aafbb5adca756e0d59b8ae6661f2d3fc409c88d8baf3836fac55df78b9ba522221345f42bd794c26d5d1a83fed0114d1d1b04d3c3b77ff0083647710b316e17896b2081d9375fde1f2fe063e66423a0d413919ffa6b5754d10de8de64d32ede0d02ebe8f8791d8e9f59462b615f4122dd8c3b97671a8c156eb32ebebb3fb91832fd01f6afee9d4ab045fea83ec87743823ea3bd18f7826229c312ad8a4bc9e2f6d1ad520e6d850bd189b4538d10005abf5a7c50f4f8ded6a62b18cd2a7e6bd3159edc3e9b553cbddd419af540da10576e9ea7d49e2fd0dc1c5ee7693504b63b928e4e23b1753147a3d0ad00cc2e6390fba10e925dc536db4eb30cf152ddb0420f8e8eaa8460feb9a7f0be589ccb877732d8d606085536c405c2ba6c03cb68e12f7d14609587a6c478e2a32794290ba35ce6dba21784d8f6faf401920bfc2aa172c3b4d9bea2eae8542b18410d3a40414247a406379855cb78c28e82ab67b62433a4016b15c4abf4f01c372ba4f1562596531cb0337117ad769eaa666b497b7822eba924e358693bc48cf555f70");
 
     let tag: [u8; 16] = hex!("e404257c9cf7eb9774fc288a9ef1592e");
 
-    let encrypted = DeoxysI256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysI256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -302,7 +302,7 @@ fn test_deoxys_i_256_8() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysI256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysI256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }

--- a/deoxys/tests/deoxys_ii_128.rs
+++ b/deoxys/tests/deoxys_ii_128.rs
@@ -20,16 +20,16 @@ fn test_deoxys_ii_128_1() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("97d951f2fd129001483e831f2a6821e9");
 
-    let encrypted = DeoxysII128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -40,7 +40,7 @@ fn test_deoxys_ii_128_1() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -57,16 +57,16 @@ fn test_deoxys_ii_128_2() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("3c197ca5317af5a2b95b178a60553132");
 
-    let encrypted = DeoxysII128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -77,7 +77,7 @@ fn test_deoxys_ii_128_2() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -94,16 +94,16 @@ fn test_deoxys_ii_128_3() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("0a989ed78fa16776cd6c691ea734d874");
 
-    let encrypted = DeoxysII128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -114,7 +114,7 @@ fn test_deoxys_ii_128_3() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -131,16 +131,16 @@ fn test_deoxys_ii_128_4() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext = hex!("fa22f8eb84ee6d2388bdb16150232e856cd5fa3508bc589dad16d284208048c9");
 
     let tag: [u8; 16] = hex!("a381b06ef16db99df089e738c3b4064a");
 
-    let encrypted = DeoxysII128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -151,7 +151,7 @@ fn test_deoxys_ii_128_4() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -168,16 +168,16 @@ fn test_deoxys_ii_128_5() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext = hex!("82bf241958b324ed053555d23315d3cc20935527fc970ff34a9f521a95e302136d");
 
     let tag: [u8; 16] = hex!("0eadc8612d5208c491e93005195e9769");
 
-    let encrypted = DeoxysII128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -188,7 +188,7 @@ fn test_deoxys_ii_128_5() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -205,17 +205,17 @@ fn test_deoxys_ii_128_6() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: [u8; 32] =
         hex!("9cdb554dfc03bff4feeb94df7736038361a76532b6b5a9c0bdb64a74dee983ff");
 
     let tag: [u8; 16] = hex!("bc1a7b5b8e961e65ceff6877ef9e4a98");
 
-    let encrypted = DeoxysII128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -226,7 +226,7 @@ fn test_deoxys_ii_128_6() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -243,17 +243,17 @@ fn test_deoxys_ii_128_7() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: [u8; 33] =
         hex!("801f1b81878faca562c8c6c0859b166c2669fbc54b1784be637827b4905729bdf9");
 
     let tag: [u8; 16] = hex!("fe4e9bcd26b96647350eda1e550cc994");
 
-    let encrypted = DeoxysII128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -264,7 +264,7 @@ fn test_deoxys_ii_128_7() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -282,17 +282,17 @@ fn test_deoxys_ii_128_8() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext=
         hex!("b8eddddb8d0042bb42fdf675bae285e504b90e4d73e02f99f790b2ffe7815dba40fe4c7bc886ce44505f6ac53d3bba5d3c73efd98daf4b7a5af250a5d100ff5558c211cb03a28d9519502d7d0fc85a6d73e618feb6b503af12cb0330bb9c5743b19996174a84dbf5bac38d10d207067e4ab211a62ad0f85dd8245dfb077443017b7847996fe7ed547b9e02051f1cbe39128e21486b4f73399d0a50d9a1111bed11ebb0547454d0a922633c83f0bba784571f63f55dc33f92e09862471945312d99e40b4ed739556f102afd43055497739a4b22d107e867cc652a5d96974ff785976c82bc1ff89731c780e84a257bb885cd23e00a7bdc7a68e0a1668516fb972721a777429c76cfd4adb45afa554d44a8932d133af8c9254fd3fef2bd0bb65801f2ffbf752f14eaa783e53c2342f021863598e88b20232a0c44e963dd8943e9a54213ffbb174b90e38b55aa9b223e9596acb1517ff21b7458b7694488047797c521883c00762e7227f1e8a5e3f11a43962bdccde8dc4009aef7628a96efa8793d6080982f9b00a7b97d93fd5928702e78427f34eb434e2286de00216b405c36105dc2e8dae68c3342a23274b32a6d2d8ac85239a8fa2947126f505a517fb18847104b21b0326b7fd67efb54f5d0b12b311ef998ebaf14939b7cdb44b35435eedf1ba5b07eea99533f1857b8cc1538290a8dbd44ca696c6bc2f1105451032a650c");
 
     let tag: [u8; 16] = hex!("e68a5de27beaeb6472611dfa9783602a");
 
-    let encrypted = DeoxysII128::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII128::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -303,7 +303,7 @@ fn test_deoxys_ii_128_8() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII128::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII128::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }

--- a/deoxys/tests/deoxys_ii_256.rs
+++ b/deoxys/tests/deoxys_ii_256.rs
@@ -20,16 +20,16 @@ fn test_deoxys_ii_256_1() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("2b97bd77712f0cde975309959dfe1d7c");
 
-    let encrypted = DeoxysII256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -40,7 +40,7 @@ fn test_deoxys_ii_256_1() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -57,16 +57,16 @@ fn test_deoxys_ii_256_2() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("54708ae5565a71f147bdb94d7ba3aed7");
 
-    let encrypted = DeoxysII256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -77,7 +77,7 @@ fn test_deoxys_ii_256_2() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -94,16 +94,16 @@ fn test_deoxys_ii_256_3() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: Vec<u8> = Vec::new();
 
     let tag: [u8; 16] = hex!("3277689dc4208cc1ff59d15434a1baf1");
 
-    let encrypted = DeoxysII256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -114,7 +114,7 @@ fn test_deoxys_ii_256_3() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(plaintext, decrypted);
 }
@@ -131,16 +131,16 @@ fn test_deoxys_ii_256_4() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext = hex!("9da20db1c2781f6669257d87e2a4d9be1970f7581bef2c995e1149331e5e8cc1");
 
     let tag: [u8; 16] = hex!("92ce3aec3a4b72ff9eab71c2a93492fa");
 
-    let encrypted = DeoxysII256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -151,7 +151,7 @@ fn test_deoxys_ii_256_4() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -168,16 +168,16 @@ fn test_deoxys_ii_256_5() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext = hex!("e5ffd2abc5b459a73667756eda6443ede86c0883fc51dd75d22bb14992c684618c");
 
     let tag: [u8; 16] = hex!("5fa78d57308f19d0252072ee39df5ecc");
 
-    let encrypted = DeoxysII256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -188,7 +188,7 @@ fn test_deoxys_ii_256_5() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -205,17 +205,17 @@ fn test_deoxys_ii_256_6() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: [u8; 32] =
         hex!("109f8a168b36dfade02628a9e129d5257f03cc7912aefa79729b67b186a2b08f");
 
     let tag: [u8; 16] = hex!("6549f9bf10acba0a451dbb2484a60d90");
 
-    let encrypted = DeoxysII256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -226,7 +226,7 @@ fn test_deoxys_ii_256_6() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -243,17 +243,17 @@ fn test_deoxys_ii_256_7() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext: [u8; 33] =
         hex!("7d772203fa38be296d8d20d805163130c69aba8cb16ed845c2296c61a8f34b394e");
 
     let tag: [u8; 16] = hex!("0b3f10e3933c78190b24b33008bf80e9");
 
-    let encrypted = DeoxysII256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -264,7 +264,7 @@ fn test_deoxys_ii_256_7() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }
@@ -282,17 +282,17 @@ fn test_deoxys_ii_256_8() {
     };
 
     let key = hex!("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
-    let key = Array::from_slice(&key);
+    let key = Array(key);
 
     let nonce = hex!("202122232425262728292a2b2c2d2e2f");
-    let nonce = Array::from_slice(&nonce[..15]);
+    let nonce = Array::try_from(&nonce[..15]).unwrap();
 
     let ciphertext =
         hex!("88294fcef65a1bdfd7baaa472816c64ef5bef2622b88c1ec5a739396157ef4935f3aa76449e391c32da28ee2857f399ac3dd95aed30cfb26cc0063cd4cd8f7431108176fbf370123856662b000a8348e5925fbb97c9ec0c737758330a7983f06b51590c1d2f5e5faaf0eb58e34e19e5fc85cec03d3926dd46a79ba7026e83dec24e07484c9103dd0cdb0edb505500caca5e1d5dbc71348cf00648821488ebaab7f9d84bbbf91b3c521dbef30110e7bd94f8dad5ab8e0cc5411ca9682d210d5d80c0c4bdbba8181789a4273d6deb80899fdcd976ca6f3a9770b54305f586a04256cfbeb4c11254e88559f294db3b9a94b80ab9f9a02cb4c0748de0af7818685521691dba5738be546dba13a56016fb8635af9dff50f25d1b17ad21707db2640a76a741e65e559b2afaaec0f37e18436bf02008f84dbd7b2698687a22376b65dc7524fca8a28709eee3f3caee3b28ed1173d1e08ee849e2ca63d2c90d555755c8fbafd5d2f4b37f06a1dbd6852ee2ffcfe79d510152e98fc4f3094f740a4aede9ee378b606d34576776bf5f1269f5385a84b3928433bfca177550ccfcd22cd0331bbc595e38c2758b2662476fa66354c4e84c7b360405aa3f5b2a48621bdca1a90c69b21789c91b5b8c568e3c741d99e22f6d7e26f2abed045f1d578b782ab4a5cf2af636d842b3012e180e4b045d8d15b057b69c92398a517053daf9be7c2935e");
 
     let tag: [u8; 16] = hex!("a616f0c218e18b526cf2a3f8c115e262");
 
-    let encrypted = DeoxysII256::new(key).encrypt(nonce, payload).unwrap();
+    let encrypted = DeoxysII256::new(&key).encrypt(&nonce, payload).unwrap();
 
     let tag_begins = encrypted.len() - 16;
     assert_eq!(ciphertext, encrypted[..tag_begins]);
@@ -303,7 +303,7 @@ fn test_deoxys_ii_256_8() {
         aad: &aad,
     };
 
-    let decrypted = DeoxysII256::new(key).decrypt(nonce, payload).unwrap();
+    let decrypted = DeoxysII256::new(&key).decrypt(&nonce, payload).unwrap();
 
     assert_eq!(&plaintext[..], &decrypted[..]);
 }

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -20,15 +20,15 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.71"
 
 [dependencies]
-aead = { version = "=0.6.0-pre.0", default-features = false }
-cipher = "=0.5.0-pre.4"
-cmac = "=0.8.0-pre"
-ctr = "=0.10.0-pre.0"
+aead = { version = "0.6.0-rc.0", default-features = false }
+cipher = "=0.5.0-pre.6"
+cmac = "=0.8.0-pre.1"
+ctr = "=0.10.0-pre.1"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.6.0-pre.0", features = ["dev"], default-features = false }
-aes = "=0.9.0-pre"
+aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
+aes = "=0.9.0-pre.1"
 
 [features]
 default = ["alloc", "getrandom"]

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -256,7 +256,7 @@ where
             .take(OutputSize::<Cmac<Cipher>>::to_usize())
             .collect();
 
-        let tag = Tag::<M>::clone_from_slice(&full_tag[..M::to_usize()]);
+        let tag = Tag::<M>::try_from(&full_tag[..M::to_usize()]).expect("tag size mismatch");
         Ok(tag)
     }
 

--- a/eax/src/online.rs
+++ b/eax/src/online.rs
@@ -358,7 +358,7 @@ where
             .take(Cipher::BlockSize::to_usize())
             .collect();
 
-        Tag::<M>::clone_from_slice(&full_tag[..M::to_usize()])
+        Tag::<M>::try_from(&full_tag[..M::to_usize()]).expect("tag size mismatch")
     }
 
     /// Derives the tag from the encrypted/decrypted message so far.
@@ -377,7 +377,7 @@ where
             .take(Cipher::BlockSize::to_usize())
             .collect();
 
-        Tag::<M>::clone_from_slice(&full_tag[..M::to_usize()])
+        Tag::<M>::try_from(&full_tag[..M::to_usize()]).expect("tag size mismatch")
     }
 
     /// Finishes the decryption stream, verifying whether the associated and

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -16,16 +16,16 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.72"
 
 [dependencies]
-aead = { version = "=0.6.0-pre.0", default-features = false }
-cipher = "=0.5.0-pre.4"
-ctr = "=0.10.0-pre.0"
-dbl = "=0.4.0-pre.4"
+aead = { version = "0.6.0-rc.0", default-features = false }
+cipher = "=0.5.0-pre.6"
+ctr = "=0.10.0-pre.1"
+dbl = "=0.4.0-rc.0"
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "=0.6.0-pre.0", features = ["dev"], default-features = false }
-aes = { version = "=0.9.0-pre", default-features = false }
+aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
+aes = { version = "=0.9.0-pre.1", default-features = false }
 hex-literal = "0.4"
 
 [features]

--- a/ocb3/tests/kats.rs
+++ b/ocb3/tests/kats.rs
@@ -24,7 +24,7 @@ macro_rules! rfc7253_wider_variety {
         let mut key_bytes = vec![0u8; $keylen];
         key_bytes[$keylen - 1] = 8 * $taglen; // taglen in bytes
 
-        let key = Array::from_slice(key_bytes.as_slice());
+        let key = <&Array<_, _>>::try_from(key_bytes.as_slice()).unwrap();
         let ocb = $ocb::new(key);
 
         let mut ciphertext = Vec::new();


### PR DESCRIPTION
This includes the following dependency bumps along with fixing all of the deprecation warnings that come when upgrading `hybrid-array` to v0.2.0-pre.9:

- `aead` v0.6.0-rc.0
- `aes` v0.9.0-pre.1
- `chacha20` v0.10.0-pre.1
- `cipher` v0.5.0-pre.6
- `cmac` v0.8.0-pre.1
- `crypto-common` v0.2.0-rc.0
- `ctr` v0.10.0-pre.1
- `dbl` v0.4.0-rc.0
- `digest` v0.11.0-pre.9
- `ghash` v0.6.0-rc.0
- `hybrid-array` v0.2.0-rc.9
- `pmac` v0.8.0-pre.1
- `poly1305` v0.9.0-rc.0
- `polyval` v0.7.0-rc.0
- `universal-hash` v0.6.0-rc.0