### PR TITLE
CI: fix security audit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,14 +13,14 @@ on:
 jobs:
   security_audit:
     name: Security Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Cache cargo bin
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.20
-      - uses: actions-rs/audit-check@v1
+          key: ${{ runner.os }}-cargo-audit-v0.20-ubuntu-v24.04
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
New Ubuntu images are being deployed, which is causing the cached binaries not to work due to a GLIBC upgrade:

https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/

To ensure we're caching consistently on the new image, switches from using `ubuntu-latest` to `ubuntu-24.04`.

We can revert this change after October 30th, when the blog post says the deployment is complete.