### PR TITLE
Bump universal hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc2072a7f2eb76d8cb988195d48046451ea2c3dc98a5bbe1b112b70e1cffa60"
+checksum = "fb78a635f75d76d856374961deecf61031c0b6f928c83dc9c0924ab6c019c298"
 dependencies = [
  "cpufeatures",
  "universal-hash",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -21,7 +21,7 @@ aead = { version = "0.6.0-rc.1", default-features = false }
 aes = { version = "0.9.0-rc.1", optional = true }
 cipher = "0.5.0-rc.1"
 ctr = "0.10.0-rc.1"
-polyval = { version = "0.7.0-rc.1", default-features = false }
+polyval = { version = "0.7.0-rc.2", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -21,7 +21,7 @@ aead = { version = "0.6.0-rc.1", default-features = false }
 aes = { version = "0.9.0-rc.1", optional = true }
 cipher = "0.5.0-rc.1"
 ctr = "0.10.0-rc.1"
-ghash = { version = "0.6.0-rc.1", default-features = false }
+ghash = { version = "0.6.0-rc.2", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,10 +13,10 @@ rust-version = "1.56"
 [dependencies]
 criterion = "0.4.0"
 rand = "0.9.0"
-aes = "=0.9.0-pre.3"
+aes = "0.9.0-rc.1"
 aes-gcm = { path = "../aes-gcm/" }
 aes-gcm-siv = { path = "../aes-gcm-siv/" }
-ascon-aead = { path = "../ascon-aead/" }
+ascon-aead128 = { path = "../ascon-aead128/" }
 chacha20poly1305 = { path = "../chacha20poly1305/" }
 deoxys = { path = "../deoxys/" }
 eax = { path = "../eax/" }
@@ -35,8 +35,8 @@ path = "src/aes-gcm-siv.rs"
 harness = false
 
 [[bench]]
-name = "ascon-aead"
-path = "src/ascon-aead.rs"
+name = "ascon-aead128"
+path = "src/ascon-aead128.rs"
 harness = false
 
 [[bench]]
@@ -53,16 +53,3 @@ harness = false
 name = "eax"
 path = "src/eax.rs"
 harness = false
-
-[patch.crates-io]
-aead-stream = { path = "../aead-stream" }
-
-crypto-common = { git = "https://github.com/RustCrypto/traits.git" }
-aead          = { git = "https://github.com/RustCrypto/traits.git" }
-
-chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }
-
-ctr = { git = "https://github.com/baloo/block-modes.git", branch = "baloo/edition-2024" }
-
-ghash   = { git = "https://github.com/RustCrypto/universal-hashes.git" }
-polyval = { git = "https://github.com/RustCrypto/universal-hashes.git" }

--- a/benches/src/ascon-aead128.rs
+++ b/benches/src/ascon-aead128.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
-use ascon_aead::aead::{AeadInPlaceDetached, KeyInit};
-use ascon_aead::AsconAead128;
+use ascon_aead128::aead::{AeadInOut, KeyInit};
+use ascon_aead128::AsconAead128;
 
 const KB: usize = 1024;
 
@@ -10,7 +10,7 @@ type Benchmarker = Criterion;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 type Benchmarker = Criterion<criterion_cycles_per_byte::CyclesPerByte>;
 
-fn bench<A: AeadInPlaceDetached + KeyInit>(name: &str, c: &mut Benchmarker) {
+fn bench<A: AeadInOut + KeyInit>(name: &str, c: &mut Benchmarker) {
     let mut group = c.benchmark_group(name);
     let nonce = black_box(Default::default());
     let cipher = black_box(A::new(&Default::default()));
@@ -18,15 +18,17 @@ fn bench<A: AeadInPlaceDetached + KeyInit>(name: &str, c: &mut Benchmarker) {
     let mut buf = vec![0u8; 16 * KB];
     for size in [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
         let buf = &mut buf[..size];
-        let tag = cipher.encrypt_in_place_detached(&nonce, b"", buf).unwrap();
+        let tag = cipher
+            .encrypt_inout_detached(&nonce, b"", buf.into())
+            .unwrap();
 
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_function(BenchmarkId::new("encrypt-128", size), |b| {
-            b.iter(|| cipher.encrypt_in_place_detached(&nonce, b"", buf))
+            b.iter(|| cipher.encrypt_inout_detached(&nonce, b"", buf.into()))
         });
         group.bench_function(BenchmarkId::new("decrypt-128", size), |b| {
-            b.iter(|| cipher.decrypt_in_place_detached(&nonce, b"", buf, &tag))
+            b.iter(|| cipher.decrypt_inout_detached(&nonce, b"", buf.into(), &tag))
         });
     }
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -23,7 +23,7 @@ rust-version = "1.85"
 aead = { version = "0.6.0-rc.1", default-features = false }
 chacha20 = { version = "0.10.0-rc.1", default-features = false, features = ["xchacha"] }
 cipher = "0.5.0-rc.1"
-poly1305 = "0.9.0-rc.1"
+poly1305 = "0.9.0-rc.2"
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Uses `hybrid-array` v0.4-compatible versions