### PR TITLE
Fix incorrect `aes_gcm` constants used in xaes-256-gcm

### DIFF
--- a/xaes-256-gcm/src/lib.rs
+++ b/xaes-256-gcm/src/lib.rs
@@ -129,6 +129,9 @@ impl AeadInOut for Xaes256Gcm {
         buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag,
     ) -> Result<(), Error> {
+        // Operating in a detached state, where the tag is handled separately
+        // from the ciphertext, means the ciphertext is always the same length
+        // as the plaintext. So, checking `P_MAX` is acceptable.
         if buffer.len() as u64 > P_MAX || associated_data.len() as u64 > A_MAX {
             return Err(Error);
         }

--- a/xaes-256-gcm/src/lib.rs
+++ b/xaes-256-gcm/src/lib.rs
@@ -67,14 +67,10 @@ pub type Key<B = Aes256> = aes_gcm::Key<B>;
 pub type Tag<Size = TagSize> = aes_gcm::Tag<Size>;
 
 /// Maximum length of plaintext.
-pub const P_MAX: u64 = 1 << 36;
+pub const P_MAX: u64 = aes_gcm::P_MAX;
 
 /// Maximum length of associated data.
-// pub const A_MAX: u64 = 1 << 61;
-pub const A_MAX: u64 = 1 << 36;
-
-/// Maximum length of ciphertext.
-pub const C_MAX: u64 = (1 << 36) + 16;
+pub const A_MAX: u64 = aes_gcm::A_MAX;
 
 impl AeadCore for Xaes256Gcm {
     type NonceSize = NonceSize;
@@ -133,7 +129,7 @@ impl AeadInOut for Xaes256Gcm {
         buffer: InOutBuf<'_, '_, u8>,
         tag: &Tag,
     ) -> Result<(), Error> {
-        if buffer.len() as u64 > C_MAX || associated_data.len() as u64 > A_MAX {
+        if buffer.len() as u64 > P_MAX || associated_data.len() as u64 > A_MAX {
             return Err(Error);
         }
 


### PR DESCRIPTION
Fixes #837. 

Currently the max length constants for plaintext (`P_MAX`), associated data (`A_MAX`), and ciphertext (`C_MAX`) are not correct for `XAES-256-GCM`.

|         | Current          | Correct          |
|---------|------------------|------------------|
| `P_MAX` | `1 << 36`        | `(1 << 36) - 32` |
| `A_MAX` | `1 << 36`        | `(1 << 61) - 1`  |
| `C_MAX` | `(1 << 36) + 16` | `(1 << 36) - 32` |

This PR resolves this by using the `aes_gcm` crates constants instead of redefining them in this crate. Relying on the definition in `aes_gcm` makes sense because the underlying call to `aes_gcm` dictates the maximums for plaintext, aad, and ciphertext.

Additionally, the code previously included the 16-byte tag in the `C_MAX` length. However, the `AeadInOut` trait explicitly operates in a detached state where the tag is handled separately from the ciphertext, meaning the ciphertext is always the same length as the plaintext. So [the current `C_MAX` check in `decrypt_inout_detached()`](https://github.com/RustCrypto/AEADs/blob/0dfab31ae4d9a7b82f2dbf12116faa447d79335d/xaes-256-gcm/src/lib.rs#L136) can be replaced with a `P_MAX` check (alternatively, `C_MAX` could be defined as equivalent to `P_MAX`).

All tests run and pass.