### PR TITLE
Implement trait AeadInto for AES-GCM and ChaCha20-Poly1305

### DIFF
--- a/aes-gcm/tests/aead_into.rs
+++ b/aes-gcm/tests/aead_into.rs
@@ -1,0 +1,52 @@
+use aes_gcm::aead::{ Aead, AeadInto, Payload };
+use aes_gcm::{ Aes256Gcm, KeyInit };
+
+
+/// Confirm that the [AeadInto] implementation produces exactly the same output as the [Aead]
+/// implementation.
+#[test]
+fn test_aeadinto() {
+    let key = [0x60, 0xaf, 0x5d, 0xe1, 0x8b, 0x63, 0xf8, 0xe3, 0xe9, 0xbc, 0xff, 0x93, 0xa1, 0xab, 0x69, 0x1c, 0x8c, 0x2a, 0x87, 0xb5, 0x35, 0xac, 0x2a, 0xa1, 0x4e, 0xba, 0xd1, 0xf1, 0x7d, 0x02, 0xff, 0x92];
+    let aad = [0xbc, 0xf7, 0x7c, 0x42, 0x96, 0xf4, 0x96, 0x63, 0x16, 0x70, 0x02, 0x4e, 0xb2, 0x70, 0xd5, 0x0d, 0x6d, 0xef, 0xa2, 0x82, 0x59, 0xf7, 0x74, 0x60, 0xfc, 0x15, 0x05, 0xa1, 0x4c, 0x97, 0x4d, 0x4c];
+    let data = [0xf6, 0xef, 0x21, 0x88, 0x8c, 0xfa, 0x75, 0x82, 0xda, 0x73, 0x7c, 0xad, 0x6a, 0x08, 0x64, 0x9b, 0xa3, 0x11, 0xfa, 0x27, 0x90, 0xdb, 0x74, 0x6f, 0xf0, 0x70, 0x57, 0xca, 0x15, 0xf8, 0xc8, 0x0a];
+
+    let mut trait_aeadinto_encrypted_output = [0u8; 32 + 16];
+    Aes256Gcm::new((&key).try_into().unwrap())
+        .encrypt_into(
+            (&[0u8; 12]).try_into().unwrap(),
+            &data,
+            &aad,
+            &mut trait_aeadinto_encrypted_output
+        ).unwrap();
+
+    let trait_aead_encrypted_output = Aes256Gcm::new((&key).try_into().unwrap())
+        .encrypt(
+            (&[0u8; 12]).try_into().unwrap(),
+            Payload {
+                msg: &data,
+                aad: &aad
+            }
+        ).unwrap();
+
+    assert_eq!(trait_aead_encrypted_output, trait_aeadinto_encrypted_output);
+
+    let mut trait_aeadinto_decrypted_output = [0u8; 32];
+    Aes256Gcm::new((&key).try_into().unwrap())
+        .decrypt_into(
+            (&[0u8; 12]).try_into().unwrap(),
+            &trait_aeadinto_encrypted_output,
+            &aad,
+            &mut trait_aeadinto_decrypted_output
+        ).unwrap();
+
+    let trait_aead_decrypted_output = Aes256Gcm::new((&key).try_into().unwrap())
+        .decrypt(
+            (&[0u8; 12]).try_into().unwrap(),
+            Payload {
+                msg: &trait_aeadinto_encrypted_output,
+                aad: &aad
+            }
+        ).unwrap();
+
+    assert_eq!(trait_aead_decrypted_output, trait_aeadinto_decrypted_output);
+}

--- a/chacha20poly1305/tests/aead_into.rs
+++ b/chacha20poly1305/tests/aead_into.rs
@@ -1,0 +1,52 @@
+use chacha20poly1305::aead::{ Aead, AeadInto, Payload };
+use chacha20poly1305::{ ChaCha20Poly1305, KeyInit };
+
+
+/// Confirm that the [AeadInto] implementation produces exactly the same output as the [Aead]
+/// implementation.
+#[test]
+fn test_aeadinto() {
+    let key = [0xfe, 0x14, 0xbc, 0x65, 0x16, 0xd6, 0x4a, 0x80, 0x8d, 0x58, 0xa3, 0x09, 0x8b, 0x0d, 0xa1, 0xc3, 0x2d, 0xf4, 0x62, 0xc0, 0x4d, 0x9e, 0x85, 0x55, 0x70, 0xc6, 0x83, 0xc2, 0x0f, 0xd7, 0xf4, 0x88];
+    let aad = [0xfe, 0xa6, 0xa3, 0xc3, 0xae, 0x1a, 0xab, 0x0f, 0x80, 0xe7, 0xa9, 0xcb, 0x9a, 0x9e, 0x5f, 0x06, 0x16, 0x4d, 0x85, 0x46, 0x43, 0xbf, 0x74, 0xd4, 0x38, 0x19, 0xf6, 0xd3, 0x38, 0xa0, 0x5e, 0xaf];
+    let data = [0xae, 0xfb, 0x8c, 0x8c, 0x38, 0xc9, 0x12, 0x04, 0x0f, 0x1d, 0xc0, 0x10, 0xf1, 0x94, 0xb0, 0x31, 0xcc, 0x00, 0xd8, 0xe4, 0xae, 0x5d, 0x04, 0x70, 0xb3, 0x6b, 0xfa, 0xb8, 0xe1, 0x23, 0x0c, 0x8c];
+
+    let mut trait_aeadinto_encrypted_output = [0u8; 32 + 16];
+    ChaCha20Poly1305::new((&key).try_into().unwrap())
+        .encrypt_into(
+            (&[0u8; 12]).try_into().unwrap(),
+            &data,
+            &aad,
+            &mut trait_aeadinto_encrypted_output
+        ).unwrap();
+
+    let trait_aead_encrypted_output = ChaCha20Poly1305::new((&key).try_into().unwrap())
+        .encrypt(
+            (&[0u8; 12]).try_into().unwrap(),
+            Payload {
+                msg: &data,
+                aad: &aad
+            }
+        ).unwrap();
+
+    assert_eq!(trait_aead_encrypted_output, trait_aeadinto_encrypted_output);
+
+    let mut trait_aeadinto_decrypted_output = [0u8; 32];
+    ChaCha20Poly1305::new((&key).try_into().unwrap())
+        .decrypt_into(
+            (&[0u8; 12]).try_into().unwrap(),
+            &trait_aeadinto_encrypted_output,
+            &aad,
+            &mut trait_aeadinto_decrypted_output
+        ).unwrap();
+
+    let trait_aead_decrypted_output = ChaCha20Poly1305::new((&key).try_into().unwrap())
+        .decrypt(
+            (&[0u8; 12]).try_into().unwrap(),
+            Payload {
+                msg: &trait_aeadinto_encrypted_output,
+                aad: &aad
+            }
+        ).unwrap();
+
+    assert_eq!(trait_aead_decrypted_output, trait_aeadinto_decrypted_output);
+}

--- a/chacha20poly1305/tests/lib.rs
+++ b/chacha20poly1305/tests/lib.rs
@@ -2,6 +2,8 @@
 
 #![cfg(feature = "alloc")]
 
+pub mod aead_into;
+
 use chacha20poly1305::ChaCha20Poly1305;
 use chacha20poly1305::XChaCha20Poly1305;
 


### PR DESCRIPTION
**Relies on [this PR](https://github.com/RustCrypto/traits/pull/1663)!**

Resolves [this issue](https://github.com/RustCrypto/traits/issues/1311).

## Notes

I only implement `AeadInto` for AES-GCM and ChaChaPoly because these are the algorithms officially supported by the [Noise Protocol Framework](https://noiseprotocol.org/noise.html) (the driving factor behind my PR).

While I'm not personally invested in doing so, let me know if you need me to implement `AeadInto` for the other algorithms in order to accept this PR.