### PR TITLE
[WIP] Migrate to `AeadInOut`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,13 +6,14 @@ version = 4
 [[package]]
 name = "aead"
 version = "0.6.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits.git#1548d2a7d7ce71a278a783d19d94b59b0103ab15"
+source = "git+https://github.com/RustCrypto/traits.git#204a4e030fa98863429ccd3797e12f9e7c45dc33"
 dependencies = [
  "arrayvec",
  "blobby 0.4.0-pre.0",
  "bytes",
  "crypto-common",
  "heapless",
+ "inout",
 ]
 
 [[package]]
@@ -38,7 +39,6 @@ name = "aes-gcm"
 version = "0.11.0-pre.2"
 dependencies = [
  "aead",
- "aead-stream",
  "aes",
  "cipher",
  "ctr",
@@ -53,7 +53,6 @@ name = "aes-gcm-siv"
 version = "0.12.0-pre.2"
 dependencies = [
  "aead",
- "aead-stream",
  "aes",
  "cipher",
  "ctr",
@@ -67,7 +66,6 @@ name = "aes-siv"
 version = "0.8.0-pre.2"
 dependencies = [
  "aead",
- "aead-stream",
  "aes",
  "blobby 0.3.1",
  "cipher",
@@ -100,7 +98,6 @@ name = "ascon-aead"
 version = "0.4.2"
 dependencies = [
  "aead",
- "aead-stream",
  "ascon",
  "hex-literal",
  "subtle",
@@ -151,7 +148,6 @@ name = "ccm"
 version = "0.5.0"
 dependencies = [
  "aead",
- "aead-stream",
  "aes",
  "cipher",
  "ctr",
@@ -181,7 +177,6 @@ name = "chacha20poly1305"
 version = "0.11.0-pre.2"
 dependencies = [
  "aead",
- "aead-stream",
  "chacha20",
  "cipher",
  "poly1305",
@@ -221,7 +216,7 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits.git#1548d2a7d7ce71a278a783d19d94b59b0103ab15"
+source = "git+https://github.com/RustCrypto/traits.git#204a4e030fa98863429ccd3797e12f9e7c45dc33"
 dependencies = [
  "hybrid-array",
  "rand_core",
@@ -249,7 +244,6 @@ name = "deoxys"
 version = "0.1.0"
 dependencies = [
  "aead",
- "aead-stream",
  "aes",
  "hex-literal",
  "subtle",
@@ -272,7 +266,6 @@ name = "eax"
 version = "0.5.0"
 dependencies = [
  "aead",
- "aead-stream",
  "aes",
  "cipher",
  "cmac",

--- a/aes-gcm/tests/aes128gcm.rs
+++ b/aes-gcm/tests/aes128gcm.rs
@@ -7,7 +7,7 @@ mod common;
 
 use self::common::TestVector;
 use aes_gcm::Aes128Gcm;
-use aes_gcm::aead::{Aead, AeadInPlaceDetached, KeyInit, Payload, array::Array};
+use aes_gcm::aead::{Aead, AeadInOut, KeyInit, Payload, array::Array};
 use hex_literal::hex;
 
 /// NIST CAVS vectors

--- a/aes-gcm/tests/aes256gcm.rs
+++ b/aes-gcm/tests/aes256gcm.rs
@@ -7,7 +7,7 @@ mod common;
 
 use self::common::TestVector;
 use aes_gcm::Aes256Gcm;
-use aes_gcm::aead::{Aead, AeadInPlaceDetached, KeyInit, Payload, array::Array};
+use aes_gcm::aead::{Aead, AeadInOut, KeyInit, Payload, array::Array};
 use hex_literal::hex;
 
 /// NIST CAVS vectors

--- a/aes-gcm/tests/common/mod.rs
+++ b/aes-gcm/tests/common/mod.rs
@@ -77,7 +77,7 @@ macro_rules! tests {
         }
 
         #[test]
-        fn decrypt_in_place_detached_modified() {
+        fn decrypt_inout_detached_modified() {
             let vector = &$vectors.iter().last().unwrap();
             let key = Array(*vector.key);
             let nonce = Array(*vector.nonce);
@@ -92,7 +92,7 @@ macro_rules! tests {
             let cipher = <$aead>::new(&key);
             assert!(
                 cipher
-                    .decrypt_in_place_detached(&nonce, &[], &mut buffer, &tag)
+                    .decrypt_inout_detached(&nonce, &[], &mut buffer, &tag)
                     .is_err()
             );
 

--- a/aes-siv/tests/aead.rs
+++ b/aes-siv/tests/aead.rs
@@ -32,7 +32,7 @@ macro_rules! tests {
         }
 
         #[test]
-        fn encrypt_in_place_detached() {
+        fn encrypt_inout_detached() {
             for vector in $vectors {
                 let key = Array(*vector.key);
                 let nonce = Array(*vector.nonce);
@@ -40,7 +40,7 @@ macro_rules! tests {
 
                 let cipher = <$aead>::new(&key);
                 let tag = cipher
-                    .encrypt_in_place_detached(&nonce, vector.aad, &mut buffer)
+                    .encrypt_inout_detached(&nonce, vector.aad, &mut buffer)
                     .unwrap();
                 let (expected_tag, expected_ciphertext) = vector.ciphertext.split_at(16);
                 assert_eq!(expected_tag, &tag[..]);
@@ -67,7 +67,7 @@ macro_rules! tests {
         }
 
         #[test]
-        fn decrypt_in_place_detached() {
+        fn decrypt_inout_detached() {
             for vector in $vectors {
                 let key = Array(*vector.key);
                 let nonce = Array(*vector.nonce);
@@ -75,7 +75,7 @@ macro_rules! tests {
                 let mut buffer = vector.ciphertext[16..].to_vec();
 
                 <$aead>::new(&key)
-                    .decrypt_in_place_detached(&nonce, vector.aad, &mut buffer, &tag)
+                    .decrypt_inout_detached(&nonce, vector.aad, &mut buffer, &tag)
                     .unwrap();
 
                 assert_eq!(vector.plaintext, buffer.as_slice());
@@ -108,7 +108,7 @@ macro_rules! tests {
 mod aes128cmacsivaead {
     use super::TestVector;
     use aes_siv::Aes128SivAead;
-    use aes_siv::aead::{Aead, AeadInPlaceDetached, KeyInit, Payload, array::Array};
+    use aes_siv::aead::{Aead, AeadInOut, KeyInit, Payload, array::Array};
 
     /// AES-128-CMAC-SIV test vectors
     const TEST_VECTORS: &[TestVector<[u8; 32]>] = &[TestVector {
@@ -132,7 +132,7 @@ mod aes128cmacsivaead {
 mod aes128pmacsivaead {
     use super::TestVector;
     use aes_siv::Aes128PmacSivAead;
-    use aes_siv::aead::{Aead, AeadInPlaceDetached, KeyInit, Payload, array::Array};
+    use aes_siv::aead::{Aead, AeadInOut, KeyInit, Payload, array::Array};
 
     /// AES-128-PMAC-SIV test vectors
     const AES_128_PMAC_SIV_TEST_VECTORS: &[TestVector<[u8; 32]>] = &[TestVector {

--- a/ascon-aead/src/lib.rs
+++ b/ascon-aead/src/lib.rs
@@ -106,8 +106,9 @@ pub use zeroize;
 
 pub use aead::{self, Error, Key, Nonce, Tag};
 use aead::{
-    AeadCore, AeadInPlaceDetached, KeyInit, KeySizeUser, PostfixTagged,
+    AeadCore, AeadInOut, KeyInit, KeySizeUser, PostfixTagged,
     consts::{U16, U20},
+    inout::InOutBuf,
 };
 
 mod asconcore;
@@ -142,12 +143,12 @@ impl<P: Parameters> AeadCore for Ascon<P> {
 
 impl<P: Parameters> PostfixTagged for Ascon<P> {}
 
-impl<P: Parameters> AeadInPlaceDetached for Ascon<P> {
-    fn encrypt_in_place_detached(
+impl<P: Parameters> AeadInOut for Ascon<P> {
+    fn encrypt_inout_detached(
         &self,
         nonce: &Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> Result<Tag<Self>, Error> {
         if (buffer.len() as u64)
             .checked_add(associated_data.len() as u64)
@@ -160,11 +161,11 @@ impl<P: Parameters> AeadInPlaceDetached for Ascon<P> {
         Ok(core.encrypt_inplace(buffer, associated_data))
     }
 
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag<Self>,
     ) -> Result<(), Error> {
         if (buffer.len() as u64)
@@ -205,28 +206,28 @@ impl AeadCore for Ascon128 {
 
 impl PostfixTagged for Ascon128 {}
 
-impl AeadInPlaceDetached for Ascon128 {
+impl AeadInOut for Ascon128 {
     #[inline(always)]
-    fn encrypt_in_place_detached(
+    fn encrypt_inout_detached(
         &self,
         nonce: &Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> Result<Tag<Self>, Error> {
         self.0
-            .encrypt_in_place_detached(nonce, associated_data, buffer)
+            .encrypt_inout_detached(nonce, associated_data, buffer)
     }
 
     #[inline(always)]
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag<Self>,
     ) -> Result<(), Error> {
         self.0
-            .decrypt_in_place_detached(nonce, associated_data, buffer, tag)
+            .decrypt_inout_detached(nonce, associated_data, buffer, tag)
     }
 }
 
@@ -257,28 +258,28 @@ impl AeadCore for Ascon128a {
 
 impl PostfixTagged for Ascon128a {}
 
-impl AeadInPlaceDetached for Ascon128a {
+impl AeadInOut for Ascon128a {
     #[inline(always)]
-    fn encrypt_in_place_detached(
+    fn encrypt_inout_detached(
         &self,
         nonce: &Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> Result<Tag<Self>, Error> {
         self.0
-            .encrypt_in_place_detached(nonce, associated_data, buffer)
+            .encrypt_inout_detached(nonce, associated_data, buffer)
     }
 
     #[inline(always)]
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag<Self>,
     ) -> Result<(), Error> {
         self.0
-            .decrypt_in_place_detached(nonce, associated_data, buffer, tag)
+            .decrypt_inout_detached(nonce, associated_data, buffer, tag)
     }
 }
 
@@ -308,27 +309,27 @@ impl AeadCore for Ascon80pq {
 
 impl PostfixTagged for Ascon80pq {}
 
-impl AeadInPlaceDetached for Ascon80pq {
+impl AeadInOut for Ascon80pq {
     #[inline(always)]
-    fn encrypt_in_place_detached(
+    fn encrypt_inout_detached(
         &self,
         nonce: &Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> Result<Tag<Self>, Error> {
         self.0
-            .encrypt_in_place_detached(nonce, associated_data, buffer)
+            .encrypt_inout_detached(nonce, associated_data, buffer)
     }
 
     #[inline(always)]
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag<Self>,
     ) -> Result<(), Error> {
         self.0
-            .decrypt_in_place_detached(nonce, associated_data, buffer, tag)
+            .decrypt_inout_detached(nonce, associated_data, buffer, tag)
     }
 }

--- a/ascon-aead/tests/kats_test.rs
+++ b/ascon-aead/tests/kats_test.rs
@@ -3,11 +3,11 @@
 
 use ascon_aead::{
     Ascon80pq, Ascon128, Ascon128a,
-    aead::{Aead, AeadInPlaceDetached, KeyInit, Payload, Tag},
+    aead::{Aead, AeadInOut, KeyInit, Payload, Tag},
 };
 use hex_literal::hex;
 
-fn run_tv<A: KeyInit + Aead + AeadInPlaceDetached>(
+fn run_tv<A: KeyInit + Aead + AeadInOut>(
     key: &[u8],
     nonce: &[u8],
     plaintext: &[u8],
@@ -40,7 +40,7 @@ fn run_tv<A: KeyInit + Aead + AeadInPlaceDetached>(
 
     let bad_tag = Tag::<A>::default();
     let mut buf = ciphertext[..ciphertext.len() - bad_tag.len()].to_vec();
-    let res = core.decrypt_in_place_detached(nonce, associated_data, &mut buf, &bad_tag);
+    let res = core.decrypt_inout_detached(nonce, associated_data, &mut buf, &bad_tag);
     assert!(res.is_err());
     assert!(buf.iter().all(|b| *b == 0));
 }

--- a/benches/src/ascon-aead.rs
+++ b/benches/src/ascon-aead.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
-use ascon_aead::aead::{AeadInPlaceDetached, KeyInit};
+use ascon_aead::aead::{AeadInOut, KeyInit};
 use ascon_aead::{Ascon128, Ascon128a, Ascon80pq};
 
 const KB: usize = 1024;
@@ -10,7 +10,7 @@ type Benchmarker = Criterion;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 type Benchmarker = Criterion<criterion_cycles_per_byte::CyclesPerByte>;
 
-fn bench<A: AeadInPlaceDetached + KeyInit>(name: &str, c: &mut Benchmarker) {
+fn bench<A: AeadInOut + KeyInit>(name: &str, c: &mut Benchmarker) {
     let mut group = c.benchmark_group(name);
     let nonce = black_box(Default::default());
     let cipher = black_box(A::new(&Default::default()));
@@ -18,15 +18,15 @@ fn bench<A: AeadInPlaceDetached + KeyInit>(name: &str, c: &mut Benchmarker) {
     let mut buf = vec![0u8; 16 * KB];
     for size in [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
         let buf = &mut buf[..size];
-        let tag = cipher.encrypt_in_place_detached(&nonce, b"", buf).unwrap();
+        let tag = cipher.encrypt_inout_detached(&nonce, b"", buf).unwrap();
 
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_function(BenchmarkId::new("encrypt-128", size), |b| {
-            b.iter(|| cipher.encrypt_in_place_detached(&nonce, b"", buf))
+            b.iter(|| cipher.encrypt_inout_detached(&nonce, b"", buf))
         });
         group.bench_function(BenchmarkId::new("decrypt-128", size), |b| {
-            b.iter(|| cipher.decrypt_in_place_detached(&nonce, b"", buf, &tag))
+            b.iter(|| cipher.decrypt_inout_detached(&nonce, b"", buf, &tag))
         });
     }
 

--- a/ccm/tests/mod.rs
+++ b/ccm/tests/mod.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "alloc")]
 
-use aead::{Aead, AeadInPlaceDetached, KeyInit, Payload, array::Array};
+use aead::{Aead, AeadInOut, KeyInit, Payload, array::Array};
 use aes::{Aes128, Aes192, Aes256};
 use ccm::{
     Ccm,
@@ -19,11 +19,11 @@ fn test_data_len_check() {
     let c = Cipher::new(&key);
 
     let mut buf1 = [1; u16::MAX as usize];
-    let res = c.encrypt_in_place_detached(&nonce, &[], &mut buf1);
+    let res = c.encrypt_inout_detached(&nonce, &[], &mut buf1);
     assert!(res.is_ok());
 
     let mut buf2 = [1; u16::MAX as usize + 1];
-    let res = c.encrypt_in_place_detached(&nonce, &[], &mut buf2);
+    let res = c.encrypt_inout_detached(&nonce, &[], &mut buf2);
     assert!(res.is_err());
 }
 

--- a/chacha20poly1305/src/cipher.rs
+++ b/chacha20poly1305/src/cipher.rs
@@ -50,7 +50,7 @@ where
     }
 
     /// Encrypt the given message in-place, returning the authentication tag
-    pub(crate) fn encrypt_in_place_detached(
+    pub(crate) fn encrypt_inout_detached(
         mut self,
         associated_data: &[u8],
         buffer: &mut [u8],
@@ -72,7 +72,7 @@ where
 
     /// Decrypt the given message, first authenticating ciphertext integrity
     /// and returning an error if it's been tampered with.
-    pub(crate) fn decrypt_in_place_detached(
+    pub(crate) fn decrypt_inout_detached(
         mut self,
         associated_data: &[u8],
         buffer: &mut [u8],

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -139,7 +139,7 @@
 
 mod cipher;
 
-pub use aead::{self, AeadCore, AeadInPlaceDetached, Error, KeyInit, KeySizeUser, consts};
+pub use aead::{self, AeadCore, AeadInOut, Error, KeyInit, KeySizeUser, consts};
 
 use self::cipher::Cipher;
 use ::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
@@ -147,6 +147,7 @@ use aead::{
     PostfixTagged,
     array::{Array, ArraySize},
     consts::{U12, U16, U24, U32},
+    inout::InOutBuf,
 };
 use core::marker::PhantomData;
 
@@ -254,32 +255,28 @@ where
 {
 }
 
-impl<C, N> AeadInPlaceDetached for ChaChaPoly1305<C, N>
+impl<C, N> AeadInOut for ChaChaPoly1305<C, N>
 where
     C: KeyIvInit<KeySize = U32, IvSize = N> + StreamCipher + StreamCipherSeek,
     N: ArraySize,
 {
-    fn encrypt_in_place_detached(
+    fn encrypt_inout_detached(
         &self,
         nonce: &aead::Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> Result<Tag, Error> {
-        Cipher::new(C::new(&self.key, nonce)).encrypt_in_place_detached(associated_data, buffer)
+        Cipher::new(C::new(&self.key, nonce)).encrypt_inout_detached(associated_data, buffer)
     }
 
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &aead::Nonce<Self>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag,
     ) -> Result<(), Error> {
-        Cipher::new(C::new(&self.key, nonce)).decrypt_in_place_detached(
-            associated_data,
-            buffer,
-            tag,
-        )
+        Cipher::new(C::new(&self.key, nonce)).decrypt_inout_detached(associated_data, buffer, tag)
     }
 }
 

--- a/deoxys/src/lib.rs
+++ b/deoxys/src/lib.rs
@@ -110,12 +110,13 @@ mod deoxys_bc;
 /// Operation modes for Deoxys.
 mod modes;
 
-pub use aead::{self, AeadCore, AeadInPlaceDetached, Error, Key, KeyInit, KeySizeUser, consts};
+pub use aead::{self, AeadCore, AeadInOut, Error, Key, KeyInit, KeySizeUser, consts};
 
 use aead::{
     PostfixTagged,
     array::{Array, ArraySize},
     consts::U16,
+    inout::InOutBuf,
 };
 use core::marker::PhantomData;
 
@@ -268,16 +269,16 @@ where
 {
 }
 
-impl<M, B> AeadInPlaceDetached for Deoxys<M, B>
+impl<M, B> AeadInOut for Deoxys<M, B>
 where
     M: DeoxysMode<B>,
     B: DeoxysBcType,
 {
-    fn encrypt_in_place_detached(
+    fn encrypt_inout_detached(
         &self,
         nonce: &Nonce<M::NonceSize>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> Result<Tag, Error> {
         Ok(Tag::from(M::encrypt_in_place(
             nonce,
@@ -287,11 +288,11 @@ where
         )))
     }
 
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &Nonce<M::NonceSize>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag,
     ) -> Result<(), Error> {
         M::decrypt_in_place(nonce, associated_data, buffer, tag, &self.subkeys)

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -97,7 +97,7 @@
 //! # {
 //! use aes::Aes256;
 //! use eax::Eax;
-//! use eax::aead::{AeadInPlaceDetached, KeyInit, array::Array};
+//! use eax::aead::{AeadInOut, KeyInit, array::Array};
 //! use eax::aead::heapless::Vec;
 //! use eax::aead::consts::{U8, U128};
 //!
@@ -110,7 +110,7 @@
 //! buffer.extend_from_slice(b"plaintext message");
 //!
 //! // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
-//! let tag = cipher.encrypt_in_place_detached(nonce, b"", &mut buffer).expect("encryption failure!");
+//! let tag = cipher.encrypt_inout_detached(nonce, b"", &mut buffer).expect("encryption failure!");
 //!
 //! // The tag has only 8 bytes, compared to the usual 16 bytes
 //! assert_eq!(tag.len(), 8);
@@ -119,15 +119,15 @@
 //! assert_ne!(&buffer, b"plaintext message");
 //!
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
-//! cipher.decrypt_in_place_detached(nonce, b"", &mut buffer, &tag).expect("decryption failure!");
+//! cipher.decrypt_inout_detached(nonce, b"", &mut buffer, &tag).expect("decryption failure!");
 //! assert_eq!(&buffer, b"plaintext message");
 //! # }
 //! ```
 
-pub use aead::{self, AeadCore, AeadInPlaceDetached, Error, Key, KeyInit, KeySizeUser};
+pub use aead::{self, AeadCore, AeadInOut, Error, Key, KeyInit, KeySizeUser};
 pub use cipher;
 
-use aead::PostfixTagged;
+use aead::{PostfixTagged, inout::InOutBuf};
 use cipher::{
     BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore, array::Array, consts::U16,
     crypto_common::OutputSizeUser, typenum::Unsigned,
@@ -219,16 +219,16 @@ where
 {
 }
 
-impl<Cipher, M> AeadInPlaceDetached for Eax<Cipher, M>
+impl<Cipher, M> AeadInOut for Eax<Cipher, M>
 where
     Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + Clone + KeyInit,
     M: TagSize,
 {
-    fn encrypt_in_place_detached(
+    fn encrypt_inout_detached(
         &self,
         nonce: &Nonce<Self::NonceSize>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> Result<Tag<M>, Error> {
         if buffer.len() as u64 > P_MAX || associated_data.len() as u64 > A_MAX {
             return Err(Error);
@@ -267,11 +267,11 @@ where
         Ok(tag)
     }
 
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &Nonce<Self::NonceSize>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag<M>,
     ) -> Result<(), Error> {
         if buffer.len() as u64 > C_MAX || associated_data.len() as u64 > A_MAX {

--- a/ocb3/src/lib.rs
+++ b/ocb3/src/lib.rs
@@ -14,11 +14,11 @@ pub mod consts {
 }
 
 pub use aead::{
-    self, AeadCore, AeadInPlaceDetached, Error, KeyInit, KeySizeUser,
+    self, AeadCore, AeadInOut, Error, KeyInit, KeySizeUser,
     array::{Array, AssocArraySize},
 };
 
-use aead::{PostfixTagged, array::ArraySize};
+use aead::{PostfixTagged, array::ArraySize, inout::InOutBuf};
 use cipher::{
     BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser,
     consts::{U12, U16},
@@ -198,17 +198,17 @@ where
 {
 }
 
-impl<Cipher, NonceSize, TagSize> AeadInPlaceDetached for Ocb3<Cipher, NonceSize, TagSize>
+impl<Cipher, NonceSize, TagSize> AeadInOut for Ocb3<Cipher, NonceSize, TagSize>
 where
     Cipher: BlockSizeUser<BlockSize = U16> + BlockCipherEncrypt + BlockCipherDecrypt,
     NonceSize: sealed::NonceSizes,
     TagSize: sealed::TagSizes,
 {
-    fn encrypt_in_place_detached(
+    fn encrypt_inout_detached(
         &self,
         nonce: &Nonce<NonceSize>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> aead::Result<aead::Tag<Self>> {
         if (buffer.len() > P_MAX) || (associated_data.len() > A_MAX) {
             unimplemented!()
@@ -263,11 +263,11 @@ where
         Ok(tag)
     }
 
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &Nonce<NonceSize>,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &aead::Tag<Self>,
     ) -> aead::Result<()> {
         let expected_tag = self.decrypt_in_place_return_tag(nonce, associated_data, buffer);

--- a/ocb3/tests/kats.rs
+++ b/ocb3/tests/kats.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use aead::{
-    AeadInPlaceDetached, KeyInit,
+    AeadInOut, KeyInit,
     consts::{U8, U12},
 };
 use aes::{Aes128, Aes192, Aes256};
@@ -38,7 +38,7 @@ macro_rules! rfc7253_wider_variety {
             let N = num2str96(3 * i + 1);
             let mut buffer = S.clone();
             let tag = ocb
-                .encrypt_in_place_detached(N.as_slice().try_into().unwrap(), &S, &mut buffer)
+                .encrypt_inout_detached(N.as_slice().try_into().unwrap(), &S, &mut buffer)
                 .unwrap();
             ciphertext.append(&mut buffer);
             ciphertext.append(&mut tag.as_slice().to_vec());
@@ -48,7 +48,7 @@ macro_rules! rfc7253_wider_variety {
             let N = num2str96(3 * i + 2);
             let mut buffer = S.clone();
             let tag = ocb
-                .encrypt_in_place_detached(N.as_slice().try_into().unwrap(), &[], &mut buffer)
+                .encrypt_inout_detached(N.as_slice().try_into().unwrap(), &[], &mut buffer)
                 .unwrap();
             ciphertext.append(&mut buffer);
             ciphertext.append(&mut tag.as_slice().to_vec());
@@ -57,7 +57,7 @@ macro_rules! rfc7253_wider_variety {
             // C = C || OCB-ENCRYPT(K,N,S,<empty string>)
             let N = num2str96(3 * i + 3);
             let tag = ocb
-                .encrypt_in_place_detached(N.as_slice().try_into().unwrap(), &S, &mut [])
+                .encrypt_inout_detached(N.as_slice().try_into().unwrap(), &S, &mut [])
                 .unwrap();
             ciphertext.append(&mut tag.as_slice().to_vec());
         }
@@ -75,7 +75,7 @@ macro_rules! rfc7253_wider_variety {
         // Output : OCB-ENCRYPT(K,N,C,<empty string>)
         let N = num2str96(385);
         let tag = ocb
-            .encrypt_in_place_detached(N.as_slice().try_into().unwrap(), &ciphertext, &mut [])
+            .encrypt_inout_detached(N.as_slice().try_into().unwrap(), &ciphertext, &mut [])
             .unwrap();
 
         assert_eq!(tag.as_slice(), hex!($expected))

--- a/xaes-256-gcm/src/lib.rs
+++ b/xaes-256-gcm/src/lib.rs
@@ -56,7 +56,7 @@ pub use aes_gcm;
 use core::ops::{Div, Mul};
 
 use aead::{
-    AeadCore, AeadInPlaceDetached, Error, KeyInit, KeySizeUser, PostfixTagged, array::Array,
+    AeadCore, AeadInOut, Error, KeyInit, KeySizeUser, PostfixTagged, array::Array, inout::InOutBuf,
 };
 use aes::Aes256;
 use aes_gcm::Aes256Gcm;
@@ -128,12 +128,12 @@ impl KeyInit for Xaes256Gcm {
 
 impl PostfixTagged for Xaes256Gcm {}
 
-impl AeadInPlaceDetached for Xaes256Gcm {
-    fn encrypt_in_place_detached(
+impl AeadInOut for Xaes256Gcm {
+    fn encrypt_inout_detached(
         &self,
         nonce: &Nonce,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
     ) -> Result<Tag, Error> {
         if buffer.len() as u64 > P_MAX || associated_data.len() as u64 > A_MAX {
             return Err(Error);
@@ -141,14 +141,14 @@ impl AeadInPlaceDetached for Xaes256Gcm {
 
         let (n1, n) = nonce.split_ref::<<NonceSize as Div<U2>>::Output>();
         let k = self.derive_key(n1);
-        Aes256Gcm::new(&k).encrypt_in_place_detached(n, associated_data, buffer)
+        Aes256Gcm::new(&k).encrypt_inout_detached(n, associated_data, buffer)
     }
 
-    fn decrypt_in_place_detached(
+    fn decrypt_inout_detached(
         &self,
         nonce: &Nonce,
         associated_data: &[u8],
-        buffer: &mut [u8],
+        buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag,
     ) -> Result<(), Error> {
         if buffer.len() as u64 > C_MAX || associated_data.len() as u64 > A_MAX {
@@ -157,7 +157,7 @@ impl AeadInPlaceDetached for Xaes256Gcm {
 
         let (n1, n) = nonce.split_ref::<<NonceSize as Div<U2>>::Output>();
         let k = self.derive_key(n1);
-        Aes256Gcm::new(&k).decrypt_in_place_detached(n, associated_data, buffer, tag)
+        Aes256Gcm::new(&k).decrypt_inout_detached(n, associated_data, buffer, tag)
     }
 }
 

--- a/xaes-256-gcm/tests/xaes256gcm.rs
+++ b/xaes-256-gcm/tests/xaes256gcm.rs
@@ -4,7 +4,7 @@
 #[path = "../../aes-gcm/tests/common/mod.rs"]
 mod common;
 
-use aes_gcm::aead::{Aead, AeadInPlaceDetached, KeyInit, Payload, array::Array};
+use aes_gcm::aead::{Aead, AeadInOut, KeyInit, Payload, array::Array};
 use common::TestVector;
 use hex_literal::hex;
 use xaes_256_gcm::Xaes256Gcm;


### PR DESCRIPTION
Replaces the previous `AeadInPlaceDetached` impls with `AeadInOut`, which was introduced in RustCrypto/traits#1793