### PR TITLE
ocb3: remove unused `ctr` and `zeroize` dependencies

### DIFF
--- a/.github/workflows/ocb3.yml
+++ b/.github/workflows/ocb3.yml
@@ -69,7 +69,6 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }} --lib --no-default-features
       - run: cargo test --target ${{ matrix.target }} --lib
-      - run: cargo test --target ${{ matrix.target }} --lib --features zeroize
       - run: cargo test --target ${{ matrix.target }} --all-features --lib
       - run: cargo test --target ${{ matrix.target }} --all-features --release
       - run: cargo test --target ${{ matrix.target }} --all-features --doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,11 +375,9 @@ dependencies = [
  "aead-stream",
  "aes",
  "cipher",
- "ctr",
  "dbl",
  "hex-literal",
  "subtle",
- "zeroize",
 ]
 
 [[package]]

--- a/ocb3/Cargo.toml
+++ b/ocb3/Cargo.toml
@@ -18,11 +18,9 @@ rust-version = "1.85"
 [dependencies]
 aead = { version = "0.6", default-features = false }
 cipher = "0.5"
-ctr = "0.10"
 dbl = "0.5"
 subtle = { version = "2", default-features = false }
 aead-stream = { version = "0.6", optional = true, default-features = false }
-zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 aead = { version = "0.6", features = ["dev"], default-features = false }


### PR DESCRIPTION
They aren't actually used in the implementation