### PR TITLE
eax: remove toplevel lint attributes

### DIFF
--- a/eax/src/lib.rs
+++ b/eax/src/lib.rs
@@ -5,8 +5,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![deny(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
 
 //! # Usage
 //!


### PR DESCRIPTION
These are now covered by the workspace-level lints