### PR TITLE
Cut rc.2 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "aead-stream"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "aead",
 ]
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "aead",
  "aes",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.12.0-rc.1"
+version = "0.12.0-rc.2"
 dependencies = [
  "aead",
  "aes",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "aead",
  "aes",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ascon-aead128"
-version = "0.1.0-pre"
+version = "0.1.0-rc.2"
 dependencies = [
  "aead",
  "ascon",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "belt-dwp"
-version = "0.1.0-pre"
+version = "0.1.0-rc.2"
 dependencies = [
  "aead",
  "belt-block",
@@ -166,7 +166,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "ccm"
-version = "0.6.0-pre.0"
+version = "0.6.0-rc.2"
 dependencies = [
  "aead",
  "aes",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "aead",
  "chacha20",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "deoxys"
-version = "0.2.0-pre"
+version = "0.2.0-rc.2"
 dependencies = [
  "aead",
  "aes",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.6.0-pre"
+version = "0.6.0-rc.2"
 dependencies = [
  "aead",
  "aes",
@@ -360,7 +360,7 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "ocb3"
-version = "0.2.0-pre"
+version = "0.2.0-rc.2"
 dependencies = [
  "aead",
  "aead-stream",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "xaes-256-gcm"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "aead",
  "aead-stream",

--- a/aead-stream/Cargo.toml
+++ b/aead-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead-stream"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 description = "Generic implementation of the STREAM online authenticated encryption construction"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.12.0-rc.1"
+version = "0.12.0-rc.2"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific

--- a/ascon-aead128/Cargo.toml
+++ b/ascon-aead128/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon-aead128"
-version = "0.1.0-pre"
+version = "0.1.0-rc.2"
 description = "Implementation of the Ascon-AEAD128 authenticated encryption scheme"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-dwp"
-version = "0.1.0-pre"
+version = "0.1.0-rc.2"
 description = "Pure Rust implementation of the Belt-DWP authenticated encryption algorithm (STB 34.101.31-2020)"
 edition = "2024"
 license = "Apache-2.0 OR MIT"

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.6.0-pre.0"
+version = "0.6.0-rc.2"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deoxys"
-version = "0.2.0-pre"
+version = "0.2.0-rc.2"
 description = """
 Pure Rust implementation of the Deoxys Authenticated Encryption with Associated
 Data (AEAD) cipher, including the Deoxys-II variant which was selected by the

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.6.0-pre"
+version = "0.6.0-rc.2"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocb3"
-version = "0.2.0-pre"
+version = "0.2.0-rc.2"
 description = """
 Pure Rust implementation of the Offset Codebook Mode v3 (OCB3) Authenticated Encryption with
 Associated Data (AEAD) Cipher as described in RFC7253
@@ -21,7 +21,7 @@ cipher = "0.5.0-rc.2"
 ctr = "0.10.0-rc.2"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }
-aead-stream = { version = "0.6.0-rc.1", optional = true, default-features = false }
+aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xaes-256-gcm"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 description = """
 Pure Rust implementation of the XAES-256-GCM extended-nonce Authenticated
 Encryption with Associated Data (AEAD).
@@ -18,9 +18,9 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.3", default-features = false }
 aes = "0.9.0-rc.2"
-aes-gcm = { version = "0.11.0-rc.1", default-features = false, features = ["aes"] }
+aes-gcm = { version = "0.11.0-rc.2", default-features = false, features = ["aes"] }
 cipher = "0.5.0-rc.2"
-aead-stream = { version = "0.6.0-rc.1", optional = true, default-features = false }
+aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }

--- a/xsalsa20poly1305/README.md
+++ b/xsalsa20poly1305/README.md
@@ -1,7 +1,0 @@
-## 🚨 DEPRECATED! 🚨
-
-Please switch to the `crypto_secretbox` crate:
-
-<https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretbox>
-
-This crate is deprecated and will not receive further updates.


### PR DESCRIPTION
Releases the following:
- `aead-stream` v0.6.0-rc.2
- `aes-gcm` v0.11.0-rc.2
- `aes-gcm-siv` v0.12.0-rc.2
- `aes-siv` v0.8.0-rc.2
- `ascon-aead128` v0.1.0-rc.2
- `belt-dwp` v0.1.0-rc.2
- `ccm` v0.6.0-rc.2
- `chacha20poly1305` v0.11.0-rc.2
- `deoxys` v0.2.0-rc.2
- `eax` v0.6.0-rc.2
- `ocb3` v0.2.0-rc.2
- `xaes-256-gcm` v0.1.0-rc.2