### PR TITLE
Add accumulated randomized tests to xaes-256-gcm

### DIFF
--- a/.github/workflows/xaes-256-gcm.yml
+++ b/.github/workflows/xaes-256-gcm.yml
@@ -71,5 +71,5 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --lib
       #- run: cargo test --target ${{ matrix.target }} --lib --features zeroize
       - run: cargo test --target ${{ matrix.target }} --all-features --lib
-      - run: cargo test --target ${{ matrix.target }} --all-features --release
+      - run: cargo test --target ${{ matrix.target }} --all-features --release -- --include-ignored
       - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +457,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +522,7 @@ dependencies = [
  "aes-gcm",
  "cipher",
  "hex-literal",
+ "shake",
 ]
 
 [[package]]

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -25,6 +25,7 @@ aead-stream = { version = "0.6", optional = true, default-features = false }
 [dev-dependencies]
 aead = { version = "0.6", features = ["dev"], default-features = false }
 hex-literal = "1"
+shake = { version = "0.1.0", default-features = false }
 
 [features]
 default = ["alloc", "getrandom"]

--- a/xaes-256-gcm/tests/xaes256gcm.rs
+++ b/xaes-256-gcm/tests/xaes256gcm.rs
@@ -7,11 +7,12 @@ mod common;
 use aes_gcm::aead::{Aead, AeadInOut, KeyInit, Payload, array::Array};
 use common::TestVector;
 use hex_literal::hex;
-use xaes_256_gcm::Xaes256Gcm;
+use shake::{ExtendableOutput, Shake128, Update, XofReader};
+use xaes_256_gcm::{Key, Nonce, Xaes256Gcm};
 
 /// C2SP XAES-256-GCM test vectors
 ///
-/// <https://github.com/C2SP/C2SP/blob/main/XAES-256-GCM.md>
+/// <https://c2sp.org/XAES-256-GCM#test-vectors>
 const TEST_VECTORS: &[TestVector<[u8; 32], [u8; 24]>] = &[
     TestVector {
         key: &hex!("0101010101010101010101010101010101010101010101010101010101010101"),
@@ -32,3 +33,72 @@ const TEST_VECTORS: &[TestVector<[u8; 32], [u8; 24]>] = &[
 ];
 
 tests!(Xaes256Gcm, TEST_VECTORS);
+
+/// C2SP XAES-256-GCM accumulated randomized tests.
+///
+/// <https://c2sp.org/XAES-256-GCM#accumulated-randomized-tests>
+fn run_accumulated_test(iterations: usize, expected: [u8; 32]) {
+    let mut seed = Shake128::default().finalize_xof();
+    let mut digest = Shake128::default();
+
+    for _ in 0..iterations {
+        let mut key = Key::<Xaes256Gcm>::default();
+        seed.read(&mut key);
+        let mut nonce = Nonce::default();
+        seed.read(&mut nonce);
+        let mut length = [0u8; 1];
+        seed.read(&mut length);
+        let mut plaintext = vec![0u8; length[0] as usize];
+        seed.read(&mut plaintext);
+        seed.read(&mut length);
+        let mut aad = vec![0u8; length[0] as usize];
+        seed.read(&mut aad);
+
+        let cipher = Xaes256Gcm::new(&key);
+        let ciphertext = cipher
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: &plaintext,
+                    aad: &aad,
+                },
+            )
+            .unwrap();
+
+        let decrypted = cipher
+            .decrypt(
+                &nonce,
+                Payload {
+                    msg: &ciphertext,
+                    aad: &aad,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(plaintext, decrypted);
+
+        digest.update(&ciphertext);
+    }
+
+    let mut reader = digest.finalize_xof();
+    let mut buf = [0u8; 32];
+    reader.read(&mut buf);
+    assert_eq!(expected, buf);
+}
+
+#[test]
+fn accumulated_randomized_10_000_iterations() {
+    run_accumulated_test(
+        10_000,
+        hex!("e6b9edf2df6cec60c8cbd864e2211b597fb69a529160cd040d56c0c210081939"),
+    );
+}
+
+#[test]
+#[ignore = "slow in debug; run with `cargo test --release -- --include-ignored`"]
+fn accumulated_randomized_1_000_000_iterations() {
+    run_accumulated_test(
+        1_000_000,
+        hex!("2163ae1445985a30b60585ee67daa55674df06901b890593e824b8a7c885ab15"),
+    );
+}


### PR DESCRIPTION
Fixes #864. 

The current tests for `xaes-256-gcm` include the [C2SP test vectors](https://c2sp.org/XAES-256-GCM#test-vectors) but are missing the additional [C2SP accumulated randomized tests](https://c2sp.org/XAES-256-GCM#accumulated-randomized-tests).

This PR adds the missing tests, verifying the output against the C2SP expected hash for both 10,000 and 1,000,000 iterations. The `shake` crate is added as a dev-only dependency enabling `Shake128` hashing.

## **NOTE**

The `accumulated_randomized_1_000_000_iterations` takes a long time (~172s) when run using the default debug mode `cargo test`. However, the test is fast (~2s) when run with `cargo test --release`. I added an `#[ignore]` to the test so it doesn't punish casual `cargo test` runs and updated the xaes-256-gcm CI workflow to `--include-ignored`. Is this solution acceptable?