### PR TITLE
CI: run tests as debug builds with `--lib`

### DIFF
--- a/.github/workflows/aes-gcm-siv.yml
+++ b/.github/workflows/aes-gcm-siv.yml
@@ -67,7 +67,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release --no-default-features
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
-      - run: cargo build --target ${{ matrix.target }} --benches
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/aes-gcm.yml
+++ b/.github/workflows/aes-gcm.yml
@@ -67,8 +67,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release --no-default-features --lib
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features zeroize
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
-      - run: cargo build --target ${{ matrix.target }} --benches
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/aes-siv.yml
+++ b/.github/workflows/aes-siv.yml
@@ -46,14 +46,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - 1.85.0 # MSRV
-          - stable
+        include:
+          # 32-bit Linux
+          - target: i686-unknown-linux-gnu
+            rust: 1.85.0 # MSRV
+            deps: sudo apt update && sudo apt install gcc-multilib
+          - target: i686-unknown-linux-gnu
+            rust: stable
+            deps: sudo apt update && sudo apt install gcc-multilib
+
+          # 64-bit Linux
+          - target: x86_64-unknown-linux-gnu
+            rust: 1.85.0 # MSRV
+          - target: x86_64-unknown-linux-gnu
+            rust: stable
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --release --no-default-features
-      - run: cargo test --release
-      - run: cargo test --release --all-features
+          targets: ${{ matrix.target }}
+      - run: ${{ matrix.deps }}
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/ascon-aead128.yml
+++ b/.github/workflows/ascon-aead128.yml
@@ -67,7 +67,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release --no-default-features
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features zeroize
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/belt-dwp.yml
+++ b/.github/workflows/belt-dwp.yml
@@ -76,6 +76,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release --no-default-features --lib
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/ccm.yml
+++ b/.github/workflows/ccm.yml
@@ -66,7 +66,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release --no-default-features
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
-      - run: cargo build --target ${{ matrix.target }} --benches
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      #- run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/chacha20poly1305.yml
+++ b/.github/workflows/chacha20poly1305.yml
@@ -68,9 +68,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release --no-default-features
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features reduced-round
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
-      - run: cargo build --target ${{ matrix.target }} --benches
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc
 

--- a/.github/workflows/deoxys.yml
+++ b/.github/workflows/deoxys.yml
@@ -46,14 +46,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - 1.85.0 # MSRV
-          - stable
+        include:
+          # 32-bit Linux
+          - target: i686-unknown-linux-gnu
+            rust: 1.85.0 # MSRV
+            deps: sudo apt update && sudo apt install gcc-multilib
+          - target: i686-unknown-linux-gnu
+            rust: stable
+            deps: sudo apt update && sudo apt install gcc-multilib
+
+          # 64-bit Linux
+          - target: x86_64-unknown-linux-gnu
+            rust: 1.85.0 # MSRV
+          - target: x86_64-unknown-linux-gnu
+            rust: stable
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --release --no-default-features --lib
-      - run: cargo test --release
-      - run: cargo test --release --all-features
+          targets: ${{ matrix.target }}
+      - run: ${{ matrix.deps }}
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/eax.yml
+++ b/.github/workflows/eax.yml
@@ -45,14 +45,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - 1.85.0 # MSRV
-          - stable
+        include:
+          # 32-bit Linux
+          - target: i686-unknown-linux-gnu
+            rust: 1.85.0 # MSRV
+            deps: sudo apt update && sudo apt install gcc-multilib
+          - target: i686-unknown-linux-gnu
+            rust: stable
+            deps: sudo apt update && sudo apt install gcc-multilib
+
+          # 64-bit Linux
+          - target: x86_64-unknown-linux-gnu
+            rust: 1.85.0 # MSRV
+          - target: x86_64-unknown-linux-gnu
+            rust: stable
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --release --no-default-features
-      - run: cargo test --release
-      - run: cargo test --release --all-features
+          targets: ${{ matrix.target }}
+      - run: ${{ matrix.deps }}
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      #- run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/ocb3.yml
+++ b/.github/workflows/ocb3.yml
@@ -67,7 +67,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features zeroize
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
-      - run: cargo build --target ${{ matrix.target }} --benches
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/.github/workflows/xaes-256-gcm.yml
+++ b/.github/workflows/xaes-256-gcm.yml
@@ -67,7 +67,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release --no-default-features --lib
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
-      - run: cargo build --target ${{ matrix.target }} --benches
+      - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --lib
+      #- run: cargo test --target ${{ matrix.target }} --lib --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --lib
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --doc


### PR DESCRIPTION
- Runs tests with `--lib` and adds separate `--doc` step
- Run tests with debug builds and adds a separate `--release` step

This should test more combinations (both debug and release builds), but largely serves as a workaround for the weirdness happening in #752 where feature-gating seems to be working incorrectly in the doctests.