### PR TITLE
chacha20poly1305: bump `poly1305` dependency to v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19feddcbdf17fad33f40041c7f9e768faf19455f32a6d52ba1b8b65ffc7b1cae"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
 dependencies = [
  "cpufeatures",
  "universal-hash",

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -23,7 +23,7 @@ rust-version = "1.85"
 aead = { version = "0.6.0-rc.10", default-features = false }
 chacha20 = { version = "0.10", default-features = false, features = ["xchacha"] }
 cipher = "0.5"
-poly1305 = "0.9.0-rc.6"
+poly1305 = "0.9"
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Release PR: RustCrypto/universal-hashes#333