### PR TITLE
ccm v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "ccm"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 dependencies = [
  "aead",
  "aes",

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -4,26 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (UNRELEASED)
+## 0.6.0 (2026-08-12)
 ### Added
 - `rand_core` feature ([#467])
-- `arrayvec` support ([#503])
+- `arrayvec` feature ([#503])
+- `bytes` feature ([#631])
 
 ### Changed
-- Bump `aead` from `0.5` to `0.6` ([#583])
-- Bump `cipher` from `0.4` to `0.5` ([#583])
-- Bump `ctr` from `0.9` to `0.10` ([#583])
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
 - Relax MSRV policy and allow MSRV bumps in patch releases
-- `getrandom` feature renamed as `os_rng` ([#662])
+- Migrate to `AeadInOut` ([#665])
+- Bump `cipher` to v0.5 ([#793])
+- Bump `aes` to v0.9 ([#821])
+- Bump `ctr` to v0.10 ([#821])
+- Bump `aead` to v0.6 ([#831])
 
-## Removed
+### Removed
 - `std` and `stream` features ([#662])
 
 [#467]: https://github.com/RustCrypto/AEADs/pull/467
 [#503]: https://github.com/RustCrypto/AEADs/pull/503
-[#583]: https://github.com/RustCrypto/AEADs/pull/583
+[#631]: https://github.com/RustCrypto/AEADs/pull/631
 [#662]: https://github.com/RustCrypto/AEADs/pull/662
+[#665]: https://github.com/RustCrypto/AEADs/pull/665
+[#793]: https://github.com/RustCrypto/AEADs/pull/793
+[#821]: https://github.com/RustCrypto/AEADs/pull/821
+[#831]: https://github.com/RustCrypto/AEADs/pull/831
 
 ## 0.5.0 (2022-07-30)
 ### Added

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2024"


### PR DESCRIPTION
## Added
- `rand_core` feature ([#467])
- `arrayvec` feature ([#503])
- `bytes` feature ([#631])

## Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
- Relax MSRV policy and allow MSRV bumps in patch releases
- Migrate to `AeadInOut` ([#665])
- Bump `cipher` to v0.5 ([#793])
- Bump `aes` to v0.9 ([#821])
- Bump `ctr` to v0.10 ([#821])
- Bump `aead` to v0.6 ([#831])

## Removed
- `std` and `stream` features ([#662])

[#467]: https://github.com/RustCrypto/AEADs/pull/467
[#503]: https://github.com/RustCrypto/AEADs/pull/503
[#631]: https://github.com/RustCrypto/AEADs/pull/631
[#662]: https://github.com/RustCrypto/AEADs/pull/662
[#665]: https://github.com/RustCrypto/AEADs/pull/665
[#793]: https://github.com/RustCrypto/AEADs/pull/793
[#821]: https://github.com/RustCrypto/AEADs/pull/821
[#831]: https://github.com/RustCrypto/AEADs/pull/831