### PR TITLE
bump [aes, cipher, pmac, cmac] dependencies

### DIFF
--- a/.github/workflows/aes-gcm-siv.yml
+++ b/.github/workflows/aes-gcm-siv.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi

--- a/.github/workflows/aes-gcm.yml
+++ b/.github/workflows/aes-gcm.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-pre.1"
+version = "0.9.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3b4639f8f7237857117abb74f3dc8648b77e67ff78d9cb6959fd7e76f387"
+checksum = "e7856582c758ade85d71daf27ec6bcea6c1c73913692b07b8dffea2dc03531c9"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -161,8 +161,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chacha20"
 version = "0.10.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6a99ac5abed8864eaedd3b95efdab3e10f41f008f0967bb9c53b093eeb3c62"
+source = "git+https://github.com/RustCrypto/stream-ciphers.git#9fcbf802c3ec29672f6fa2f22fc6ac1abce24996"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -183,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.6"
+version = "0.5.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71c893d5a1e8257048dbb29954d2e1f85f091a150304f1defe4ca2806da5d3f"
+checksum = "5b1425e6ce000f05a73096556cabcfb6a10a3ffe3bb4d75416ca8f00819c0b6a"
 dependencies = [
  "crypto-common",
  "inout",
@@ -193,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-pre.1"
+version = "0.8.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16deb366a100cbd9ecd84d1ec674168385f769c95ec3841179663b0f2e6ff4b1"
+checksum = "02a53c8815f718726c448e4e83b86806245fb37bfaa82ad50893d9f01ad3a503"
 dependencies = [
  "cipher",
  "dbl",
@@ -224,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-pre.1"
+version = "0.10.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1637b299862a663dd5af70ee109d53555eff68b99b454fe535ed6599b0e9b3"
+checksum = "77e1482d284b80d7fddb211666d513dc5e23b0cc3a03ad398ff70543827c789f"
 dependencies = [
  "cipher",
 ]
@@ -367,9 +366,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "pmac"
-version = "0.8.0-pre.1"
+version = "0.8.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b944724c703d6337fd6fe54f72a24e56565efcf64a67b77364eaeabfe7a4c10c"
+checksum = "943dc8a86690cc9d8049e5b9597762a99baa240e1a9a90facc65012799764e3f"
 dependencies = [
  "cipher",
  "dbl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ members = [
     "ocb3",
 ]
 resolver = "2"
+
+[patch.crates-io]
+# https://github.com/RustCrypto/stream-ciphers/pull/368
+chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/aes-gcm-siv"
 repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "aes", "aes-gcm", "encryption", "siv"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -18,9 +18,9 @@ rust-version = "1.65"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }
-aes = { version = "=0.9.0-pre.1", optional = true }
-cipher = "=0.5.0-pre.6"
-ctr = "=0.10.0-pre.1"
+aes = { version = "=0.9.0-pre.2", optional = true }
+cipher = "=0.5.0-pre.7"
+ctr = "0.10.0-pre.2"
 polyval = { version = "0.7.0-rc.0", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -92,7 +92,7 @@ pub use aes;
 use cipher::{
     array::Array,
     consts::{U0, U12, U16},
-    BlockCipher, BlockCipherEncrypt, InnerIvInit, StreamCipherCore,
+    BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore,
 };
 use polyval::{universal_hash::UniversalHash, Polyval};
 use zeroize::Zeroize;
@@ -143,7 +143,7 @@ where
 
 impl<Aes> KeyInit for AesGcmSiv<Aes>
 where
-    Aes: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
 {
     fn new(key_bytes: &Key<Self>) -> Self {
         Self {
@@ -154,7 +154,7 @@ where
 
 impl<Aes> From<Aes> for AesGcmSiv<Aes>
 where
-    Aes: BlockCipher<BlockSize = U16> + BlockCipherEncrypt,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
 {
     fn from(key_generating_key: Aes) -> Self {
         Self { key_generating_key }
@@ -163,7 +163,7 @@ where
 
 impl<Aes> AeadCore for AesGcmSiv<Aes>
 where
-    Aes: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
 {
     type NonceSize = U12;
     type TagSize = U16;
@@ -172,7 +172,7 @@ where
 
 impl<Aes> AeadInPlace for AesGcmSiv<Aes>
 where
-    Aes: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
 {
     fn encrypt_in_place_detached(
         &self,
@@ -202,7 +202,7 @@ where
 /// AES-GCM-SIV: Misuse-Resistant Authenticated Encryption Cipher (RFC8452).
 struct Cipher<Aes>
 where
-    Aes: BlockCipher<BlockSize = U16> + BlockCipherEncrypt,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
 {
     /// Encryption cipher.
     enc_cipher: Aes,
@@ -216,7 +216,7 @@ where
 
 impl<Aes> Cipher<Aes>
 where
-    Aes: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
 {
     /// Initialize AES-GCM-SIV, deriving per-nonce message-authentication and
     /// message-encryption keys.
@@ -352,7 +352,7 @@ where
 #[inline]
 fn init_ctr<Aes>(cipher: Aes, nonce: &cipher::Block<Aes>) -> Ctr32LE<Aes>
 where
-    Aes: BlockCipher<BlockSize = U16> + BlockCipherEncrypt,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
 {
     let mut counter_block = *nonce;
     counter_block[15] |= 0x80;

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -18,9 +18,9 @@ rust-version = "1.65"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }
-aes = { version = "=0.9.0-pre.1", optional = true }
-cipher = "=0.5.0-pre.6"
-ctr = "=0.10.0-pre.1"
+aes = { version = "=0.9.0-pre.2", optional = true }
+cipher = "=0.5.0-pre.7"
+ctr = "0.10.0-pre.2"
 ghash = { version = "0.6.0-rc.0", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/aes-gcm"
 repository = "https://github.com/RustCrypto/AEADs"
 keywords = ["aead", "aes", "encryption", "gcm", "ghash"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -118,7 +118,7 @@ pub use aes;
 use cipher::{
     array::{Array, ArraySize},
     consts::{U0, U16},
-    BlockCipher, BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore,
+    BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore,
 };
 use core::marker::PhantomData;
 use ghash::{universal_hash::UniversalHash, GHash};
@@ -152,7 +152,7 @@ pub trait TagSize: private::SealedTagSize {}
 impl<T: private::SealedTagSize> TagSize for T {}
 
 mod private {
-    use cipher::{array::ArraySize, consts, Unsigned};
+    use cipher::{array::ArraySize, consts, typenum::Unsigned};
 
     // Sealed traits stop other crates from implementing any traits that use it.
     pub trait SealedTagSize: ArraySize + Unsigned {}
@@ -268,7 +268,7 @@ where
 
 impl<Aes, NonceSize, TagSize> AeadInPlace for AesGcm<Aes, NonceSize, TagSize>
 where
-    Aes: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
     NonceSize: ArraySize,
     TagSize: self::TagSize,
 {
@@ -321,7 +321,7 @@ where
 
 impl<Aes, NonceSize, TagSize> AesGcm<Aes, NonceSize, TagSize>
 where
-    Aes: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
+    Aes: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
     NonceSize: ArraySize,
     TagSize: self::TagSize,
 {

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.72"
 
 [dependencies]
 aead = "0.6.0-rc.0"
-aes = "=0.9.0-pre.1"
-cipher = "=0.5.0-pre.6"
-cmac = "=0.8.0-pre.1"
-ctr = "=0.10.0-pre.1"
+aes = "=0.9.0-pre.2"
+cipher = "=0.5.0-pre.7"
+cmac = "0.8.0-pre.2"
+ctr = "0.10.0-pre.2"
 dbl = "0.4.0-rc.0"
 digest = { version = "=0.11.0-pre.9", features = ["mac"] }
 zeroize = { version = "1", default-features = false }

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -98,7 +98,7 @@ use aead::{
     Buffer,
 };
 use aes::{Aes128, Aes256};
-use cipher::{typenum::IsGreaterOrEqual, ArraySize, BlockCipher, BlockCipherEncrypt};
+use cipher::{array::ArraySize, typenum::IsGreaterOrEqual, BlockCipherEncrypt, BlockSizeUser};
 use cmac::Cmac;
 use core::{marker::PhantomData, ops::Add};
 use digest::{FixedOutputReset, Mac};
@@ -121,7 +121,7 @@ pub type Tag = Array<u8, U16>;
 pub struct SivAead<C, M, NonceSize = U16>
 where
     Self: KeySizeUser,
-    C: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
     M: Mac<OutputSize = U16> + FixedOutputReset + KeyInit,
     <C as KeySizeUser>::KeySize: Add,
     NonceSize: ArraySize + IsGreaterOrEqual<U1>,
@@ -199,7 +199,7 @@ where
 impl<C, M, NonceSize> AeadCore for SivAead<C, M, NonceSize>
 where
     Self: KeySizeUser,
-    C: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
     M: Mac<OutputSize = U16> + FixedOutputReset + KeyInit,
     <C as KeySizeUser>::KeySize: Add,
     NonceSize: ArraySize + IsGreaterOrEqual<U1>,
@@ -217,7 +217,7 @@ impl<C, M, NonceSize> AeadInPlace for SivAead<C, M, NonceSize>
 where
     Self: KeySizeUser,
     Siv<C, M>: KeyInit + KeySizeUser<KeySize = <Self as KeySizeUser>::KeySize>,
-    C: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
     M: Mac<OutputSize = U16> + FixedOutputReset + KeyInit,
     <C as KeySizeUser>::KeySize: Add,
     NonceSize: ArraySize + IsGreaterOrEqual<U1>,

--- a/aes-siv/src/siv.rs
+++ b/aes-siv/src/siv.rs
@@ -75,7 +75,7 @@ use aead::{
 };
 use aes::{Aes128, Aes256};
 use cipher::{
-    BlockCipher, BlockCipherEncrypt, InnerIvInit, Key, KeyInit, KeySizeUser, StreamCipherCore,
+    BlockCipherEncrypt, BlockSizeUser, InnerIvInit, Key, KeyInit, KeySizeUser, StreamCipherCore,
 };
 use cmac::Cmac;
 use core::ops::Add;
@@ -105,7 +105,7 @@ pub type KeySize<C> = <<C as KeySizeUser>::KeySize as Add>::Output;
 /// authenticated encryption (MRAE).
 pub struct Siv<C, M>
 where
-    C: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
     M: Mac<OutputSize = U16>,
 {
     encryption_key: Key<C>,
@@ -138,7 +138,7 @@ pub type Aes256PmacSiv = PmacSiv<Aes256>;
 
 impl<C, M> KeySizeUser for Siv<C, M>
 where
-    C: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
     M: Mac<OutputSize = U16> + FixedOutputReset + KeyInit,
     <C as KeySizeUser>::KeySize: Add,
     KeySize<C>: ArraySize,
@@ -148,7 +148,7 @@ where
 
 impl<C, M> KeyInit for Siv<C, M>
 where
-    C: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
     M: Mac<OutputSize = U16> + FixedOutputReset + KeyInit,
     <C as KeySizeUser>::KeySize: Add,
     KeySize<C>: ArraySize,
@@ -168,7 +168,7 @@ where
 
 impl<C, M> Siv<C, M>
 where
-    C: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
     M: Mac<OutputSize = U16> + FixedOutputReset + KeyInit,
 {
     /// Encrypt the given plaintext, allocating and returning a `Vec<u8>` for
@@ -325,7 +325,7 @@ where
 
 impl<C, M> Drop for Siv<C, M>
 where
-    C: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit + KeySizeUser,
     M: Mac<OutputSize = U16>,
 {
     fn drop(&mut self) {

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -15,13 +15,13 @@ rust-version = "1.65"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }
-cipher = { version = "=0.5.0-pre.6", default-features = false }
-ctr = { version = "=0.10.0-pre.1", default-features = false }
+cipher = { version = "=0.5.0-pre.7", default-features = false }
+ctr = { version = "0.10.0-pre.2", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
-aes = { version = "=0.9.0-pre.1" }
+aes = { version = "=0.9.0-pre.2" }
 hex-literal = "0.4.1"
 
 [features]

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -49,8 +49,7 @@ use aead::{
     consts::{U0, U16},
 };
 use cipher::{
-    Block, BlockCipher, BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipher,
-    StreamCipherSeek,
+    Block, BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipher, StreamCipherSeek,
 };
 use core::marker::PhantomData;
 use ctr::{Ctr32BE, Ctr64BE, CtrCore};
@@ -95,7 +94,7 @@ impl<T: private::SealedNonce> NonceSize for T {}
 #[derive(Clone)]
 pub struct Ccm<C, M, N>
 where
-    C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
     M: ArraySize + TagSize,
     N: ArraySize + NonceSize,
 {
@@ -105,7 +104,7 @@ where
 
 impl<C, M, N> Ccm<C, M, N>
 where
-    C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
     M: ArraySize + TagSize,
     N: ArraySize + NonceSize,
 {
@@ -171,7 +170,7 @@ where
 
 impl<C, M, N> From<C> for Ccm<C, M, N>
 where
-    C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
     M: ArraySize + TagSize,
     N: ArraySize + NonceSize,
 {
@@ -185,7 +184,7 @@ where
 
 impl<C, M, N> KeySizeUser for Ccm<C, M, N>
 where
-    C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
     M: ArraySize + TagSize,
     N: ArraySize + NonceSize,
 {
@@ -194,7 +193,7 @@ where
 
 impl<C, M, N> KeyInit for Ccm<C, M, N>
 where
-    C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + KeyInit,
     M: ArraySize + TagSize,
     N: ArraySize + NonceSize,
 {
@@ -205,7 +204,7 @@ where
 
 impl<C, M, N> AeadCore for Ccm<C, M, N>
 where
-    C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
     M: ArraySize + TagSize,
     N: ArraySize + NonceSize,
 {
@@ -216,7 +215,7 @@ where
 
 impl<C, M, N> AeadInPlace for Ccm<C, M, N>
 where
-    C: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
+    C: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt,
     M: ArraySize + TagSize,
     N: ArraySize + NonceSize,
 {
@@ -285,14 +284,14 @@ where
     }
 }
 
-struct CbcMac<'a, C: BlockCipher + BlockCipherEncrypt> {
+struct CbcMac<'a, C: BlockCipherEncrypt> {
     cipher: &'a C,
     state: Block<C>,
 }
 
 impl<'a, C> CbcMac<'a, C>
 where
-    C: BlockCipher + BlockCipherEncrypt,
+    C: BlockCipherEncrypt,
 {
     fn from_cipher(cipher: &'a C) -> Self {
         Self {

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.65"
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }
 chacha20 = { version = "=0.10.0-pre.1", default-features = false, features = ["xchacha", "zeroize"] }
-cipher = "=0.5.0-pre.6"
+cipher = "=0.5.0-pre.7"
 poly1305 = "0.9.0-rc.0"
 zeroize = { version = "1.8", default-features = false }
 

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.72"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }
-aes = { version = "=0.9.0-pre.1", features = ["hazmat"], default-features = false }
+aes = { version = "=0.9.0-pre.2", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -21,14 +21,14 @@ rust-version = "1.71"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }
-cipher = "=0.5.0-pre.6"
-cmac = "=0.8.0-pre.1"
-ctr = "=0.10.0-pre.1"
+cipher = "=0.5.0-pre.7"
+cmac = "0.8.0-pre.2"
+ctr = "0.10.0-pre.2"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
-aes = "=0.9.0-pre.1"
+aes = "=0.9.0-pre.2"
 
 [features]
 default = ["alloc", "getrandom"]

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -131,7 +131,8 @@ use cipher::{
     array::Array,
     consts::{U0, U16},
     crypto_common::OutputSizeUser,
-    BlockCipher, BlockCipherEncrypt, InnerIvInit, StreamCipherCore, Unsigned,
+    typenum::Unsigned,
+    BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore,
 };
 use cmac::{digest::Output, Cmac, Mac};
 use core::marker::PhantomData;
@@ -175,7 +176,7 @@ type Ctr128BE<C> = ctr::CtrCore<C, ctr::flavors::Ctr128BE>;
 #[derive(Clone)]
 pub struct Eax<Cipher, M = U16>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     /// Encryption key
@@ -185,7 +186,7 @@ where
 
 impl<Cipher, M> KeySizeUser for Eax<Cipher, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     type KeySize = Cipher::KeySize;
@@ -193,7 +194,7 @@ where
 
 impl<Cipher, M> KeyInit for Eax<Cipher, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     fn new(key: &Key<Cipher>) -> Self {
@@ -206,7 +207,7 @@ where
 
 impl<Cipher, M> AeadCore for Eax<Cipher, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     type NonceSize = Cipher::BlockSize;
@@ -216,7 +217,7 @@ where
 
 impl<Cipher, M> AeadInPlace for Eax<Cipher, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     fn encrypt_in_place_detached(
@@ -311,7 +312,7 @@ where
 
 impl<Cipher, M> Eax<Cipher, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     /// CMAC/OMAC1

--- a/eax/src/online.rs
+++ b/eax/src/online.rs
@@ -60,7 +60,8 @@
 use crate::{Cmac, Error, Nonce, Tag, TagSize};
 use aead::consts::U16;
 use cipher::{
-    array::Array, BlockCipher, BlockCipherEncrypt, Key, KeyInit, KeyIvInit, StreamCipher, Unsigned,
+    array::Array, typenum::Unsigned, BlockCipherEncrypt, BlockSizeUser, Key, KeyInit, KeyIvInit,
+    StreamCipher,
 };
 use cmac::Mac;
 use core::marker::PhantomData;
@@ -149,7 +150,7 @@ impl CipherOp for Decrypt {}
 /// [`finish`]: #method.finish
 pub struct Eax<Cipher, Op, M = U16>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     Op: CipherOp,
     M: TagSize,
 {
@@ -160,7 +161,7 @@ where
 
 impl<Cipher, Op, M> Eax<Cipher, Op, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     Op: CipherOp,
     M: TagSize,
 {
@@ -195,7 +196,7 @@ where
 
 impl<Cipher, M> Eax<Cipher, Encrypt, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     /// Applies encryption to the plaintext.
@@ -216,7 +217,7 @@ where
 
 impl<Cipher, M> Eax<Cipher, Decrypt, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     /// Applies decryption to the ciphertext **without** verifying the
@@ -264,7 +265,7 @@ where
 #[doc(hidden)]
 struct EaxImpl<Cipher, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
 
     M: TagSize,
 {
@@ -280,7 +281,7 @@ where
 
 impl<Cipher, M> EaxImpl<Cipher, M>
 where
-    Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+    Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
     /// Creates a stateful EAX instance that is capable of processing both
@@ -407,7 +408,7 @@ mod test_impl {
 
     impl<Cipher, M> KeySizeUser for EaxImpl<Cipher, M>
     where
-        Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+        Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
         M: TagSize,
     {
         type KeySize = Cipher::KeySize;
@@ -415,7 +416,7 @@ mod test_impl {
 
     impl<Cipher, M> KeyInit for EaxImpl<Cipher, M>
     where
-        Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+        Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
         M: TagSize,
     {
         fn new(key: &Key<Cipher>) -> Self {
@@ -432,7 +433,7 @@ mod test_impl {
 
     impl<Cipher, M> AeadCore for super::EaxImpl<Cipher, M>
     where
-        Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+        Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
         M: TagSize,
     {
         type NonceSize = Cipher::BlockSize;
@@ -442,7 +443,7 @@ mod test_impl {
 
     impl<Cipher, M> AeadMutInPlace for super::EaxImpl<Cipher, M>
     where
-        Cipher: BlockCipher<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
+        Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
         M: TagSize,
     {
         fn encrypt_in_place_detached(

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -17,15 +17,15 @@ rust-version = "1.72"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }
-cipher = "=0.5.0-pre.6"
-ctr = "=0.10.0-pre.1"
+cipher = "=0.5.0-pre.7"
+ctr = "0.10.0-pre.2"
 dbl = "=0.4.0-rc.0"
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
-aes = { version = "=0.9.0-pre.1", default-features = false }
+aes = { version = "=0.9.0-pre.2", default-features = false }
 hex-literal = "0.4"
 
 [features]

--- a/ocb3/src/lib.rs
+++ b/ocb3/src/lib.rs
@@ -22,7 +22,8 @@ pub use aead::{
 use aead::array::ArraySize;
 use cipher::{
     consts::{U0, U12, U16},
-    BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser, Unsigned,
+    typenum::Unsigned,
+    BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser,
 };
 use core::marker::PhantomData;
 use dbl::Dbl;


### PR DESCRIPTION
- aes 0.9.0-pre.1 -> 0.9.0-pre.2
- cipher 0.5.0-pre.6 -> 0.5.0-pre.7
- cmac 0.8.0-pre.1 -> 0.8.0-pre.2
- pmac 0.8.0-pre.1 -> 0.8.0-pre.2