### PR TITLE
aes-siv v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,11 +64,10 @@ dependencies = [
 
 [[package]]
 name = "aes-siv"
-version = "0.8.0-rc.3"
+version = "0.8.0"
 dependencies = [
  "aead",
  "aes",
- "blobby",
  "cipher",
  "cmac",
  "ctr",

--- a/aes-siv/CHANGELOG.md
+++ b/aes-siv/CHANGELOG.md
@@ -4,28 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.0 (UNRELEASED)
+## 0.8.0 (2026-08-12)
 ### Added
-- `arrayvec` support ([#503])
+- `rand_core` feature ([#467])
+- `arrayvec` feature ([#503])
+- `bytes` feature ([#631])
 
 ### Changed
-- Bump `aead` from `0.5` to `0.6` ([#583])
-- Bump `aes` from `0.8` to `0.9` ([#583])
-- Bump `cipher` from `0.4` to `0.5` ([#583])
-- Bump `ctr` from `0.9` to `0.10` ([#583])
-- Bump `dbl` from `0.3` to `0.4` ([#583])
-- Bump `digest` from `0.10` to `0.11` ([#583])
-- Bump `pmac` from `0.7` to `0.8` ([#583])
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
 - Relax MSRV policy and allow MSRV bumps in patch releases
-- `getrandom` feature renamed as `os_rng` ([#662])
+- Bump `cipher` to v0.5 ([#793])
+- Bump `aes` to v0.9 ([#821])
+- Bump `cmac` to v0.8 ([#821])
+- Bump `ctr` to v0.10 ([#821])
+- Bump `pmac` to v0.8 ([#821])
+- Bump `aead` to v0.6 ([#831])
 
-## Removed
+### Removed
 - `std` and `stream` features ([#662])
 
+[#467]: https://github.com/RustCrypto/AEADs/pull/467
 [#503]: https://github.com/RustCrypto/AEADs/pull/503
-[#583]: https://github.com/RustCrypto/AEADs/pull/583
+[#631]: https://github.com/RustCrypto/AEADs/pull/631
 [#662]: https://github.com/RustCrypto/AEADs/pull/662
+[#793]: https://github.com/RustCrypto/AEADs/pull/793
+[#821]: https://github.com/RustCrypto/AEADs/pull/821
+[#831]: https://github.com/RustCrypto/AEADs/pull/831
 
 ## 0.7.0 (2022-07-30)
 ### Added

--- a/aes-siv/Cargo.toml
+++ b/aes-siv/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "aes-siv"
-version = "0.8.0-rc.3"
+version = "0.8.0"
 description = """
-Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated
-Encryption Cipher (RFC 5297) with optional architecture-specific
-hardware acceleration
+Pure Rust implementation of the AES-SIV Misuse-Resistant Authenticated Encryption Cipher (RFC 5297)
+with optional architecture-specific hardware acceleration
 """
 authors = ["RustCrypto Developers"]
 edition = "2024"
@@ -31,7 +30,6 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6", features = ["alloc", "dev"], default-features = false }
-blobby = "0.4"
 hex-literal = "1"
 
 [features]


### PR DESCRIPTION
## Added
- `rand_core` feature ([#467])
- `arrayvec` feature ([#503])
- `bytes` feature ([#631])

## Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
- Relax MSRV policy and allow MSRV bumps in patch releases
- Bump `cipher` to v0.5 ([#793])
- Bump `aes` to v0.9 ([#821])
- Bump `cmac` to v0.8 ([#821])
- Bump `ctr` to v0.10 ([#821])
- Bump `pmac` to v0.8 ([#821])
- Bump `aead` to v0.6 ([#831])

## Removed
- `std` and `stream` features ([#662])

[#467]: https://github.com/RustCrypto/AEADs/pull/467
[#503]: https://github.com/RustCrypto/AEADs/pull/503
[#631]: https://github.com/RustCrypto/AEADs/pull/631
[#662]: https://github.com/RustCrypto/AEADs/pull/662
[#793]: https://github.com/RustCrypto/AEADs/pull/793
[#821]: https://github.com/RustCrypto/AEADs/pull/821
[#831]: https://github.com/RustCrypto/AEADs/pull/831