### PR TITLE
aes-gcm v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.4"
+version = "0.11.0"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2026-06-28)
 ### Added
 - `bytes` feature passthrough ([#631])
+- Support for 32-bit and 64-bit tags under `hazmat` feature ([#777])
 
 ### Changed
 - Bump `aead` from `0.5` to `0.6` ([#583])
@@ -19,9 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `getrandom` feature renamed as `os_rng` ([#662])
 
 ### Fixed
-- Plaintext and associated data length checks ([#762])
+- `P_MAX` and `A_MAX` constants; plaintext and AAD length checks ([#762])
 
-## Removed
+### Removed
 - `std` & `stream` features ([#662])
 - `C_MAX` constant ([#762])
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#631]: https://github.com/RustCrypto/AEADs/pull/631
 [#662]: https://github.com/RustCrypto/AEADs/pull/662
 [#762]: https://github.com/RustCrypto/AEADs/pull/762
+[#777]: https://github.com/RustCrypto/AEADs/pull/777
 
 ## 0.10.3 (2023-09-21)
 ### Security

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.11.0-rc.4"
+version = "0.11.0"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/aes-gcm/LICENSE-MIT
+++ b/aes-gcm/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019 The RustCrypto Project Developers
+Copyright (c) 2019-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/xaes-256-gcm/Cargo.toml
+++ b/xaes-256-gcm/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6", default-features = false }
 aes = "0.9"
-aes-gcm = { version = "0.11.0-rc.3", default-features = false, features = ["aes"] }
+aes-gcm = { version = "0.11", default-features = false, features = ["aes"] }
 cipher = "0.5"
 aead-stream = { version = "0.6", optional = true, default-features = false }
 


### PR DESCRIPTION
## Added
- `bytes` feature passthrough ([#631])
- Support for 32-bit and 64-bit tags under `hazmat` feature ([#777])

## Changed
- Bump `aead` from `0.5` to `0.6` ([#583])
- Bump `aes` from `0.8` to `0.9` ([#583])
- Bump `cipher` from `0.4` to `0.5` ([#583])
- Bump `ctr` from `0.9` to `0.10` ([#583])
- Bump `ghash` from `0.5` to `0.6` ([#583])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
- Relax MSRV policy and allow MSRV bumps in patch releases
- `getrandom` feature renamed as `os_rng` ([#662])

## Fixed
- `P_MAX` and `A_MAX` constants; plaintext and AAD length checks ([#762])

## Removed
- `std` & `stream` features ([#662])
- `C_MAX` constant ([#762])

[#583]: https://github.com/RustCrypto/AEADs/pull/583
[#631]: https://github.com/RustCrypto/AEADs/pull/631
[#662]: https://github.com/RustCrypto/AEADs/pull/662
[#762]: https://github.com/RustCrypto/AEADs/pull/762
[#777]: https://github.com/RustCrypto/AEADs/pull/777