### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aead-stream"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 dependencies = [
  "aead",
 ]
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "aead",
  "aes",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.12.0-rc.0"
+version = "0.12.0-rc.1"
 dependencies = [
  "aead",
  "aes",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 dependencies = [
  "aead",
  "aes",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "aead",
  "chacha20",
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df2ef47489983b86b012ce4955b61fcfb1a99a761a1a8c79c3129e722da6795"
+checksum = "4f88107cb02ed63adcc4282942e60c4d09d80208d33b360ce7c729ce6dae1739"
 dependencies = [
  "polyval",
 ]
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff52e661730d7c6f95a72137e812e337eb5ff371d38d8588798e0df8404e610c"
+checksum = "1ffd40cc99d0fbb02b4b3771346b811df94194bc103983efa0203c8893755085"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "xaes-256-gcm"
-version = "0.0.1-pre.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "aead",
  "aead-stream",

--- a/aead-stream/Cargo.toml
+++ b/aead-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead-stream"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 description = "Generic implementation of the STREAM online authenticated encryption construction"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.12.0-rc.0"
+version = "0.12.0-rc.1"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -21,7 +21,7 @@ cipher = "0.5.0-rc.1"
 ctr = "0.10.0-rc.1"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }
-aead-stream = { version = "0.6.0-rc.0", optional = true, default-features = false }
+aead-stream = { version = "0.6.0-rc.1", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xaes-256-gcm"
-version = "0.0.1-pre.0"
+version = "0.1.0-rc.1"
 description = """
 Pure Rust implementation of the XAES-256-GCM extended-nonce Authenticated
 Encryption with Associated Data (AEAD).
@@ -18,9 +18,9 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.1", default-features = false }
 aes = "0.9.0-rc.1"
-aes-gcm = { version = "0.11.0-rc.0", default-features = false, features = ["aes"] }
+aes-gcm = { version = "0.11.0-rc.1", default-features = false, features = ["aes"] }
 cipher = "0.5.0-rc.1"
-aead-stream = { version = "0.6.0-rc.0", optional = true, default-features = false }
+aead-stream = { version = "0.6.0-rc.1", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.1", features = ["dev"], default-features = false }


### PR DESCRIPTION
Releases the following:
- `aead-stream` v0.6.0-rc.1
- `aes-gcm` v0.11.0-rc.1
- `aes-gcm-siv` v0.12.0-rc.1
- `aes-siv` v0.8.0-rc.1
- `chacha20poly1305` v0.11.0-rc.1
- `xaes-256-gcm` v0.1.0-rc.1