### PR TITLE
Cut pre.2 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 dependencies = [
  "aead",
  "aes",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.12.0-pre.1"
+version = "0.12.0-pre.2"
 dependencies = [
  "aead",
  "aes",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.7.0"
+version = "0.8.0-pre.2"
 dependencies = [
  "aead",
  "aes",
@@ -160,8 +160,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-pre.1"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#9fcbf802c3ec29672f6fa2f22fc6ac1abce24996"
+version = "0.10.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b84c7bfc26c71699d402c69451239fc99b736135bef89fc1115671c99c1a1e"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -171,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 dependencies = [
  "aead",
  "chacha20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,3 @@ members = [
     "ocb3",
 ]
 resolver = "2"
-
-[patch.crates-io]
-# https://github.com/RustCrypto/stream-ciphers/pull/368
-chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.12.0-pre.1"
+version = "0.12.0-pre.2"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.7.0"
+version = "0.8.0-pre.2"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific
@@ -27,7 +27,7 @@ digest = { version = "=0.11.0-pre.9", features = ["mac"] }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
-pmac = { version = "0.8.0-pre", optional = true }
+pmac = { version = "0.8.0-pre.2", optional = true }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific
@@ -21,7 +21,7 @@ rust-version = "1.81"
 
 [dependencies]
 aead = { version = "0.6.0-rc.0", default-features = false }
-chacha20 = { version = "=0.10.0-pre.1", default-features = false, features = ["xchacha", "zeroize"] }
+chacha20 = { version = "=0.10.0-pre.2", default-features = false, features = ["xchacha", "zeroize"] }
 cipher = "=0.5.0-pre.7"
 poly1305 = "0.9.0-rc.0"
 zeroize = { version = "1.8", default-features = false }


### PR DESCRIPTION
Cuts the following prerelease versions:

- `aes-gcm` v0.11.0-pre.2
- `aes-gcm-siv` v0.12.0-pre.2
- `aes-siv` v0.8.0-pre.2
- `chacha20poly1305` v0.11.0-pre.2