### PR TITLE
ocb3: update hex-literal to version 1

### DIFF
--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -27,7 +27,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 [dev-dependencies]
 aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
 aes = { version = "0.9.0-rc.2", default-features = false }
-hex-literal = "0.4"
+hex-literal = "1"
 
 [features]
 default = ["alloc", "getrandom"]


### PR DESCRIPTION
This crate was already bumped to Edition 2025 / MSRV 1.85 in a09f3d2ef400613055d4b83c5d817669dcf0a0ef, so the `hex-literal` dev-dependency can be updated to match the other crates (except `mgm`, which is still at Edition 2021, MSRV 1.81, and `hex-literal` 0.2).