### PR TITLE
Bump dependency requirements

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -8,3 +8,7 @@ extend-ignore-re = [
     # Patterns which appear to be 16 or more hex characters
     '\b[0-9A-Fa-f]{16,}\b',
 ]
+
+[default.extend-words]
+consts = "consts"
+cpy = "cpy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b86f658b0f536411ee61c10cec8376f83375b0c98bdc6a640e249f01549d0"
+checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -18,25 +18,25 @@ dependencies = [
 
 [[package]]
 name = "aead-stream"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "aead",
 ]
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
+checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "aead",
  "aes",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.12.0-rc.2"
+version = "0.12.0-rc.3"
 dependencies = [
  "aead",
  "aes",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 dependencies = [
  "aead",
  "aes",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "ascon-aead128"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "aead",
  "ascon",
@@ -111,18 +111,18 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d9cc93a6506887eed92e4e9459c13469eee4ef2b2af305a182ebf53e4d6a3"
+checksum = "0e3b1e9d1ad19c345095575076767febd525013fc5782276a21069901815ea45"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "belt-ctr"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c29c60fc2c2dde42f07616fcede769e6bebacf35b4ffbb046cb847dfe03c7c"
+checksum = "60e7bec27a46c5aa78db395601672fc329517993e9f8e5c95c9c96990d6165f1"
 dependencies = [
  "belt-block",
  "cipher",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "belt-dwp"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "aead",
  "belt-block",
@@ -172,7 +172,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "ccm"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "aead",
  "aes",
@@ -190,9 +190,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.9"
+version = "0.10.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
+checksum = "c536927023d1c432e6e23a25ef45f6756094eac2ab460db5fb17a772acdfd312"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "aead",
  "chacha20",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.6"
+version = "0.5.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba4d87abf4032a6d927f84b71af5086128a3349b929b4501c51a0fe0981a937"
+checksum = "9002c8edb9b1e21938663da3489c9c4403bba2393997fb2ecbd401386c0e71dc"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f22bad4cbf035f087384fa49d3c5d105af29801fe3d04831a737a982d67cd0"
+checksum = "cdc38bbb1aee462c696ea55990b6e2a2ea5c5f02ebd667bb676ce54eff6e9d33"
 dependencies = [
  "cipher",
  "dbl",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "cpubits"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251aaca52dbc19119279d9364222e188ffdf48006791040bfd002617ab0ebc41"
+checksum = "11a8c0210fa48ba3ea04ac1e9c6e72ae66009db3b1f1745635d4ff2e58eaadd0"
 
 [[package]]
 name = "cpufeatures"
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
+checksum = "65ea71550d18331d179854662ab330bb54306b9b56020d0466aae2a58f4e17c1"
 dependencies = [
  "cipher",
 ]
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "deoxys"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "aead",
  "aes",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "aead",
  "aes",
@@ -326,9 +326,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
-version = "0.4.0-rc.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f70a332ddf75e5e5e43284304179ba02f391f82f692f030b08a8378adf3c99"
+checksum = "cd66c162c2a0609c0507f49814877c621d00cb85978e6fbbf04e88b8048c07c8"
 dependencies = [
  "cfg-if",
  "libc",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2450dbd372f0b86224cdb9220351b1d5384e0aa0d29a50defd22b29a12f5e50"
+checksum = "f484be0236661c5ba22d445ed75d3624ba5544541c647549f867fb576e55b2a2"
 dependencies = [
  "polyval",
 ]
@@ -443,7 +443,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ocb3"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "aead",
  "aead-stream",
@@ -464,9 +464,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "pmac"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedfe418db7dc831d5108be56451ea366147c38cf2c2e2ea0700449040dd2184"
+checksum = "13cb649fd36f1a370bdc1a58fc61ce13a836d0f71f9fc18ec3ca7adc0f203727"
 dependencies = [
  "cipher",
  "dbl",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.4"
+version = "0.9.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54ecc48420a43ccac4e81088bc994e02ded1381a82564a982940966c3a9bd1c"
+checksum = "518693a4015fbfd281debf35bcac145ba2e180ae325ec855fdb405be0b2971fb"
 dependencies = [
  "cpufeatures",
  "universal-hash",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.6"
+version = "0.7.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c26fb288ad859274ad7e33746324ab027f70802d54bfadf07732b93bbe3ef7"
+checksum = "63641a86fddf4b5274f31c43734458ec7acd3133016dbaa37e4e247e1e9acd46"
 dependencies = [
  "cpubits",
  "cpufeatures",
@@ -530,9 +530,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "semver"
@@ -619,9 +619,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82084f2919885ea910502c74f0a362827aaad3d28d142ca97448bfb39c7e271a"
+checksum = "058482a494bb3c9c39447d8b40a3a0f38ebb3dccaf02c5a2d681e69035f8da11"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -638,18 +638,18 @@ dependencies = [
 
 [[package]]
 name = "wasip3"
-version = "0.3.1+wasi-0.3.0-rc-2025-09-16"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba4be47b1d11244670d11857eee0758a8f2c39aea64d80b78c1ce29b4642cd"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.48.1",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876fe286f2fa416386deedebe8407e6f19e0b5aeaef3d03161e77a15fa80f167"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
@@ -687,18 +687,18 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.48.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8c2adb5f74ac9395bc3121c99a1254bf9310482c27b13f97167aedb5887138"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.48.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b881a098cae03686d7a0587f8f306f8a58102ad8da8b5599100fbe0e7f5800b"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.48.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69667efa439a453e1d50dac939c6cab6d2c3ac724a9d232b6631dad2472a5b70"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.48.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae2e22cceb5d105d52326c07e3e67603a861cc7add70fc467f7cc7ec5265017"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0c57df25e7ee612d946d3b7646c1ddb2310f8280aa2c17e543b66e0812241"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.241.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ef1c6ad67f35c831abd4039c02894de97034100899614d1c44e2268ad01c91"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "xaes-256-gcm"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "aead",
  "aead-stream",

--- a/aead-stream/Cargo.toml
+++ b/aead-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead-stream"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 description = "Generic implementation of the STREAM online authenticated encryption construction"
 authors = ["RustCrypto Developers"]
 edition = "2024"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
+aead = { version = "0.6.0-rc.10", default-features = false }
 
 [features]
 alloc = ["aead/alloc"]

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.12.0-rc.2"
+version = "0.12.0-rc.3"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific
@@ -17,16 +17,16 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-aes = { version = "0.9.0-rc.2", optional = true }
-cipher = "0.5.0-rc.6"
-ctr = "0.10.0-rc.2"
-polyval = { version = "0.7.0-rc.6", default-features = false }
+aead = { version = "0.6.0-rc.10", default-features = false }
+aes = { version = "0.9.0-rc.4", optional = true }
+cipher = "0.5.0-rc.8"
+ctr = "0.10.0-rc.3"
+polyval = { version = "0.7.0-rc.7", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
 
 [features]
 default = ["aes", "alloc", "getrandom"]

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher
@@ -17,18 +17,18 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-cipher = "0.5.0-rc.6"
-ctr = "0.10.0-rc.2"
-ghash = { version = "0.6.0-rc.4", default-features = false }
+aead = { version = "0.6.0-rc.10", default-features = false }
+cipher = "0.5.0-rc.8"
+ctr = "0.10.0-rc.3"
+ghash = { version = "0.6.0-rc.5", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
-aes = { version = "0.9.0-rc.2", optional = true }
+aes = { version = "0.9.0-rc.4", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6.0-rc.10", features = ["alloc", "dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-siv"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 description = """
 Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 5297) with optional architecture-specific
@@ -17,20 +17,20 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = "0.6.0-rc.8"
-aes = "0.9.0-rc.2"
-cipher = "0.5.0-rc.6"
-cmac = "0.8.0-rc.3"
-ctr = "0.10.0-rc.2"
+aead = "0.6.0-rc.10"
+aes = "0.9.0-rc.4"
+cipher = "0.5.0-rc.8"
+cmac = "0.8.0-rc.4"
+ctr = "0.10.0-rc.3"
 dbl = "0.5"
-digest = { version = "0.11.0-rc.9", features = ["mac"] }
+digest = { version = "0.11.0-rc.11", features = ["mac"] }
 
 # optional dependencies
-pmac = { version = "0.8.0-rc.3", optional = true }
+pmac = { version = "0.8.0-rc.4", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6.0-rc.10", features = ["alloc", "dev"], default-features = false }
 blobby = "0.4"
 hex-literal = "1"
 

--- a/ascon-aead128/Cargo.toml
+++ b/ascon-aead128/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon-aead128"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 description = "Implementation of the Ascon-AEAD128 authenticated encryption scheme"
 authors = ["RustCrypto Developers"]
 edition = "2024"
@@ -12,13 +12,13 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
+aead = { version = "0.6.0-rc.10", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false, features = ["derive"] }
 ascon = "0.5.0-rc.0"
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["dev"] }
+aead = { version = "0.6.0-rc.10", features = ["dev"] }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-dwp"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 description = "Pure Rust implementation of the Belt-DWP authenticated encryption algorithm (STB 34.101.31-2020)"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,12 +12,12 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-belt-block = { version = "0.2.0-rc.2" }
-belt-ctr = { version = "0.2.0-rc.2" }
+aead = { version = "0.6.0-rc.10", default-features = false }
+belt-block = { version = "0.2.0-rc.3" }
+belt-ctr = { version = "0.2.0-rc.3" }
 opaque-debug = { version = "0.3" }
 subtle = { version = "2", default-features = false }
-universal-hash = { version = "0.6.0-rc.7" }
+universal-hash = { version = "0.6.0-rc.10" }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/belt-dwp/src/lib.rs
+++ b/belt-dwp/src/lib.rs
@@ -80,13 +80,13 @@ pub use belt_block::BeltBlock;
 use aead::array::ArraySize;
 use aead::consts::{True, U8, U16};
 use aead::{TagPosition, inout::InOutBuf};
-use belt_block::cipher::crypto_common::InnerUser;
+use belt_block::cipher::common::InnerUser;
 use belt_block::cipher::{Block, BlockCipherEncrypt, StreamCipher};
 use belt_ctr::cipher::InnerIvInit;
 use belt_ctr::{BeltCtr, BeltCtrCore};
 use core::marker::PhantomData;
 use universal_hash::UniversalHash;
-use universal_hash::crypto_common::{BlockSizeUser, InnerInit};
+use universal_hash::common::{BlockSizeUser, InnerInit};
 use universal_hash::typenum::{IsLessOrEqual, NonZero};
 
 /// Nonce type for [`Dwp`]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.56"
 [dependencies]
 criterion = "0.4.0"
 rand = "0.9.0"
-aes = "0.9.0-rc.2"
+aes = "0.9.0-rc.4"
 aes-gcm = { path = "../aes-gcm/" }
 aes-gcm-siv = { path = "../aes-gcm-siv/" }
 ascon-aead128 = { path = "../ascon-aead128/" }

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2024"
@@ -14,14 +14,14 @@ keywords = ["encryption", "aead"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-cipher = { version = "0.5.0-rc.6", default-features = false }
-ctr = { version = "0.10.0-rc.2", default-features = false }
+aead = { version = "0.6.0-rc.10", default-features = false }
+cipher = { version = "0.5.0-rc.8", default-features = false }
+ctr = { version = "0.10.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
-aes = { version = "0.9.0-rc.2" }
+aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aes = { version = "0.9.0-rc.4" }
 hex-literal = "1"
 
 [features]

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-chacha20 = { version = "0.10.0-rc.9", default-features = false, features = ["xchacha"] }
-cipher = "0.5.0-rc.6"
-poly1305 = "0.9.0-rc.4"
+aead = { version = "0.6.0-rc.10", default-features = false }
+chacha20 = { version = "0.10.0-rc.10", default-features = false, features = ["xchacha"] }
+cipher = "0.5.0-rc.8"
+poly1305 = "0.9.0-rc.5"
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deoxys"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 description = """
 Pure Rust implementation of the Deoxys Authenticated Encryption with Associated
 Data (AEAD) cipher, including the Deoxys-II variant which was selected by the
@@ -18,13 +18,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-aes = { version = "0.9.0-rc.2", features = ["hazmat"], default-features = false }
+aead = { version = "0.6.0-rc.10", default-features = false }
+aes = { version = "0.9.0-rc.4", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 description = """
 Pure Rust implementation of the EAX
 Authenticated Encryption with Associated Data (AEAD) Cipher
@@ -20,15 +20,15 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-cipher = "0.5.0-rc.6"
+aead = { version = "0.6.0-rc.10", default-features = false }
+cipher = "0.5.0-rc.8"
 cmac = "0.8.0-rc.3"
-ctr = "0.10.0-rc.2"
+ctr = "0.10.0-rc.3"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
-aes = "0.9.0-rc.2"
+aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aes = "0.9.0-rc.4"
 
 [features]
 default = ["alloc"]

--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -133,8 +133,8 @@ pub use cipher;
 
 use aead::{TagPosition, inout::InOutBuf};
 use cipher::{
-    BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore, array::Array, consts::U16,
-    crypto_common::OutputSizeUser, typenum::Unsigned,
+    BlockCipherEncrypt, BlockSizeUser, InnerIvInit, StreamCipherCore, array::Array,
+    common::OutputSizeUser, consts::U16, typenum::Unsigned,
 };
 use cmac::{Cmac, Mac, digest::Output};
 use core::marker::PhantomData;

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocb3"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 description = """
 Pure Rust implementation of the Offset Codebook Mode v3 (OCB3) Authenticated Encryption with
 Associated Data (AEAD) Cipher as described in RFC7253
@@ -16,17 +16,17 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-cipher = "0.5.0-rc.6"
-ctr = "0.10.0-rc.2"
+aead = { version = "0.6.0-rc.10", default-features = false }
+cipher = "0.5.0-rc.8"
+ctr = "0.10.0-rc.3"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }
-aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }
+aead-stream = { version = "0.6.0-rc.3", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
-aes = { version = "0.9.0-rc.2", default-features = false }
+aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aes = { version = "0.9.0-rc.4", default-features = false }
 hex-literal = "1"
 
 [features]

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xaes-256-gcm"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 description = """
 Pure Rust implementation of the XAES-256-GCM extended-nonce Authenticated
 Encryption with Associated Data (AEAD).
@@ -16,14 +16,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.8", default-features = false }
-aes = "0.9.0-rc.2"
-aes-gcm = { version = "0.11.0-rc.2", default-features = false, features = ["aes"] }
-cipher = "0.5.0-rc.6"
+aead = { version = "0.6.0-rc.10", default-features = false }
+aes = "0.9.0-rc.4"
+aes-gcm = { version = "0.11.0-rc.3", default-features = false, features = ["aes"] }
+cipher = "0.5.0-rc.8"
 aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.8", features = ["dev"], default-features = false }
+aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]


### PR DESCRIPTION
Updates the following dependency requirements in Cargo.toml files:

- `aead` v0.6.0-rc.10
- `aes` v0.9.0-rc.4
- `belt-block` v0.2.0-rc.3
- `belt-ctr` v0.2.0-rc.3
- `chacha20` v0.10.0-rc.10
- `cipher` v0.5.0-rc.6
- `cmac` v0.8.0-rc.4
- `ctr` v0.10.0-rc.2
- `digest` v0.11.0-rc.11
- `ghash` v0.6.0-rc.5
- `pmac` v0.8.0-rc.4
- `poly1305` v0.9.0-rc.5
- `polyval` v0.7.0-rc.6
- `universal-hash` v0.6.0-rc.10

Releases the following new versions:
- `aead-stream` v0.6.0-rc.3
- `aes-gcm` v0.11.0-rc.3
- `aes-gcm-siv` v0.12.0-rc.3
- `aes-siv` v0.8.0-rc.3
- `ascon-aead128` v0.1.0-rc.3
- `belt-dwp` v0.1.0-rc.3
- `ccm` v0.6.0-rc.3
- `chacha20poly1305` v0.11.0-rc.3
- `deoxys` v0.2.0-rc.3
- `eax` v0.6.0-rc.3
- `ocb3` v0.2.0-rc.3
- `xaes-256-gcm` v0.1.0-rc.3