### PR TITLE
CI: attempt to fix cargo-audit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,7 +1,9 @@
 name: Security Audit
 on:
   pull_request:
-    paths: Cargo.lock
+    paths:
+      - Cargo.lock
+      - .github/workflows/security-audit.yml
   push:
     branches: master
     paths: Cargo.lock
@@ -18,7 +20,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.12
+          key: ${{ runner.os }}-cargo-audit-v0.20
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously getting the following error:

    /home/runner/.cargo/bin/cargo-audit: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory

This busts the cache to see if that helps