### PR TITLE
chore(deps): bump dependencies to release versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,13 +25,13 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -111,18 +111,18 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3b1e9d1ad19c345095575076767febd525013fc5782276a21069901815ea45"
+checksum = "0304188fd8684b910d24cae451c724cd5140a037c407e696247e94bb57b06434"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "belt-ctr"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e7bec27a46c5aa78db395601672fc329517993e9f8e5c95c9c96990d6165f1"
+checksum = "618f4ade7527d77aa56ba5fb98d483ef83e42030f7c572cd9b0fb3e047cc66d7"
 dependencies = [
  "belt-block",
  "cipher",
@@ -195,7 +195,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "zeroize",
 ]
 
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7f5c25253a49afbdd6a256a21a554c509cf0e6400f59d6dd85e0f15b5f15f6"
+checksum = "ac78aa94ce13e432b332a4d1bf2eff167d3a2520188ee05b337180a42fd2e62e"
 dependencies = [
  "cipher",
  "dbl",
@@ -244,15 +244,6 @@ name = "cpubits"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -276,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee683dd898fbd052617b4514bc31f98bc32081a83b69ec46adef3b1ef4ae36f"
+checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
 dependencies = [
  "cipher",
 ]
@@ -481,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "pmac"
-version = "0.8.0-rc.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d4c706c1edefc97d37b1ce46960f9173597d5f808f900c56471c7dd47cd79e"
+checksum = "24ceb90ade0c891295d683cc9c70a798ebdba27b574e7f80b703d40d8b2e9123"
 dependencies = [
  "cipher",
  "dbl",
@@ -496,7 +487,7 @@ version = "0.9.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19feddcbdf17fad33f40041c7f9e768faf19455f32a6d52ba1b8b65ffc7b1cae"
 dependencies = [
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -507,7 +498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
-aes = { version = "0.9.0-rc.4", optional = true }
+aes = { version = "0.9", optional = true }
 cipher = "0.5"
-ctr = "0.10.0-rc.3"
-polyval = { version = "0.7.0-rc.7", default-features = false }
+ctr = "0.10"
+polyval = { version = "0.7", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -19,12 +19,12 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
 cipher = "0.5"
-ctr = "0.10.0-rc.3"
-ghash = { version = "0.6.0-rc.6", default-features = false }
+ctr = "0.10"
+ghash = { version = "0.6", default-features = false }
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
-aes = { version = "0.9.0-rc.4", optional = true }
+aes = { version = "0.9", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -18,15 +18,15 @@ rust-version = "1.85"
 
 [dependencies]
 aead = "0.6.0-rc.10"
-aes = "0.9.0-rc.4"
+aes = "0.9"
 cipher = "0.5"
-cmac = "0.8.0-rc.4"
-ctr = "0.10.0-rc.3"
+cmac = "0.8"
+ctr = "0.10"
 dbl = "0.5"
-digest = { version = "0.11.0-rc.11", features = ["mac"] }
+digest = { version = "0.11", features = ["mac"] }
 
 # optional dependencies
-pmac = { version = "0.8.0-rc.4", optional = true }
+pmac = { version = "0.8", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -13,10 +13,10 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
-belt-block = { version = "0.2.0-rc.3" }
-belt-ctr = { version = "0.2.0-rc.3" }
+belt-block = "0.2"
+belt-ctr = "0.2"
 subtle = { version = "2", default-features = false }
-universal-hash = { version = "0.6.0-rc.10" }
+universal-hash = { version = "0.6" }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -15,8 +15,8 @@ rust-version = "1.85"
 aead = { version = "0.6.0-rc.10", default-features = false }
 belt-block = "0.2"
 belt-ctr = "0.2"
+universal-hash = "0.6"
 subtle = { version = "2", default-features = false }
-universal-hash = { version = "0.6" }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/belt-dwp/src/lib.rs
+++ b/belt-dwp/src/lib.rs
@@ -83,7 +83,7 @@ use aead::{TagPosition, inout::InOutBuf};
 use belt_block::cipher::common::InnerUser;
 use belt_block::cipher::{Block, BlockCipherEncrypt, StreamCipher};
 use belt_ctr::cipher::InnerIvInit;
-use belt_ctr::{BeltCtr, BeltCtrCore};
+use belt_ctr::{GenericBeltCtr, GenericBeltCtrCore};
 use core::marker::PhantomData;
 use universal_hash::UniversalHash;
 use universal_hash::common::{BlockSizeUser, InnerInit};
@@ -162,8 +162,8 @@ where
         let mut ghash = GHash::new_with_init_block(&r, T);
 
         // Initialize CTR mode
-        let core = BeltCtrCore::inner_iv_init(&self.cipher, nonce);
-        let mut enc_cipher = BeltCtr::from_core(core);
+        let core = GenericBeltCtrCore::inner_iv_init(&self.cipher, nonce);
+        let mut enc_cipher = GenericBeltCtr::from_core(core);
 
         // 3. For 𝑖 = 1, 2, . . . , 𝑚 do:
         //  3.1 𝑡 ← 𝑡 ⊕ (𝐼𝑖 ‖ 0^{128−|𝐼𝑖|})
@@ -232,8 +232,8 @@ where
             // 8. For 𝑖 = 1,2,...,𝑛 do:
             // 8.1. 𝑠 ← 𝑠 ⊞ ⟨1⟩128;
             // 8.2. 𝑋𝑖 ← 𝑌𝑖 ⊕ Lo(belt-block(𝑠, 𝐾), |𝑌𝑖|)
-            let core = BeltCtrCore::inner_iv_init(&self.cipher, nonce);
-            let mut enc_cipher = BeltCtr::from_core(core);
+            let core = GenericBeltCtrCore::inner_iv_init(&self.cipher, nonce);
+            let mut enc_cipher = GenericBeltCtr::from_core(core);
             enc_cipher.apply_keystream_inout(buffer);
             Ok(())
         } else {

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.56"
 [dependencies]
 criterion = "0.4.0"
 rand = "0.9.0"
-aes = "0.9.0-rc.4"
+aes = "0.9"
 aes-gcm = { path = "../aes-gcm/" }
 aes-gcm-siv = { path = "../aes-gcm-siv/" }
 ascon-aead128 = { path = "../ascon-aead128/" }

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -16,12 +16,12 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
 cipher = { version = "0.5", default-features = false }
-ctr = { version = "0.10.0-rc.3", default-features = false }
+ctr = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
-aes = { version = "0.9.0-rc.4" }
+aes = "0.9"
 hex-literal = "1"
 
 [features]

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
-aes = { version = "0.9.0-rc.4", features = ["hazmat"], default-features = false }
+aes = { version = "0.9", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -22,13 +22,13 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
 cipher = "0.5"
-cmac = "0.8.0-rc.3"
-ctr = "0.10.0-rc.3"
+cmac = "0.8"
+ctr = "0.10"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
-aes = "0.9.0-rc.4"
+aes = "0.9"
 
 [features]
 default = ["alloc"]

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
 cipher = "0.5"
-ctr = "0.10.0-rc.3"
+ctr = "0.10"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }
 aead-stream = { version = "0.6.0-rc.3", optional = true, default-features = false }
@@ -26,7 +26,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
-aes = { version = "0.9.0-rc.4", default-features = false }
+aes = { version = "0.9", default-features = false }
 hex-literal = "1"
 
 [features]

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 aead = { version = "0.6.0-rc.10", default-features = false }
-aes = "0.9.0-rc.4"
+aes = "0.9"
 aes-gcm = { version = "0.11.0-rc.3", default-features = false, features = ["aes"] }
 cipher = "0.5"
 aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }


### PR DESCRIPTION
This bumps:
 - `aes` to `0.9.0`
 - `belt-block` to `0.2.0`
 - `belt-ctr` to `0.2.0`
 - `cmac` to `0.8.0`
 - `ctr` to `0.10.0`
 - `ghash` to `0.6.0`
 - `pmac` to `0.8.0`
 - `universal-hash` to `0.6.1`