### PR TITLE
Bump trait crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a578e7d4edaef88aeb9cdd81556f4a62266ce26601317c006a79e8bc58b5af"
+checksum = "cc2b86f658b0f536411ee61c10cec8376f83375b0c98bdc6a640e249f01549d0"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -79,6 +79,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "blobby"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,9 +190,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
+checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -201,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
+checksum = "eba4d87abf4032a6d927f84b71af5086128a3349b929b4501c51a0fe0981a937"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -233,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
+checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -295,16 +307,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.0-rc.0"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f70a332ddf75e5e5e43284304179ba02f391f82f692f030b08a8378adf3c99"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -315,6 +340,27 @@ checksum = "333de57ed9494a40df4bbb866752b100819dde0d18f2264c48f5a08a85fe673d"
 dependencies = [
  "polyval",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex-literal"
@@ -333,6 +379,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,10 +406,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ocb3"
@@ -401,6 +489,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,9 +524,57 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-3"
+version = "0.10.0-rc-6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
+checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "subtle"
@@ -460,10 +606,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "universal-hash"
-version = "0.6.0-rc.4"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0386f227888b17b65d3e38219a7d41185035471300855c285667811907bb1677"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca141d401f08b91a03a23c3cdd32064da6a4a30b1714d7c3f2f62299644d11f"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -475,7 +627,50 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.3.1+wasi-0.3.0-rc-2025-09-16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba4be47b1d11244670d11857eee0758a8f2c39aea64d80b78c1ce29b4642cd"
+dependencies = [
+ "wit-bindgen 0.48.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876fe286f2fa416386deedebe8407e6f19e0b5aeaef3d03161e77a15fa80f167"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -483,6 +678,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8c2adb5f74ac9395bc3121c99a1254bf9310482c27b13f97167aedb5887138"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b881a098cae03686d7a0587f8f306f8a58102ad8da8b5599100fbe0e7f5800b"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69667efa439a453e1d50dac939c6cab6d2c3ac724a9d232b6631dad2472a5b70"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae2e22cceb5d105d52326c07e3e67603a861cc7add70fc467f7cc7ec5265017"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0c57df25e7ee612d946d3b7646c1ddb2310f8280aa2c17e543b66e0812241"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ef1c6ad67f35c831abd4039c02894de97034100899614d1c44e2268ad01c91"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "xaes-256-gcm"
@@ -515,3 +798,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/aead-stream/Cargo.toml
+++ b/aead-stream/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
+aead = { version = "0.6.0-rc.8", default-features = false }
 
 [features]
 alloc = ["aead/alloc"]

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,16 +17,16 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
+aead = { version = "0.6.0-rc.8", default-features = false }
 aes = { version = "0.9.0-rc.2", optional = true }
-cipher = "0.5.0-rc.3"
+cipher = "0.5.0-rc.6"
 ctr = "0.10.0-rc.2"
 polyval = { version = "0.7.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
 
 [features]
 default = ["aes", "alloc", "getrandom"]

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,8 +17,8 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
-cipher = "0.5.0-rc.3"
+aead = { version = "0.6.0-rc.8", default-features = false }
+cipher = "0.5.0-rc.6"
 ctr = "0.10.0-rc.2"
 ghash = { version = "0.6.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
@@ -28,7 +28,7 @@ aes = { version = "0.9.0-rc.2", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["alloc", "dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -17,9 +17,9 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = "0.6.0-rc.5"
+aead = "0.6.0-rc.8"
 aes = "0.9.0-rc.2"
-cipher = "0.5.0-rc.3"
+cipher = "0.5.0-rc.6"
 cmac = "0.8.0-rc.3"
 ctr = "0.10.0-rc.2"
 dbl = "0.5"
@@ -30,7 +30,7 @@ pmac = { version = "0.8.0-rc.3", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["alloc", "dev"], default-features = false }
 blobby = "0.4"
 hex-literal = "1"
 

--- a/ascon-aead128/Cargo.toml
+++ b/ascon-aead128/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
+aead = { version = "0.6.0-rc.8", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false, features = ["derive"] }
 ascon = "0.5.0-rc.0"
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["dev"] }
+aead = { version = "0.6.0-rc.8", features = ["dev"] }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
+aead = { version = "0.6.0-rc.8", default-features = false }
 belt-block = { version = "0.2.0-rc.2" }
 belt-ctr = { version = "0.2.0-rc.2" }
 opaque-debug = { version = "0.3" }
 subtle = { version = "2", default-features = false }
-universal-hash = { version = "0.6.0-rc.3" }
+universal-hash = { version = "0.6.0-rc.7" }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["encryption", "aead"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
-cipher = { version = "0.5.0-rc.3", default-features = false }
+aead = { version = "0.6.0-rc.8", default-features = false }
+cipher = { version = "0.5.0-rc.6", default-features = false }
 ctr = { version = "0.10.0-rc.2", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
 aes = { version = "0.9.0-rc.2" }
 hex-literal = "1"
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
-chacha20 = { version = "0.10.0-rc.6", default-features = false, features = ["xchacha"] }
-cipher = "0.5.0-rc.3"
+aead = { version = "0.6.0-rc.8", default-features = false }
+chacha20 = { version = "0.10.0-rc.9", default-features = false, features = ["xchacha"] }
+cipher = "0.5.0-rc.6"
 poly1305 = "0.9.0-rc.3"
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
+aead = { version = "0.6.0-rc.8", default-features = false }
 aes = { version = "0.9.0-rc.2", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
-cipher = "0.5.0-rc.3"
+aead = { version = "0.6.0-rc.8", default-features = false }
+cipher = "0.5.0-rc.6"
 cmac = "0.8.0-rc.3"
 ctr = "0.10.0-rc.2"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
 aes = "0.9.0-rc.2"
 
 [features]

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -16,8 +16,8 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
-cipher = "0.5.0-rc.3"
+aead = { version = "0.6.0-rc.8", default-features = false }
+cipher = "0.5.0-rc.6"
 ctr = "0.10.0-rc.2"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }
@@ -25,7 +25,7 @@ aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = fals
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
 aes = { version = "0.9.0-rc.2", default-features = false }
 hex-literal = "1"
 

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -16,14 +16,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.5", default-features = false }
+aead = { version = "0.6.0-rc.8", default-features = false }
 aes = "0.9.0-rc.2"
 aes-gcm = { version = "0.11.0-rc.2", default-features = false, features = ["aes"] }
-cipher = "0.5.0-rc.3"
+cipher = "0.5.0-rc.6"
 aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.5", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]


### PR DESCRIPTION
Updates the following:
- `aead` v0.6.0-rc.8
- `cipher` v0.5.0-rc.6
- `universal-hash` v0.6.0-rc.7

Also bumps:
- `chacha20` v0.10.0-rc.9