### PR TITLE
deoxys v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "deoxys"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 dependencies = [
  "aead",
  "aes",

--- a/deoxys/CHANGELOG.md
+++ b/deoxys/CHANGELOG.md
@@ -4,27 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-08-12)
 ### Added
 - `rand_core` feature ([#467])
-- `arrayvec` support ([#503])
+- `arrayvec` feature ([#503])
+- `bytes` feature ([#631])
+- `zeroize` feature ([#644])
 
 ### Changed
-- Zeroize is now optional ([#644])
-- Bump `aead` from `0.5` to `0.6` ([#583])
-- Bump `aes` from `0.8` to `0.9` ([#583])
+- Make `zeroize` optional ([#644])
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
 - Relax MSRV policy and allow MSRV bumps in patch releases
-- `getrandom` feature renamed as `os_rng` ([#662])
+- Migrate to `AeadInOut` ([#665])
+- Bump `aes` v0.9 ([#821])
+- Bump `aead` to v0.6 ([#831])
 
-## Removed
+### Removed
 - `std` and `stream` features ([#662])
 
 [#467]: https://github.com/RustCrypto/AEADs/pull/467
 [#503]: https://github.com/RustCrypto/AEADs/pull/503
-[#583]: https://github.com/RustCrypto/AEADs/pull/583
+[#631]: https://github.com/RustCrypto/AEADs/pull/631
 [#644]: https://github.com/RustCrypto/AEADs/pull/644
 [#662]: https://github.com/RustCrypto/AEADs/pull/662
+[#665]: https://github.com/RustCrypto/AEADs/pull/665
+[#821]: https://github.com/RustCrypto/AEADs/pull/821
+[#831]: https://github.com/RustCrypto/AEADs/pull/831
 
 ## 0.1.0 (2022-07-30)
 ### Added

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deoxys"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 description = """
 Pure Rust implementation of the Deoxys Authenticated Encryption with Associated
 Data (AEAD) cipher, including the Deoxys-II variant which was selected by the


### PR DESCRIPTION
## Added
- `rand_core` feature ([#467])
- `arrayvec` feature ([#503])
- `bytes` feature ([#631])
- `zeroize` feature ([#644])

## Changed
- Make `zeroize` optional ([#644])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#662])
- Relax MSRV policy and allow MSRV bumps in patch releases
- Migrate to `AeadInOut` ([#665])
- Bump `aes` v0.9 ([#821])
- Bump `aead` to v0.6 ([#831])

## Removed
- `std` and `stream` features ([#662])

[#467]: https://github.com/RustCrypto/AEADs/pull/467
[#503]: https://github.com/RustCrypto/AEADs/pull/503
[#631]: https://github.com/RustCrypto/AEADs/pull/631
[#644]: https://github.com/RustCrypto/AEADs/pull/644
[#662]: https://github.com/RustCrypto/AEADs/pull/662
[#665]: https://github.com/RustCrypto/AEADs/pull/665
[#821]: https://github.com/RustCrypto/AEADs/pull/821
[#831]: https://github.com/RustCrypto/AEADs/pull/831