### PR TITLE
chacha20poly1305 v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.11.0-rc.3"
+version = "0.11.0"
 dependencies = [
  "aead",
  "chacha20",

--- a/chacha20poly1305/CHANGELOG.md
+++ b/chacha20poly1305/CHANGELOG.md
@@ -4,20 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2026-06-28)
+### Added
+- `bytes` feature passthrough ([#631])
+
 ### Changed
-- Bump `aead` from `0.5` to `0.6` ([#583])
+- Bump `aead` from `0.5` to `0.6` ([#831])
+- Bump `chacha20` from `0.9` to `0.10` ([#796])
 - Bump `cipher` from `0.4` to `0.5` ([#583])
-- Bump `poly1305` from `0.8` to `0.9` ([#583])
+- Bump `poly1305` from `0.8` to `0.9` ([#823])
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
 - Relax MSRV policy and allow MSRV bumps in patch releases
-- `getrandom` feature renamed as `os_rng` ([#662])
 
-## Removed
+### Removed
 - `std` and `stream` features ([#662])
 
 [#583]: https://github.com/RustCrypto/AEADs/pull/583
+[#631]: https://github.com/RustCrypto/AEADs/pull/631
 [#662]: https://github.com/RustCrypto/AEADs/pull/662
+[#796]: https://github.com/RustCrypto/AEADs/pull/796
+[#823]: https://github.com/RustCrypto/AEADs/pull/823
+[#831]: https://github.com/RustCrypto/AEADs/pull/831
 
 ## 0.10.1 (2022-08-09)
 ### Added

--- a/chacha20poly1305/Cargo.toml
+++ b/chacha20poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20poly1305"
-version = "0.11.0-rc.3"
+version = "0.11.0"
 description = """
 Pure Rust implementation of the ChaCha20Poly1305 Authenticated Encryption
 with Additional Data Cipher (RFC 8439) with optional architecture-specific


### PR DESCRIPTION
## Added
- `bytes` feature passthrough ([#631])

## Changed
- Bump `aead` from `0.5` to `0.6` ([#831])
- Bump `chacha20` from `0.9` to `0.10` ([#796])
- Bump `cipher` from `0.4` to `0.5` ([#583])
- Bump `poly1305` from `0.8` to `0.9` ([#823])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
- Relax MSRV policy and allow MSRV bumps in patch releases

## Removed
- `std` and `stream` features ([#662])

[#583]: https://github.com/RustCrypto/AEADs/pull/583
[#631]: https://github.com/RustCrypto/AEADs/pull/631
[#662]: https://github.com/RustCrypto/AEADs/pull/662
[#796]: https://github.com/RustCrypto/AEADs/pull/796
[#823]: https://github.com/RustCrypto/AEADs/pull/823
[#831]: https://github.com/RustCrypto/AEADs/pull/831