### PR TITLE
Bump `aead` dependency to v0.6.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d2d54c4d9e7006f132f615a167865bff927a79ca63d8f637237575ce0a9795"
+checksum = "d4432ec21d472b82641b64c82ad1daca981dbf58d0345d36616cf0ac7099db96"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "f7fa010a85c7440677a0f4c59cf7ebabef52d7d8b4f79051e5fa60d3f0dd87d0"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-2"
+version = "0.10.0-rc-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
+checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
 
 [[package]]
 name = "subtle"

--- a/aead-stream/Cargo.toml
+++ b/aead-stream/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 
 [features]
 alloc = ["aead/alloc"]

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 aes = { version = "0.9.0-rc.2", optional = true }
 cipher = "0.5.0-rc.2"
 ctr = "0.10.0-rc.2"
@@ -26,7 +26,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["dev"], default-features = false }
 
 [features]
 default = ["aes", "alloc", "getrandom"]

--- a/aes-gcm-siv/src/lib.rs
+++ b/aes-gcm-siv/src/lib.rs
@@ -13,16 +13,18 @@
 //!
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use aes_gcm_siv::{
-//!     aead::{Aead, AeadCore, KeyInit},
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit},
 //!     Aes256GcmSiv, Nonce // Or `Aes128GcmSiv`
 //! };
 //!
-//! let key = Aes256GcmSiv::generate_key().expect("key generation failure");
+//! let key = Key::<Aes256GcmSiv>::generate();
 //! let cipher = Aes256GcmSiv::new(&key);
 //!
-//! let nonce = Aes256GcmSiv::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
@@ -54,16 +56,18 @@
     not(all(feature = "getrandom", feature = "arrayvec")),
     doc = "```ignore"
 )]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `arrayvec` and `getrandom` features are enabled
+//!
 //! use aes_gcm_siv::{
-//!     aead::{AeadInOut, AeadCore, Buffer, KeyInit, arrayvec::ArrayVec},
+//!     aead::{AeadInOut, AeadCore, Buffer, Generate, Key, KeyInit, arrayvec::ArrayVec},
 //!     Aes256GcmSiv, Nonce, // Or `Aes128GcmSiv`
 //! };
 //!
-//! let key = Aes256GcmSiv::generate_key().expect("key generation failure");
+//! let key = Key::<Aes256GcmSiv>::generate();
 //! let cipher = Aes256GcmSiv::new(&key);
 //!
-//! let nonce = Aes256GcmSiv::generate_nonce().expect("nonce failure"); // 96-bits; unique per message
+//! let nonce = Nonce::generate(); // 96-bits; unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.extend_from_slice(b"plaintext message");
 //!

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 cipher = "0.5.0-rc.2"
 ctr = "0.10.0-rc.2"
 ghash = { version = "0.6.0-rc.3", default-features = false }
@@ -28,7 +28,7 @@ aes = { version = "0.9.0-rc.2", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["alloc", "dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -15,15 +15,17 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use aes_gcm::{
-//!     aead::{Aead, AeadCore, KeyInit},
-//!     Aes256Gcm, Nonce, Key // Or `Aes128Gcm`
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit},
+//!     Aes256Gcm, Nonce, // Or `Aes128Gcm`
 //! };
 //!
-//! let key = Aes256Gcm::generate_key().expect("generate key");
+//! let key = Key::<Aes256Gcm>::generate();
 //! let cipher = Aes256Gcm::new(&key);
 //!
-//! let nonce = Aes256Gcm::generate_nonce().expect("generate nonce"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
@@ -56,15 +58,17 @@
     doc = "```ignore"
 )]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `arrayvec` and `getrandom` features are enabled
+//!
 //! use aes_gcm::{
-//!     aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec},
+//!     aead::{AeadCore, AeadInOut, Generate, Key, KeyInit, arrayvec::ArrayVec},
 //!     Aes256Gcm, Nonce, // Or `Aes128Gcm`
 //! };
 //!
-//! let key = Aes256Gcm::generate_key().expect("key generation failure");
+//! let key = Key::<Aes256Gcm>::generate();
 //! let cipher = Aes256Gcm::new(&key);
 //!
-//! let nonce = Aes256Gcm::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
 //!

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = "0.6.0-rc.3"
+aead = "0.6.0-rc.4"
 aes = "0.9.0-rc.2"
 cipher = "0.5.0-rc.2"
 cmac = "0.8.0-rc.3"
@@ -30,7 +30,7 @@ pmac = { version = "0.8.0-rc.3", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["alloc", "dev"], default-features = false }
 blobby = "0.4"
 hex-literal = "1"
 

--- a/aes-siv/src/lib.rs
+++ b/aes-siv/src/lib.rs
@@ -14,15 +14,17 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use aes_siv::{
-//!     aead::{Aead, AeadCore, KeyInit},
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit},
 //!     Aes256SivAead, Nonce // Or `Aes128SivAead`
 //! };
 //!
-//! let key = Aes256SivAead::generate_key().expect("key generation failure");
+//! let key = Key::<Aes256SivAead>::generate();
 //! let cipher = Aes256SivAead::new(&key);
 //!
-//! let nonce = Aes256SivAead::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
@@ -55,15 +57,17 @@
     doc = "```ignore"
 )]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `arrayvec` and `getrandom` features are enabled
+//!
 //! use aes_siv::{
-//!     aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec},
+//!     aead::{AeadCore, AeadInOut, Generate, Key, KeyInit, arrayvec::ArrayVec},
 //!     Aes256SivAead, Nonce, // Or `Aes128SivAead`
 //! };
 //!
-//! let key = Aes256SivAead::generate_key().expect("key generation failure");
+//! let key = Key::<Aes256SivAead>::generate();
 //! let cipher = Aes256SivAead::new(&key);
 //!
-//! let nonce = Aes256SivAead::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
 //!

--- a/ascon-aead128/Cargo.toml
+++ b/ascon-aead128/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false, features = ["derive"] }
 ascon = "0.5.0-rc.0"
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["dev"] }
+aead = { version = "0.6.0-rc.4", features = ["dev"] }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/ascon-aead128/src/lib.rs
+++ b/ascon-aead128/src/lib.rs
@@ -14,34 +14,17 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use ascon_aead128::{
-//!     AsconAead128, Key, Nonce,
-//!     aead::{Aead, KeyInit, AeadCore}
+//!     aead::{Aead, Generate, KeyInit, AeadCore},
+//!     AsconAead128, AsconAead128Key, AsconAead128Nonce
 //! };
 //!
-//! let key = AsconAead128::generate_key().expect("key generation failure");
+//! let key = AsconAead128Key::generate();
 //! let cipher = AsconAead128::new(&key);
 //!
-//! let nonce = AsconAead128::generate_nonce().expect("generate nonce"); // MUST be unique per message
-//! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
-//!
-//! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
-//! assert_eq!(&plaintext, b"plaintext message");
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! With randomly sampled keys and nonces (requires `getrandom` feature):
-//!
-#![cfg_attr(feature = "getrandom", doc = "```")]
-#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
-//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
-//! use ascon_aead128::{AsconAead128, aead::{Aead, AeadCore, KeyInit}};
-//!
-//! let key = AsconAead128::generate_key().expect("key generation failure");
-//! let cipher = AsconAead128::new(&key);
-//!
-//! let nonce = AsconAead128::generate_nonce().expect("generate nonce"); // MUST be unique per message
+//! let nonce = AsconAead128Nonce::generate(); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
@@ -74,15 +57,17 @@
     doc = "```ignore"
 )]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `arrayvec` and `getrandom` features are enabled
+//!
 //! use ascon_aead128::{
-//!     AsconAead128, Key, Nonce,
-//!     aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec}
+//!     aead::{AeadCore, AeadInOut, Generate, KeyInit, arrayvec::ArrayVec},
+//!     AsconAead128, AsconAead128Key, AsconAead128Nonce
 //! };
 //!
-//! let key = AsconAead128::generate_key().expect("key generation failure");
+//! let key = AsconAead128Key::generate();
 //! let cipher = AsconAead128::new(&key);
 //!
-//! let nonce = AsconAead128::generate_nonce().expect("generate nonce"); // MUST be unique per message
+//! let nonce = AsconAead128Nonce::generate(); // MUST be unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Buffer needs 16-bytes overhead for authentication tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
 //!

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 belt-block = { version = "0.2.0-rc.2" }
 belt-ctr = { version = "0.2.0-rc.2" }
 opaque-debug = { version = "0.3" }

--- a/belt-dwp/src/lib.rs
+++ b/belt-dwp/src/lib.rs
@@ -11,20 +11,21 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-//! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(feature = "getrandom")] {
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use belt_dwp::{
-//!     aead::{Aead, AeadCore, KeyInit}, Nonce, BeltDwp
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit},
+//!     BeltDwp, Nonce
 //! };
 //!
-//! let key = BeltDwp::generate_key().unwrap();
+//! let key = Key::<BeltDwp>::generate();
 //! let cipher = BeltDwp::new(&key);
-//! let nonce = BeltDwp::generate_nonce().unwrap(); // 128-bits; unique per message
+//! let nonce = Nonce::generate(); // 128-bits; MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
-//! # }; Ok(()) }
+//! # Ok(()) }
 //! ```
 //!
 //! ## In-place Usage (eliminates `alloc` requirement)
@@ -43,17 +44,20 @@
 //! It can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
-//! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(all(feature = "getrandom", feature = "arrayvec"))] {
+#![cfg_attr(all(feature = "getrandom", feature = "arrayvec"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "getrandom", feature = "arrayvec")),
+    doc = "```ignore"
+)]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use belt_dwp::{
-//!     aead::{AeadInOut, KeyInit, arrayvec::ArrayVec},
-//!     Nonce, BeltDwp
+//!     aead::{AeadInOut, Generate, Key, KeyInit, arrayvec::ArrayVec},
+//!     BeltDwp, Nonce
 //! };
 //!
-//! let key = BeltDwp::generate_key().unwrap();
+//! let key = Key::<BeltDwp>::generate();
 //! let cipher = BeltDwp::new(&key);
-//! let nonce = Nonce::try_from(&b"unique nonce1234"[..]).unwrap(); // 128-bits; unique per message
+//! let nonce = Nonce::generate(); // 128-bits; MUST be unique per message
 //!
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
@@ -67,7 +71,7 @@
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
 //! cipher.decrypt_in_place(&nonce, b"", &mut buffer)?;
 //! assert_eq!(buffer.as_ref(), b"plaintext message");
-//! # }; Ok(()) }
+//! # Ok(()) }
 //! ```
 
 pub use aead::{self, AeadCore, AeadInOut, Error, Key, KeyInit, KeySizeUser, Tag};

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["encryption", "aead"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 cipher = { version = "0.5.0-rc.2", default-features = false }
 ctr = { version = "0.10.0-rc.2", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["dev"], default-features = false }
 aes = { version = "0.9.0-rc.2" }
 hex-literal = "1"
 

--- a/ccm/src/lib.rs
+++ b/ccm/src/lib.rs
@@ -11,12 +11,14 @@
 //!
 //! Simple usage (allocating, no associated data):
 //!
-#![cfg_attr(all(feature = "getrandom", feature = "alloc"), doc = "```")]
-#![cfg_attr(not(all(feature = "getrandom", feature = "alloc")), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use aes::Aes256;
 //! use ccm::{
-//!     aead::{Aead, AeadCore, KeyInit, array::Array},
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit, Nonce},
 //!     consts::{U10, U13},
 //!     Ccm,
 //! };
@@ -24,10 +26,10 @@
 //! // AES-256-CCM type with tag and nonce size equal to 10 and 13 bytes respectively
 //! pub type Aes256Ccm = Ccm<Aes256, U10, U13>;
 //!
-//! let key = Aes256Ccm::generate_key().expect("key generation failure");
+//! let key = Key::<Aes256Ccm>::generate();
 //! let cipher = Aes256Ccm::new(&key);
 //!
-//! let nonce = Aes256Ccm::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::<Aes256Ccm>::generate(); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
@@ -62,7 +64,7 @@
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use aes::Aes256;
 //! use ccm::{
-//!     aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec},
+//!     aead::{AeadCore, AeadInOut, Generate, Key, KeyInit, Nonce, arrayvec::ArrayVec},
 //!     consts::{U10, U13},
 //!     Ccm,
 //! };
@@ -70,10 +72,10 @@
 //! // AES-256-CCM type with tag and nonce size equal to 10 and 13 bytes respectively
 //! pub type Aes256Ccm = Ccm<Aes256, U10, U13>;
 //!
-//! let key = Aes256Ccm::generate_key().expect("key generation failure");
+//! let key = Key::<Aes256Ccm>::generate();
 //! let cipher = Aes256Ccm::new(&key);
 //!
-//! let nonce = Aes256Ccm::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::<Aes256Ccm>::generate(); // MUST be unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
 //!

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 chacha20 = { version = "0.10.0-rc.6", default-features = false, features = ["xchacha"] }
 cipher = "0.5.0-rc.2"
 poly1305 = "0.9.0-rc.3"
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["dev"], default-features = false }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/chacha20poly1305/src/lib.rs
+++ b/chacha20poly1305/src/lib.rs
@@ -26,15 +26,17 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use chacha20poly1305::{
-//!     aead::{Aead, AeadCore, KeyInit},
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit},
 //!     ChaCha20Poly1305, Nonce
 //! };
 //!
-//! let key = ChaCha20Poly1305::generate_key().expect("key generation failure");
+//! let key = Key::<ChaCha20Poly1305>::generate();
 //! let cipher = ChaCha20Poly1305::new(&key);
 //!
-//! let nonce = ChaCha20Poly1305::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
@@ -66,16 +68,18 @@
     not(all(feature = "getrandom", feature = "arrayvec")),
     doc = "```ignore"
 )]
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `arrayvec` and `getrandom` features are enabled
+//!
 //! use chacha20poly1305::{
-//!     aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec},
+//!     aead::{AeadCore, AeadInOut, Generate, Key, KeyInit, arrayvec::ArrayVec},
 //!     ChaCha20Poly1305, Nonce,
 //! };
 //!
-//! let key = ChaCha20Poly1305::generate_key().expect("key generation failure");
+//! let key = Key::<ChaCha20Poly1305>::generate();
 //! let cipher = ChaCha20Poly1305::new(&key);
 //!
-//! let nonce = ChaCha20Poly1305::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
 //!
@@ -124,14 +128,16 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use chacha20poly1305::{
-//!     aead::{Aead, AeadCore, KeyInit},
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit},
 //!     XChaCha20Poly1305, XNonce
 //! };
 //!
-//! let key = XChaCha20Poly1305::generate_key().expect("key generation failure");
+//! let key = Key::<XChaCha20Poly1305>::generate();
 //! let cipher = XChaCha20Poly1305::new(&key);
-//! let nonce = XChaCha20Poly1305::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = XNonce::generate(); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 aes = { version = "0.9.0-rc.2", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/deoxys/src/lib.rs
+++ b/deoxys/src/lib.rs
@@ -11,16 +11,18 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use deoxys::{
-//!     aead::{Aead, AeadCore, KeyInit},
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit},
 //!     DeoxysII256, // Can be `DeoxysI128`, `DeoxysI256`, `DeoxysII128` of `DeoxysII256`
-//!     Nonce // Or `Aes128Gcm`
+//!     Nonce
 //! };
 //!
-//! let key = DeoxysII256::generate_key().expect("key generation failure");
+//! let key = Key::<DeoxysII256>::generate();
 //! let cipher = DeoxysII256::new(&key);
 //!
-//! let nonce = DeoxysII256::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //!
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
@@ -35,13 +37,18 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
-//! use deoxys::{DeoxysII256, Nonce}; // Can be `DeoxysI128`, `DeoxysI256`, `DeoxysII128` of `DeoxysII256`
-//! use deoxys::aead::{Aead, AeadCore, KeyInit, Payload};
+//! // NOTE: requires the `getrandom` feature is enabled
 //!
-//! let key = DeoxysII256::generate_key().expect("key generation failure");
+//! use deoxys::{
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit, Payload},
+//!     DeoxysII256, // Can be `DeoxysI128`, `DeoxysI256`, `DeoxysII128` of `DeoxysII256`
+//!     Nonce
+//! };
+//!
+//! let key = Key::<DeoxysII256>::generate();
 //! let cipher = DeoxysII256::new(&key);
 //!
-//! let nonce = DeoxysII256::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //!
 //! let payload = Payload {
 //!    msg: &b"this will be encrypted".as_ref(),
@@ -85,13 +92,18 @@
     doc = "```ignore"
 )]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
-//! use deoxys::{DeoxysII256, Nonce}; // Can be `DeoxysI128`, `DeoxysI256`, `DeoxysII128` of `DeoxysII256`
-//! use deoxys::aead::{AeadCore, AeadInOut, KeyInit, arrayvec::ArrayVec};
+//! // NOTE: requires the `arrayvec` and `getrandom` features are enabled
 //!
-//! let key = DeoxysII256::generate_key().expect("key generation failure");
+//! use deoxys::{
+//!     aead::{AeadCore, AeadInOut, Generate, Key, KeyInit, arrayvec::ArrayVec},
+//!     DeoxysII256, // Can be `DeoxysI128`, `DeoxysI256`, `DeoxysII128` of `DeoxysII256`
+//!     Nonce
+//! };
+//!
+//! let key = Key::<DeoxysII256>::generate();
 //! let cipher = DeoxysII256::new(&key);
 //!
-//! let nonce = DeoxysII256::generate_nonce().expect("nonce failure"); // MUST be unique per message
+//! let nonce = Nonce::generate(); // MUST be unique per message
 //!
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Buffer needs 16-bytes overhead for tag
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 cipher = "0.5.0-rc.2"
 cmac = "0.8.0-rc.3"
 ctr = "0.10.0-rc.2"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["dev"], default-features = false }
 aes = "0.9.0-rc.2"
 
 [features]

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -17,15 +17,15 @@
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! use aes::Aes256;
 //! use eax::{
-//!     aead::{Aead, AeadCore, KeyInit, array::Array},
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit, array::Array},
 //!     Eax, Nonce
 //! };
 //!
 //! pub type Aes256Eax = Eax<Aes256>;
 //!
-//! let key = Aes256Eax::generate_key().expect("generate key");
+//! let key = Key::<Aes256Eax>::generate();
 //! let cipher = Aes256Eax::new(&key);
-//! let nonce = Aes256Eax::generate_nonce().expect("generate nonce"); // 128-bits; unique per message
+//! let nonce = Nonce::generate(); // 128-bits; MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");
@@ -51,23 +51,29 @@
 //! It can then be passed as the `buffer` parameter to the in-place encrypt
 //! and decrypt methods:
 //!
-//! ```
-//! # #[cfg(feature = "arrayvec")]
-//! # {
+#![cfg_attr(all(feature = "getrandom", feature = "arrayvec"), doc = "```")]
+#![cfg_attr(
+    not(all(feature = "getrandom", feature = "arrayvec")),
+    doc = "```ignore"
+)]
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `arrayvec` and `getrandom` features are enabled
+//!
 //! use aes::Aes256;
-//! use eax::Eax;
-//! use eax::aead::{
-//!     array::Array,
-//!     arrayvec::ArrayVec,
-//!     AeadCore, AeadInOut, KeyInit,
+//! use eax::{
+//!     aead::{
+//!         arrayvec::ArrayVec,
+//!         AeadCore, AeadInOut, Generate, Key, KeyInit,
+//!     },
+//!     Eax, Nonce
 //! };
 //!
 //! pub type Aes256Eax = Eax<Aes256>;
 //!
-//! let key = Aes256Eax::generate_key().expect("generate key");
+//! let key = Key::<Aes256Eax>::generate();
 //! let cipher = Aes256Eax::new(&key);
 //!
-//! let nonce = Aes256Eax::generate_nonce().expect("generate nonce"); // 128-bits; unique per message
+//! let nonce = Nonce::generate(); // 128-bits; MUST be unique per message
 //!
 //! let mut buffer: ArrayVec<u8, 128> = ArrayVec::new();
 //! buffer.try_extend_from_slice(b"plaintext message").unwrap();
@@ -81,6 +87,7 @@
 //! // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
 //! cipher.decrypt_in_place(&nonce, b"", &mut buffer).expect("decryption failure!");
 //! assert_eq!(buffer.as_ref(), b"plaintext message");
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 cipher = "0.5.0-rc.2"
 ctr = "0.10.0-rc.2"
 dbl = "0.5"
@@ -25,7 +25,7 @@ aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = fals
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["dev"], default-features = false }
 aes = { version = "0.9.0-rc.2", default-features = false }
 hex-literal = "1"
 

--- a/ocb3/README.md
+++ b/ocb3/README.md
@@ -17,16 +17,16 @@ Pure Rust implementation of the Offset Codebook Mode v3 (OCB3)
 ```rust
 use aes::Aes128;
 use ocb3::{
-    aead::{Aead, AeadCore, KeyInit, array::Array},
+    aead::{Aead, AeadCore, Generate, Key, KeyInit, array::Array},
     consts::U12,
-    Ocb3,
+    Ocb3, Nonce
 };
 
 type Aes128Ocb3 = Ocb3<Aes128, U12>;
 
-let key = Aes128::generate_key().expect("key generation failure");
+let key = Key::<Aes128>::generate();
 let cipher = Aes128Ocb3::new(&key);
-let nonce = Aes128Ocb3::generate_nonce().expect("nonce failure");
+let nonce = Nonce::generate(); // MUST be unique per message
 let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref()).unwrap();
 let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref()).unwrap();
 

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -16,14 +16,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.4", default-features = false }
 aes = "0.9.0-rc.2"
 aes-gcm = { version = "0.11.0-rc.2", default-features = false, features = ["aes"] }
 cipher = "0.5.0-rc.2"
 aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.3", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.4", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/xaes-256-gcm/src/lib.rs
+++ b/xaes-256-gcm/src/lib.rs
@@ -15,14 +15,16 @@
 #![cfg_attr(feature = "getrandom", doc = "```")]
 #![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // NOTE: requires the `getrandom` feature is enabled
+//!
 //! use xaes_256_gcm::{
-//!     Xaes256Gcm, Nonce, Key,
-//!     aead::{Aead, AeadCore, KeyInit},
+//!     aead::{Aead, AeadCore, Generate, Key, KeyInit},
+//!     Xaes256Gcm, Nonce
 //! };
 //!
-//! let key = Xaes256Gcm::generate_key().expect("generate key");
+//! let key = Key::<Xaes256Gcm>::generate();
 //! let cipher = Xaes256Gcm::new(&key);
-//! let nonce = Xaes256Gcm::generate_nonce().expect("Generate nonce"); // 192-bits
+//! let nonce = Nonce::generate(); // 192-bits; MUST be unique per message
 //! let ciphertext = cipher.encrypt(&nonce, b"plaintext message".as_ref())?;
 //! let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref())?;
 //! assert_eq!(&plaintext, b"plaintext message");


### PR DESCRIPTION
This is primarily the documentation changes for the newly introduced `Generate` trait which subsumed the previous RNG APIs.

See also:
- RustCrypto/traits#2096
- RustCrypto/traits#2098