### PR TITLE
Bump ciphers and block modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4838e4ad37bb032dea137f441d5f71c16c26c068af512e64c5bc13a88cdfc7"
+checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -106,17 +106,18 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9aa0cd4ec3b89021a53caa73cefc5a458cf33b338498e1191916153877bd794"
+checksum = "c4bbddee901eea0f5448cfcc94ea6390d0ee0f3ca8d0308fe34e37553f856640"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "belt-ctr"
-version = "0.2.0-rc.0"
-source = "git+https://github.com/RustCrypto/block-modes#044d1010efc422c4ee76263f9b70102d77fd342b"
+version = "0.2.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8c735d632d372934c91b23c3e118c08a71b92bfe3d1b25bb7754818a1e6d4b"
 dependencies = [
  "belt-block",
  "cipher",
@@ -190,8 +191,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.0"
-source = "git+https://github.com/RustCrypto/stream-ciphers#1b7c8220310edf3614e06e4abd1ab476c3024445"
+version = "0.10.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6715ea8ef83a13ae76da6239f97762debdf7f5fa45a638dc9c585423a9cd4834"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -224,8 +226,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.0"
-source = "git+https://github.com/RustCrypto/MACs#d1736a3f38a7c0fbbdb82e3b3ab171e526a63c57"
+version = "0.8.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2fa99ca412f76b4656efeab943ef06f1ddd8036c31ca38f35188f173d0dc85e"
 dependencies = [
  "cipher",
  "dbl",
@@ -253,8 +256,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.0"
-source = "git+https://github.com/RustCrypto/block-modes#044d1010efc422c4ee76263f9b70102d77fd342b"
+version = "0.10.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e41d01c6f73b9330177f5cf782ae5b581b5f2c7840e298e0275ceee5001434"
 dependencies = [
  "cipher",
 ]
@@ -402,8 +406,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "pmac"
-version = "0.8.0-rc.0"
-source = "git+https://github.com/RustCrypto/MACs#d1736a3f38a7c0fbbdb82e3b3ab171e526a63c57"
+version = "0.8.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e3507e63425b47335c20c1b4bae29e29094bdc64bcc8df478ecfa20af6d26"
 dependencies = [
  "cipher",
  "dbl",
@@ -495,9 +500,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17866ce72039aaa929b785c51d08d0395e02cb5eaffd3efdf634b9b1f80b8157"
+checksum = "a55be643b40a21558f44806b53ee9319595bc7ca6896372e4e08e5d7d83c9cd6"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,3 @@ members = [
 [patch.crates-io]
 aead-stream = { path = "aead-stream" }
 aes-gcm = { path = "aes-gcm" }
-
-# https://github.com/RustCrypto/block-modes/pull/84
-belt-ctr = { git = "https://github.com/RustCrypto/block-modes" }
-# https://github.com/RustCrypto/stream-ciphers/pull/450
-chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers" }
-# https://github.com/RustCrypto/MACs/pull/206
-cmac = { git = "https://github.com/RustCrypto/MACs" }
-# https://github.com/RustCrypto/block-modes/pull/84
-ctr = { git = "https://github.com/RustCrypto/block-modes" }
-# https://github.com/RustCrypto/MACs/pull/206
-pmac = { git = "https://github.com/RustCrypto/MACs" }

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -18,9 +18,9 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
-aes = { version = "0.9.0-rc.0", optional = true }
+aes = { version = "0.9.0-rc.1", optional = true }
 cipher = "0.5.0-rc.1"
-ctr = "0.10.0-rc.0"
+ctr = "0.10.0-rc.1"
 polyval = { version = "0.7.0-rc.1", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -18,9 +18,9 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
-aes = { version = "0.9.0-rc.0", optional = true }
+aes = { version = "0.9.0-rc.1", optional = true }
 cipher = "0.5.0-rc.1"
-ctr = "0.10.0-rc.0"
+ctr = "0.10.0-rc.1"
 ghash = { version = "0.6.0-rc.1", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -18,16 +18,16 @@ rust-version = "1.85"
 
 [dependencies]
 aead = "0.6.0-rc.1"
-aes = "0.9.0-rc.0"
+aes = "0.9.0-rc.1"
 cipher = "0.5.0-rc.1"
-cmac = "0.8.0-rc.0"
-ctr = "0.10.0-rc.0"
+cmac = "0.8.0-rc.1"
+ctr = "0.10.0-rc.1"
 dbl = "0.5"
-digest = { version = "0.11.0-rc.0", features = ["mac"] }
+digest = { version = "0.11.0-rc.1", features = ["mac"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 # optional dependencies
-pmac = { version = "0.8.0-rc.0", optional = true }
+pmac = { version = "0.8.0-rc.1", optional = true }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.1", features = ["alloc", "dev"], default-features = false }

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -13,13 +13,12 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
-zeroize = { version = "1.7", default-features = false, optional = true }
-universal-hash = { version = "0.6.0-rc.1" }
+belt-block = { version = "0.2.0-rc.1" }
+belt-ctr = { version = "0.2.0-rc.1" }
 opaque-debug = { version = "0.3" }
 subtle = { version = "2", default-features = false }
-
-belt-block = { version = "0.2.0-rc.0" }
-belt-ctr = { version = "0.2.0-rc.0" }
+universal-hash = { version = "0.6.0-rc.2" }
+zeroize = { version = "1.7", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -16,12 +16,12 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
 cipher = { version = "0.5.0-rc.1", default-features = false }
-ctr = { version = "0.10.0-rc.0", default-features = false }
+ctr = { version = "0.10.0-rc.1", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.1", features = ["dev"], default-features = false }
-aes = { version = "0.9.0-rc.0" }
+aes = { version = "0.9.0-rc.1" }
 hex-literal = "1"
 
 [features]

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
-chacha20 = { version = "0.10.0-rc.0", default-features = false, features = ["xchacha"] }
+chacha20 = { version = "0.10.0-rc.1", default-features = false, features = ["xchacha"] }
 cipher = "0.5.0-rc.1"
 poly1305 = "0.9.0-rc.1"
 zeroize = { version = "1.8", optional = true, default-features = false }

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
-aes = { version = "0.9.0-rc.0", features = ["hazmat"], default-features = false }
+aes = { version = "0.9.0-rc.1", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -22,13 +22,13 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
 cipher = "0.5.0-rc.1"
-cmac = "0.8.0-rc.0"
-ctr = "0.10.0-rc.0"
+cmac = "0.8.0-rc.1"
+ctr = "0.10.0-rc.1"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.1", features = ["dev"], default-features = false }
-aes = "0.9.0-rc.0"
+aes = "0.9.0-rc.1"
 
 [features]
 default = ["alloc", "os_rng"]

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
 cipher = "0.5.0-rc.1"
-ctr = "0.10.0-rc.0"
+ctr = "0.10.0-rc.1"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }
 aead-stream = { version = "0.6.0-rc.0", optional = true, default-features = false }
@@ -26,7 +26,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.0", features = ["dev"], default-features = false }
-aes = { version = "0.9.0-rc.0", default-features = false }
+aes = { version = "0.9.0-rc.1", default-features = false }
 hex-literal = "0.4"
 
 [features]

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
-aes = "0.9.0-rc.0"
+aes = "0.9.0-rc.1"
 aes-gcm = { version = "0.11.0-rc.0", default-features = false, features = ["aes"] }
 cipher = "0.5.0-rc.1"
 aead-stream = { version = "0.6.0-rc.0", optional = true, default-features = false }


### PR DESCRIPTION
Uses `hybrid-array` v0.4-compatible crate releases