### PR TITLE
fix: build aes-gcm with std feature

### DIFF
--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -31,7 +31,7 @@ hex-literal = "0.4"
 
 [features]
 default = ["aes", "alloc", "getrandom"]
-std = ["aead/std", "cipher/std", "alloc"]
+std = ["aead/std", "alloc"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]


### PR DESCRIPTION
As per -

* https://github.com/RustCrypto/traits/pull/1679
* https://github.com/RustCrypto/traits/pull/1680
* https://github.com/RustCrypto/traits/pull/1691

Build failed with `aes-gcm = { version = "0.11.0-pre.2", features = ["std"] }`:

```
error: failed to select a version for `inout`.
    ... required by package `cipher v0.5.0-pre.7`
    ... which satisfies dependency `cipher = "=0.5.0-pre.7"` (locked to 0.5.0-pre.7) of package `aes-gcm v0.11.0-pre.2`
    ... which satisfies dependency `aes-gcm = "^0.11.0-pre.2"` (locked to 0.11.0-pre.2) of package `meta v0.1.0-alpha.6 (/Users/tison/ScopeDBWorkspace/scopedb/crates/meta)`
    ... which satisfies path dependency `meta` (locked to 0.1.0-alpha.6) of package `scopedb v0.1.0-alpha.6 (/Users/tison/ScopeDBWorkspace/scopedb/cmd/scopedb)`
versions that meet the requirements `^0.2.0-rc.0` (locked to 0.2.0-rc.3) are: 0.2.0-rc.3

the package `cipher` depends on `inout`, with features: `std` but `inout` does not have these features.


failed to select a version for `inout` which could resolve this conflict
```