### PR TITLE
ascon-aead: remove license headers from source files

### DIFF
--- a/ascon-aead/src/asconcore.rs
+++ b/ascon-aead/src/asconcore.rs
@@ -1,6 +1,3 @@
-// Copyright 2021-2023 Sebastian Ramacher
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-
 use aead::{
     Error,
     array::{Array, ArraySize},

--- a/ascon-aead/src/lib.rs
+++ b/ascon-aead/src/lib.rs
@@ -1,6 +1,3 @@
-// Copyright 2021-2023 Sebastian Ramacher
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]


### PR DESCRIPTION
We generally do not include license headers in source files and rely solely on the LICENSE files instead.