### PR TITLE
fix(ocb3): Fix asymmetric bounds check vulnerability in encrypt/decrypt

### DIFF
--- a/ocb3/src/lib.rs
+++ b/ocb3/src/lib.rs
@@ -286,7 +286,7 @@ where
         buffer: InOutBuf<'_, '_, u8>,
     ) -> aead::Result<aead::Tag<Self>> {
         let max_len = 1 << (L_TABLE_SIZE + 4);
-        if (buffer.len() > max_len) || (associated_data.len() > max_len) {
+        if (buffer.len() >= max_len) || (associated_data.len() >= max_len) {
             return Err(aead::Error);
         }
 


### PR DESCRIPTION
### 🐛 **Critical Security Fix: OCB3 Asymmetric Bounds Check Vulnerability**

#### **Problem**
The OCB3 implementation had inconsistent bounds checking between encrypt and decrypt operations:

- **Encrypt** (line 206): `if (buffer.len() >= max_len) || (associated_data.len() >= max_len)`
- **Decrypt** (line 289): `if (buffer.len() > max_len) || (associated_data.len() > max_len)` ❌

This asymmetry created a critical vulnerability where:
1. Decryption would accept inputs of exactly `max_len` bytes that encryption would reject
2. At the boundary condition (`max_len = 1,073,741,824` bytes with default `L_TABLE_SIZE=26`), the `ntz(i)` function could cause out-of-bounds access to `self.ll[ntz(i)]`
3. This could lead to **panic conditions** and potential **security bypass**

#### **Solution**
Changed the decrypt bounds check to match encrypt:
```rust
// Before (vulnerable)
if (buffer.len() > max_len) || (associated_data.len() > max_len) {

// After (fixed)
if (buffer.len() >= max_len) || (associated_data.len() >= max_len) {
```