### PR TITLE
Bump `cipher` to v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.8"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9002c8edb9b1e21938663da3489c9c4403bba2393997fb2ecbd401386c0e71dc"
+checksum = "64727038c8c5e2bb503a15b9f5b9df50a1da9a33e83e1f93067d914f2c6604a5"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.15"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
+checksum = "211f05e03c7d03754740fd9e585de910a095d6b99f8bcfffdef8319fa02a8331"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -376,9 +376,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41fb3dc24fe72c2e3a4685eed55917c2fb228851257f4a8f2d985da9443c3e5"
+checksum = "e1b229d73f5803b562cc26e4da0396c8610a4ee209f4fac8fa4f8d709166dc45"
 dependencies = [
  "typenum",
  "zeroize",

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
 aes = { version = "0.9.0-rc.4", optional = true }
-cipher = "0.5.0-rc.8"
+cipher = "0.5"
 ctr = "0.10.0-rc.3"
 polyval = { version = "0.7.0-rc.7", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
-cipher = "0.5.0-rc.8"
+cipher = "0.5"
 ctr = "0.10.0-rc.3"
 ghash = { version = "0.6.0-rc.5", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 [dependencies]
 aead = "0.6.0-rc.10"
 aes = "0.9.0-rc.4"
-cipher = "0.5.0-rc.8"
+cipher = "0.5"
 cmac = "0.8.0-rc.4"
 ctr = "0.10.0-rc.3"
 dbl = "0.5"

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
-cipher = { version = "0.5.0-rc.8", default-features = false }
+cipher = { version = "0.5", default-features = false }
 ctr = { version = "0.10.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
 chacha20 = { version = "0.10.0-rc.10", default-features = false, features = ["xchacha"] }
-cipher = "0.5.0-rc.8"
+cipher = "0.5"
 poly1305 = "0.9.0-rc.5"
 zeroize = { version = "1.8", optional = true, default-features = false }
 

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
-cipher = "0.5.0-rc.8"
+cipher = "0.5"
 cmac = "0.8.0-rc.3"
 ctr = "0.10.0-rc.3"
 subtle = { version = "2", default-features = false }

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
-cipher = "0.5.0-rc.8"
+cipher = "0.5"
 ctr = "0.10.0-rc.3"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 aead = { version = "0.6.0-rc.10", default-features = false }
 aes = "0.9.0-rc.4"
 aes-gcm = { version = "0.11.0-rc.3", default-features = false, features = ["aes"] }
-cipher = "0.5.0-rc.8"
+cipher = "0.5"
 aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Release PR: RustCrypto/traits#2281