### PR TITLE
Revert "ascon-aead: remove license headers from source files (#676)"

### DIFF
--- a/ascon-aead/src/asconcore.rs
+++ b/ascon-aead/src/asconcore.rs
@@ -1,3 +1,6 @@
+// Copyright 2021-2023 Sebastian Ramacher
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use aead::{
     Error,
     array::{Array, ArraySize},

--- a/ascon-aead/src/lib.rs
+++ b/ascon-aead/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2021-2023 Sebastian Ramacher
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]


### PR DESCRIPTION
This reverts commit aafc20ed4af21c7c2246e10ce80147a5ad1196d5.

See discussion on #676 