### PR TITLE
fix(deoxys): skip redundant block cipher call for empty tail in Deoxys-II CTR

### DIFF
--- a/deoxys/src/modes.rs
+++ b/deoxys/src/modes.rs
@@ -380,11 +380,13 @@ where
             });
         }
         let mut data = tail;
-        let index = blocks_len;
+        if !data.is_empty() {
+            let index = blocks_len;
 
-        encrypt_decrypt_block::<B, _>(index, tweak, subkeys, nonce, |block| {
-            data.xor_in2out((block[..data.len()]).into())
-        });
+            encrypt_decrypt_block::<B, _>(index, tweak, subkeys, nonce, |block| {
+                data.xor_in2out((block[..data.len()]).into())
+            });
+        }
     }
 }
 


### PR DESCRIPTION
encrypt_decrypt_message in Deoxys-II unconditionally called encrypt_decrypt_block for the tail (partial block) even when the buffer length is an exact multiple of 16. This resulted in a wasted AES block cipher invocation that produced no output - xor_in2out on an empty slice is a no-op but the encryption still ran.

Every other tail-handling site in the same file (compute_ad_tag, authenticate_message, Deoxys-I encrypt_inout/decrypt_inout) guards with an is_empty() check. The Oasis Labs reference implementation also gates on remaining_bytes > 0.

Add if !data.is_empty() guard before the tail encrypt_decrypt_block call, consistent with the rest of the codebase.