### PR TITLE
aead-stream: remove unnecessary KeyInit constraint on from_aead

### DIFF
--- a/aead-stream/src/lib.rs
+++ b/aead-stream/src/lib.rs
@@ -200,7 +200,6 @@ macro_rules! impl_stream_object {
             #[doc = "object from the given AEAD primitive."]
             pub fn from_aead(aead: A, nonce: &Nonce<A, S>) -> Self
             where
-                A: KeyInit,
                 S: NewStream<A>,
             {
                 Self::from_stream_primitive(S::from_aead(aead, nonce))


### PR DESCRIPTION
`Encryptor::from_aead` and `Decryptor::from_aead` require AEAD to implement `KeyInit`, which seems unnecessary and unused. I believe we can drop that requirement.