### PR TITLE
Bump `aead` dependency to v0.6 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.10"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
+checksum = "ef60ac202874e574ce7a7158cc8bca7313dd344322482e4fadee288bf4a306b8"
 dependencies = [
  "arrayvec",
  "blobby",

--- a/aead-stream/Cargo.toml
+++ b/aead-stream/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 
 [features]
 alloc = ["aead/alloc"]

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 aes = { version = "0.9", optional = true }
 cipher = "0.5"
 ctr = "0.10"
@@ -26,7 +26,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aead = { version = "0.6", features = ["dev"], default-features = false }
 
 [features]
 default = ["aes", "alloc", "getrandom"]

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 cipher = "0.5"
 ctr = "0.10"
 ghash = { version = "0.6", default-features = false }
@@ -28,7 +28,7 @@ aes = { version = "0.9", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6", features = ["alloc", "dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = "0.6.0-rc.10"
+aead = "0.6"
 aes = "0.9"
 cipher = "0.5"
 cmac = "0.8"
@@ -30,7 +30,7 @@ pmac = { version = "0.8", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["alloc", "dev"], default-features = false }
+aead = { version = "0.6", features = ["alloc", "dev"], default-features = false }
 blobby = "0.4"
 hex-literal = "1"
 

--- a/ascon-aead128/Cargo.toml
+++ b/ascon-aead128/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false, features = ["derive"] }
 ascon = "0.5.0-rc.0"
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["dev"] }
+aead = { version = "0.6", features = ["dev"] }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 belt-block = "0.2"
 belt-ctr = "0.2"
 universal-hash = "0.6"

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["encryption", "aead"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 cipher = { version = "0.5", default-features = false }
 ctr = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aead = { version = "0.6", features = ["dev"], default-features = false }
 aes = "0.9"
 hex-literal = "1"
 

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 chacha20 = { version = "0.10", default-features = false, features = ["xchacha"] }
 cipher = "0.5"
 poly1305 = "0.9"
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aead = { version = "0.6", features = ["dev"], default-features = false }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 aes = { version = "0.9", features = ["hazmat"], default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aead = { version = "0.6", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 cipher = "0.5"
 cmac = "0.8"
 ctr = "0.10"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aead = { version = "0.6", features = ["dev"], default-features = false }
 aes = "0.9"
 
 [features]

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 cipher = "0.5"
 ctr = "0.10"
 dbl = "0.5"
@@ -25,7 +25,7 @@ aead-stream = { version = "0.6.0-rc.3", optional = true, default-features = fals
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aead = { version = "0.6", features = ["dev"], default-features = false }
 aes = { version = "0.9", default-features = false }
 hex-literal = "1"
 

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -16,14 +16,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false }
+aead = { version = "0.6", default-features = false }
 aes = "0.9"
 aes-gcm = { version = "0.11.0-rc.3", default-features = false, features = ["aes"] }
 cipher = "0.5"
 aead-stream = { version = "0.6.0-rc.2", optional = true, default-features = false }
 
 [dev-dependencies]
-aead = { version = "0.6.0-rc.10", features = ["dev"], default-features = false }
+aead = { version = "0.6", features = ["dev"], default-features = false }
 hex-literal = "1"
 
 [features]


### PR DESCRIPTION
Release PR: RustCrypto/traits#2440