### PR TITLE
Bump `aead` to v0.6.0-rc.3; restore `getrandom` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits.git#aae99a0014abd27bf73a31b2c810ffe0b86989bb"
+version = "0.6.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d2d54c4d9e7006f132f615a167865bff927a79ca63d8f637237575ce0a9795"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -24,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
+checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -85,9 +86,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascon"
-version = "0.4.0"
+version = "0.5.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e716048a18530cce4684daf98a7563a499d710e1ed8ef35567fcb43a7c5f1"
+checksum = "953707d565de11d13f8cf7d880e9a46c9c403693cb7d79dcfa49feaac2d2020f"
 dependencies = [
  "zeroize",
 ]
@@ -104,18 +105,18 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bbddee901eea0f5448cfcc94ea6390d0ee0f3ca8d0308fe34e37553f856640"
+checksum = "e34d9cc93a6506887eed92e4e9459c13469eee4ef2b2af305a182ebf53e4d6a3"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "belt-ctr"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8c735d632d372934c91b23c3e118c08a71b92bfe3d1b25bb7754818a1e6d4b"
+checksum = "14c29c60fc2c2dde42f07616fcede769e6bebacf35b4ffbb046cb847dfe03c7c"
 dependencies = [
  "belt-block",
  "cipher",
@@ -183,9 +184,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd162f2b8af3e0639d83f28a637e4e55657b7a74508dba5a9bf4da523d5c9e9"
+checksum = "5e0c1a2647603ce294594198b01c1fbf77bc80a075d5b1b9adbfa94f668fd299"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -206,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
+checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -218,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2fa99ca412f76b4656efeab943ef06f1ddd8036c31ca38f35188f173d0dc85e"
+checksum = "a4f22bad4cbf035f087384fa49d3c5d105af29801fe3d04831a737a982d67cd0"
 dependencies = [
  "cipher",
  "dbl",
@@ -238,18 +239,20 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.4"
-source = "git+https://github.com/RustCrypto/traits.git#aae99a0014abd27bf73a31b2c810ffe0b86989bb"
+version = "0.2.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
 dependencies = [
+ "getrandom",
  "hybrid-array",
  "rand_core",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e41d01c6f73b9330177f5cf782ae5b581b5f2c7840e298e0275ceee5001434"
+checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
 dependencies = [
  "cipher",
 ]
@@ -276,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6749b668519cd7149ee3d11286a442a8a8bdc3a9d529605f579777bfccc5a4bc"
+checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -311,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f88107cb02ed63adcc4282942e60c4d09d80208d33b360ce7c729ce6dae1739"
+checksum = "333de57ed9494a40df4bbb866752b100819dde0d18f2264c48f5a08a85fe673d"
 dependencies = [
  "polyval",
 ]
@@ -342,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
+checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
 dependencies = [
  "hybrid-array",
 ]
@@ -378,9 +381,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "pmac"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e3507e63425b47335c20c1b4bae29e29094bdc64bcc8df478ecfa20af6d26"
+checksum = "aedfe418db7dc831d5108be56451ea366147c38cf2c2e2ea0700449040dd2184"
 dependencies = [
  "cipher",
  "dbl",
@@ -389,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb78a635f75d76d856374961deecf61031c0b6f928c83dc9c0924ab6c019c298"
+checksum = "d9c0749ae91cfe6e68c77c4d48802d9720ee06aed3f7100a38975fb0962d50bc"
 dependencies = [
  "cpufeatures",
  "universal-hash",
@@ -399,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffd40cc99d0fbb02b4b3771346b811df94194bc103983efa0203c8893755085"
+checksum = "1ad60831c19edda4b20878a676595c357e93a9b4e6dca2ba98d75b01066b317b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -428,12 +431,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0-rc-2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom",
-]
+checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
 
 [[package]]
 name = "subtle"
@@ -466,9 +466,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55be643b40a21558f44806b53ee9319595bc7ca6896372e4e08e5d7d83c9cd6"
+checksum = "9ad6682ddb0189a4d3c2a5c54b8920ab6231ae911db53fc61a0709507bf1713b"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,3 @@ members = [
 [patch.crates-io]
 aead-stream = { path = "aead-stream" }
 aes-gcm = { path = "aes-gcm" }
-
-# https://github.com/RustCrypto/traits/pull/2019
-aead = { git = "https://github.com/RustCrypto/traits.git" }
-crypto-common = { git = "https://github.com/RustCrypto/traits.git" }

--- a/aead-stream/Cargo.toml
+++ b/aead-stream/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
+aead = { version = "0.6.0-rc.3", default-features = false }
 
 [features]
 alloc = ["aead/alloc"]

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,23 +17,23 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-aes = { version = "0.9.0-rc.1", optional = true }
-cipher = "0.5.0-rc.1"
-ctr = "0.10.0-rc.1"
-polyval = { version = "0.7.0-rc.2", default-features = false }
+aead = { version = "0.6.0-rc.3", default-features = false }
+aes = { version = "0.9.0-rc.2", optional = true }
+cipher = "0.5.0-rc.2"
+ctr = "0.10.0-rc.2"
+polyval = { version = "0.7.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
 
 [features]
-default = ["aes", "alloc", "os_rng"]
+default = ["aes", "alloc", "getrandom"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 
 [package.metadata.docs.rs]

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,24 +17,27 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-aes = { version = "0.9.0-rc.1", optional = true }
-cipher = "0.5.0-rc.1"
-ctr = "0.10.0-rc.1"
-ghash = { version = "0.6.0-rc.2", default-features = false }
+aead = { version = "0.6.0-rc.3", default-features = false }
+cipher = "0.5.0-rc.2"
+ctr = "0.10.0-rc.2"
+ghash = { version = "0.6.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
+
+# optional dependencies
+aes = { version = "0.9.0-rc.2", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6.0-rc.3", features = ["alloc", "dev"], default-features = false }
 hex-literal = "1"
 
 [features]
-default = ["aes", "alloc", "os_rng"]
+default = ["aes", "alloc", "getrandom"]
 alloc = ["aead/alloc"]
+
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 
 [package.metadata.docs.rs]

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -12,37 +12,20 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-#![cfg_attr(feature = "os_rng", doc = "```")]
-#![cfg_attr(not(feature = "os_rng"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use aes_gcm::{
-//!     aead::{Aead, AeadCore, KeyInit, rand_core::OsRng},
+//!     aead::{Aead, AeadCore, KeyInit},
 //!     Aes256Gcm, Nonce, Key // Or `Aes128Gcm`
 //! };
 //!
-//! # fn gen_key() -> Result<(), core::array::TryFromSliceError> {
-//! // The encryption key can be generated randomly:
-//! # #[cfg(feature = "os_rng")] {
 //! let key = Aes256Gcm::generate_key().expect("generate key");
-//! # }
-//!
-//! // Transformed from a byte array:
-//! let key: &[u8; 32] = &[42; 32];
-//! let key: &Key<Aes256Gcm> = key.into();
-//!
-//! // Note that you can get byte array from slice using the `TryInto` trait:
-//! let key: &[u8] = &[42; 32];
-//! let key: [u8; 32] = key.try_into()?;
-//! # Ok(()) }
-//!
-//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
-//! // Alternatively, the key can be transformed directly from a byte slice
-//! // (panics on length mismatch):
-//! # let key: &[u8] = &[42; 32];
-//! let key = Key::<Aes256Gcm>::from_slice(key);
-//!
 //! let cipher = Aes256Gcm::new(&key);
-//! let nonce = Aes256Gcm::generate_nonce().expect("generate nonce"); // 96-bits; unique per message
+//!
+//! let nonce = Aes256Gcm::generate_nonce().expect("generate nonce"); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
@@ -67,18 +50,21 @@
 //! It can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
-#![cfg_attr(all(feature = "os_rng", feature = "arrayvec"), doc = "```")]
-#![cfg_attr(not(all(feature = "os_rng", feature = "arrayvec")), doc = "```ignore")]
+#![cfg_attr(all(feature = "getrandom", feature = "arrayvec"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "getrandom", feature = "arrayvec")),
+    doc = "```ignore"
+)]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use aes_gcm::{
-//!     aead::{AeadCore, AeadInOut, KeyInit, rand_core::OsRng, arrayvec::ArrayVec},
+//!     aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec},
 //!     Aes256Gcm, Nonce, // Or `Aes128Gcm`
 //! };
 //!
-//! let key = Aes256Gcm::generate_key().expect("generate key");
+//! let key = Aes256Gcm::generate_key().expect("key generation failure");
 //! let cipher = Aes256Gcm::new(&key);
-//! let nonce = Aes256Gcm::generate_nonce().expect("generate nonce"); // 96-bits; unique per message
 //!
+//! let nonce = Aes256Gcm::generate_nonce().expect("nonce failure"); // MUST be unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
 //!

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -17,29 +17,30 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = "0.6.0-rc.2"
-aes = "0.9.0-rc.1"
-cipher = "0.5.0-rc.1"
-cmac = "0.8.0-rc.1"
-ctr = "0.10.0-rc.1"
+aead = "0.6.0-rc.3"
+aes = "0.9.0-rc.2"
+cipher = "0.5.0-rc.2"
+cmac = "0.8.0-rc.3"
+ctr = "0.10.0-rc.2"
 dbl = "0.5"
-digest = { version = "0.11.0-rc.2", features = ["mac"] }
-zeroize = { version = "1", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 # optional dependencies
-pmac = { version = "0.8.0-rc.1", optional = true }
+pmac = { version = "0.8.0-rc.3", optional = true }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6.0-rc.3", features = ["alloc", "dev"], default-features = false }
 blobby = "0.4"
 hex-literal = "1"
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc", "getrandom"]
 alloc = ["aead/alloc"]
+
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 
 [package.metadata.docs.rs]

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -11,18 +11,20 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-#![cfg_attr(feature = "os_rng", doc = "```")]
-#![cfg_attr(not(feature = "os_rng"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use aes_siv::{
-//!     aead::{Aead, AeadCore, KeyInit, rand_core::OsRng},
+//!     aead::{Aead, AeadCore, KeyInit},
 //!     Aes256SivAead, Nonce // Or `Aes128SivAead`
 //! };
 //!
-//! let key = Aes256SivAead::generate_key().expect("Generate key");
+//! let key = Aes256SivAead::generate_key().expect("key generation failure");
 //! let cipher = Aes256SivAead::new(&key);
-//! let nonce = Aes256SivAead::generate_nonce().expect("Generate nonce"); // 128-bits; unique per message
+//!
+//! let nonce = Aes256SivAead::generate_nonce().expect("nonce failure"); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
@@ -47,18 +49,21 @@
 //! It can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
-#![cfg_attr(all(feature = "os_rng", feature = "arrayvec"), doc = "```")]
-#![cfg_attr(not(all(feature = "os_rng", feature = "arrayvec")), doc = "```ignore")]
+#![cfg_attr(all(feature = "getrandom", feature = "arrayvec"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "getrandom", feature = "arrayvec")),
+    doc = "```ignore"
+)]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use aes_siv::{
-//!     aead::{AeadCore, AeadInOut, KeyInit, rand_core::OsRng, arrayvec::ArrayVec},
+//!     aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec},
 //!     Aes256SivAead, Nonce, // Or `Aes128SivAead`
 //! };
 //!
-//! let key = Aes256SivAead::generate_key().expect("Generate key");
+//! let key = Aes256SivAead::generate_key().expect("key generation failure");
 //! let cipher = Aes256SivAead::new(&key);
-//! let nonce = Aes256SivAead::generate_nonce().expect("Generate nonce"); // 128-bits; unique per message
 //!
+//! let nonce = Aes256SivAead::generate_nonce().expect("nonce failure"); // MUST be unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
 //!

--- a/ascon-aead128/Cargo.toml
+++ b/ascon-aead128/Cargo.toml
@@ -12,20 +12,20 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
+aead = { version = "0.6.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false, features = ["derive"] }
-ascon = "0.4"
+ascon = "0.5.0-rc.0"
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["dev"] }
+aead = { version = "0.6.0-rc.3", features = ["dev"] }
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc", "getrandom"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 zeroize = ["dep:zeroize", "ascon/zeroize"]
 

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -12,23 +12,23 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-belt-block = { version = "0.2.0-rc.1" }
-belt-ctr = { version = "0.2.0-rc.1" }
+aead = { version = "0.6.0-rc.3", default-features = false }
+belt-block = { version = "0.2.0-rc.2" }
+belt-ctr = { version = "0.2.0-rc.2" }
 opaque-debug = { version = "0.3" }
 subtle = { version = "2", default-features = false }
-universal-hash = { version = "0.6.0-rc.2" }
+universal-hash = { version = "0.6.0-rc.3" }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal = "1"
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc", "getrandom"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 reduced-round = []
 zeroize = ["dep:zeroize", "belt-ctr/zeroize"]

--- a/belt-dwp/src/lib.rs
+++ b/belt-dwp/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(feature = "os_rng")] {
+//! # #[cfg(feature = "getrandom")] {
 //! use belt_dwp::{
 //!     aead::{Aead, AeadCore, KeyInit}, Nonce, BeltDwp
 //! };
@@ -45,7 +45,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(all(feature = "os_rng", feature = "arrayvec"))] {
+//! # #[cfg(all(feature = "getrandom", feature = "arrayvec"))] {
 //! use belt_dwp::{
 //!     aead::{AeadInOut, KeyInit, arrayvec::ArrayVec},
 //!     Nonce, BeltDwp

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.56"
 [dependencies]
 criterion = "0.4.0"
 rand = "0.9.0"
-aes = "0.9.0-rc.1"
+aes = "0.9.0-rc.2"
 aes-gcm = { path = "../aes-gcm/" }
 aes-gcm-siv = { path = "../aes-gcm-siv/" }
 ascon-aead128 = { path = "../ascon-aead128/" }

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -14,20 +14,20 @@ keywords = ["encryption", "aead"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-cipher = { version = "0.5.0-rc.1", default-features = false }
-ctr = { version = "0.10.0-rc.1", default-features = false }
+aead = { version = "0.6.0-rc.3", default-features = false }
+cipher = { version = "0.5.0-rc.2", default-features = false }
+ctr = { version = "0.10.0-rc.2", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["dev"], default-features = false }
-aes = { version = "0.9.0-rc.1" }
+aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aes = { version = "0.9.0-rc.2" }
 hex-literal = "1"
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc", "getrandom"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -20,21 +20,21 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-chacha20 = { version = "0.10.0-rc.2", default-features = false, features = ["xchacha"] }
-cipher = "0.5.0-rc.1"
-poly1305 = "0.9.0-rc.2"
+aead = { version = "0.6.0-rc.3", default-features = false }
+chacha20 = { version = "0.10.0-rc.4", default-features = false, features = ["xchacha"] }
+cipher = "0.5.0-rc.2"
+poly1305 = "0.9.0-rc.3"
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc", "getrandom"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 reduced-round = []
 zeroize = ["dep:zeroize", "chacha20/zeroize"]

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -23,18 +23,20 @@
 //!
 //! # Usage
 //!
-#![cfg_attr(feature = "os_rng", doc = "```")]
-#![cfg_attr(not(feature = "os_rng"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use chacha20poly1305::{
-//!     aead::{Aead, AeadCore, KeyInit, rand_core::OsRng},
+//!     aead::{Aead, AeadCore, KeyInit},
 //!     ChaCha20Poly1305, Nonce
 //! };
 //!
-//! let key = ChaCha20Poly1305::generate_key().expect("generate key");
+//! let key = ChaCha20Poly1305::generate_key().expect("key generation failure");
 //! let cipher = ChaCha20Poly1305::new(&key);
-//! let nonce = ChaCha20Poly1305::generate_nonce().expect("Generate nonce"); // 96-bits; unique per message
+//!
+//! let nonce = ChaCha20Poly1305::generate_nonce().expect("nonce failure"); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
+//!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
 //! # Ok(())
@@ -59,18 +61,21 @@
 //! It can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
-#![cfg_attr(all(feature = "os_rng", feature = "arrayvec"), doc = "```")]
-#![cfg_attr(not(all(feature = "os_rng", feature = "arrayvec")), doc = "```ignore")]
+#![cfg_attr(all(feature = "getrandom", feature = "arrayvec"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "getrandom", feature = "arrayvec")),
+    doc = "```ignore"
+)]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use chacha20poly1305::{
-//!     aead::{AeadCore, AeadInOut, KeyInit, rand_core::OsRng, arrayvec::ArrayVec},
+//!     aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec},
 //!     ChaCha20Poly1305, Nonce,
 //! };
 //!
-//! let key = ChaCha20Poly1305::generate_key().expect("Generate key");
+//! let key = ChaCha20Poly1305::generate_key().expect("key generation failure");
 //! let cipher = ChaCha20Poly1305::new(&key);
-//! let nonce = ChaCha20Poly1305::generate_nonce().expect("Generate nonce"); // 96-bits; unique per message
 //!
+//! let nonce = ChaCha20Poly1305::generate_nonce().expect("nonce failure"); // MUST be unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
 //!
@@ -116,17 +121,17 @@
 //!
 //! # Usage
 //!
-#![cfg_attr(feature = "os_rng", doc = "```")]
-#![cfg_attr(not(feature = "os_rng"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use chacha20poly1305::{
-//!     aead::{Aead, AeadCore, KeyInit, rand_core::OsRng},
+//!     aead::{Aead, AeadCore, KeyInit},
 //!     XChaCha20Poly1305, XNonce
 //! };
 //!
-//! let key = XChaCha20Poly1305::generate_key().expect("Generate key");
+//! let key = XChaCha20Poly1305::generate_key().expect("key generation failure");
 //! let cipher = XChaCha20Poly1305::new(&key);
-//! let nonce = XChaCha20Poly1305::generate_nonce().expect("Generate nonce"); // 192-bits; unique per message
+//! let nonce = XChaCha20Poly1305::generate_nonce().expect("nonce failure"); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -18,21 +18,21 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-aes = { version = "0.9.0-rc.1", features = ["hazmat"], default-features = false }
+aead = { version = "0.6.0-rc.3", default-features = false }
+aes = { version = "0.9.0-rc.2", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc", "getrandom"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 
 [package.metadata.docs.rs]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -20,22 +20,22 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-cipher = "0.5.0-rc.1"
-cmac = "0.8.0-rc.1"
-ctr = "0.10.0-rc.1"
+aead = { version = "0.6.0-rc.3", default-features = false }
+cipher = "0.5.0-rc.2"
+cmac = "0.8.0-rc.3"
+ctr = "0.10.0-rc.2"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["dev"], default-features = false }
-aes = "0.9.0-rc.1"
+aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aes = "0.9.0-rc.2"
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc"]
 alloc = ["aead/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 
 [package.metadata.docs.rs]

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -12,12 +12,12 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-#![cfg_attr(feature = "os_rng", doc = "```")]
-#![cfg_attr(not(feature = "os_rng"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use aes::Aes256;
 //! use eax::{
-//!     aead::{Aead, AeadCore, KeyInit, rand_core::OsRng, array::Array},
+//!     aead::{Aead, AeadCore, KeyInit, array::Array},
 //!     Eax, Nonce
 //! };
 //!
@@ -59,7 +59,7 @@
 //! use eax::aead::{
 //!     array::Array,
 //!     arrayvec::ArrayVec,
-//!     AeadCore, AeadInOut, KeyInit, rand_core::OsRng
+//!     AeadCore, AeadInOut, KeyInit,
 //! };
 //!
 //! pub type Aes256Eax = Eax<Aes256>;

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -16,25 +16,25 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-cipher = "0.5.0-rc.1"
-ctr = "0.10.0-rc.1"
+aead = { version = "0.6.0-rc.3", default-features = false }
+cipher = "0.5.0-rc.2"
+ctr = "0.10.0-rc.2"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }
 aead-stream = { version = "0.6.0-rc.1", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["dev"], default-features = false }
-aes = { version = "0.9.0-rc.1", default-features = false }
+aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aes = { version = "0.9.0-rc.2", default-features = false }
 hex-literal = "0.4"
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc", "getrandom"]
 alloc = ["aead/alloc", "aead-stream?/alloc"]
 arrayvec = ["aead/arrayvec"]
 bytes = ["aead/bytes"]
-os_rng = ["aead/os_rng", "rand_core"]
+getrandom = ["aead/getrandom"]
 rand_core = ["aead/rand_core"]
 
 [package.metadata.docs.rs]

--- a/ocb3/README.md
+++ b/ocb3/README.md
@@ -17,16 +17,16 @@ Pure Rust implementation of the Offset Codebook Mode v3 (OCB3)
 ```rust
 use aes::Aes128;
 use ocb3::{
-    aead::{Aead, AeadCore, KeyInit, array::Array, rand_core::OsRng},
+    aead::{Aead, AeadCore, KeyInit, array::Array},
     consts::U12,
     Ocb3,
 };
 
 type Aes128Ocb3 = Ocb3<Aes128, U12>;
 
-let key = Aes128::generate_key().unwrap();
+let key = Aes128::generate_key().expect("key generation failure");
 let cipher = Aes128Ocb3::new(&key);
-let nonce = Aes128Ocb3::generate_nonce().unwrap();
+let nonce = Aes128Ocb3::generate_nonce().expect("nonce failure");
 let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref()).unwrap();
 let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref()).unwrap();
 

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -16,21 +16,21 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.2", default-features = false }
-aes = "0.9.0-rc.1"
+aead = { version = "0.6.0-rc.3", default-features = false }
+aes = "0.9.0-rc.2"
 aes-gcm = { version = "0.11.0-rc.1", default-features = false, features = ["aes"] }
-cipher = "0.5.0-rc.1"
+cipher = "0.5.0-rc.2"
 aead-stream = { version = "0.6.0-rc.1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.2", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]
-default = ["alloc", "os_rng"]
+default = ["alloc", "getrandom"]
 alloc = ["aead/alloc", "aead-stream?/alloc", "aes-gcm/alloc"]
 arrayvec = ["aead/arrayvec", "aes-gcm/arrayvec"]
-os_rng = ["aead/os_rng", "aes-gcm/os_rng", "rand_core"]
+getrandom = ["aes-gcm/getrandom"]
 rand_core = ["aead/rand_core", "aes-gcm/rand_core"]
 
 [package.metadata.docs.rs]

--- a/xaes-256-gcm/src/lib.rs
+++ b/xaes-256-gcm/src/lib.rs
@@ -12,34 +12,15 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-#![cfg_attr(feature = "os_rng", doc = "```")]
-#![cfg_attr(not(feature = "os_rng"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use xaes_256_gcm::{
 //!     Xaes256Gcm, Nonce, Key,
-//!     aead::{Aead, AeadCore, KeyInit, rand_core::OsRng},
+//!     aead::{Aead, AeadCore, KeyInit},
 //! };
 //!
-//! # fn gen_key() -> Result<(), core::array::TryFromSliceError> {
-//! // The encryption key can be generated randomly:
-//! # #[cfg(feature = "os_rng")] {
 //! let key = Xaes256Gcm::generate_key().expect("generate key");
-//! # }
-//!
-//! // Transformed from a byte array:
-//! let key: &[u8; 32] = &[42; 32];
-//! let key: &Key = key.into();
-//!
-//! // Note that you can get byte array from slice using the `TryInto` trait:
-//! let key: &[u8] = &[42; 32];
-//! let key: [u8; 32] = key.try_into()?;
-//! # Ok(()) }
-//!
-//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
-//! // Alternatively, the key can be transformed directly from a byte slice
-//! // (panics on length mismatch):
-//! # let key: &[u8] = &[42; 32];
-//! let key = <Key>::from_slice(key);
-//!
 //! let cipher = Xaes256Gcm::new(&key);
 //! let nonce = Xaes256Gcm::generate_nonce().expect("Generate nonce"); // 192-bits
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;


### PR DESCRIPTION
This release drops the dependency on `rand_core` when using `getrandom`, which was the original feature name for this functionality, and in doing so also avoids a breaking change.

It also updates `rand_core` to the v0.10 prereleases.

Dependencies which depend on `rand_core` v0.10 prereleases have also been bumped to ensure we don't pull in old versions.