### PR TITLE
aes-gcm: fix `P_MAX` and `A_MAX` values

### DIFF
--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Removed
 - `std` & `stream` features ([#662])
+- `C_MAX` constant ([#762])
 
 [#583]: https://github.com/RustCrypto/AEADs/pull/583
 [#631]: https://github.com/RustCrypto/AEADs/pull/631

--- a/aes-gcm/src/lib.rs
+++ b/aes-gcm/src/lib.rs
@@ -111,9 +111,6 @@ pub const A_MAX: u64 = (1 << 61) - 1;
 /// Maximum length of plaintext in bytes.
 pub const P_MAX: u64 = (1 << 36) - 32;
 
-/// Maximum length of ciphertext in bytes (with tag).
-pub const C_MAX: u64 = (1 << 36) + 16;
-
 /// AES-GCM nonces.
 pub type Nonce<NonceSize> = Array<u8, NonceSize>;
 


### PR DESCRIPTION
In Section 5.2.1.1 of NIST 800-38D maximum plaintext and AAD lengths are defined as 2^39-256 and 2^64-1 bits accordingly.

Reported in https://github.com/RustCrypto/AEADs/security/advisories/GHSA-8xg6-2rjr-7rv3