### PR TITLE
Cut releases that replace `subtle` with `ctutils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aead",
  "aes",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aead",
  "aes",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ascon-aead128"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aead",
  "ascon",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "belt-dwp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aead",
  "belt-block",
@@ -159,7 +159,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "ccm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aead",
  "aes",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "deoxys"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aead",
  "aes",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "eax"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aead",
  "aes",

--- a/aes-gcm-siv/CHANGELOG.md
+++ b/aes-gcm-siv/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 (2026-08-21)
+### Changed
+- Replace `subtle` with `ctutils` ([#879])
+
+[#879]: https://github.com/RustCrypto/AEADs/pull/879
+
 ## 0.12.0 (2026-08-04)
 ### Added
 - `rand_core` feature ([#467])

--- a/aes-gcm-siv/Cargo.toml
+++ b/aes-gcm-siv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm-siv"
-version = "0.12.0"
+version = "0.12.1"
 description = """
 Pure Rust implementation of the AES-GCM-SIV Misuse-Resistant Authenticated
 Encryption Cipher (RFC 8452) with optional architecture-specific

--- a/aes-gcm/CHANGELOG.md
+++ b/aes-gcm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.1 (2026-08-21)
+### Changed
+- Replace `subtle` with `ctutils` ([#879])
+
+[#879]: https://github.com/RustCrypto/AEADs/pull/879
+
 ## 0.11.0 (2026-06-28)
 ### Added
 - `bytes` feature passthrough ([#631])

--- a/aes-gcm/Cargo.toml
+++ b/aes-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-gcm"
-version = "0.11.0"
+version = "0.11.1"
 description = """
 Pure Rust implementation of the AES-GCM (Galois/Counter Mode)
 Authenticated Encryption with Associated Data (AEAD) Cipher

--- a/ascon-aead128/CHANGELOG.md
+++ b/ascon-aead128/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2026-08-21)
+### Changed
+- Replace `subtle` with `ctutils` ([#879])
+
+[#879]: https://github.com/RustCrypto/AEADs/pull/879
+
 ## 0.1.0 (2026-08-11)
 Initial release

--- a/ascon-aead128/Cargo.toml
+++ b/ascon-aead128/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon-aead128"
-version = "0.1.0"
+version = "0.1.1"
 description = "Implementation of the Ascon-AEAD128 authenticated encryption scheme"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/belt-dwp/CHANGELOG.md
+++ b/belt-dwp/CHANGELOG.md
@@ -4,5 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2026-08-21)
+### Changed
+- Replace `subtle` with `ctutils` ([#879])
+
+[#879]: https://github.com/RustCrypto/AEADs/pull/879
+
 ## 0.1.0 (2026-08-11)
 Initial release

--- a/belt-dwp/Cargo.toml
+++ b/belt-dwp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-dwp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Pure Rust implementation of the Belt-DWP authenticated encryption algorithm (STB 34.101.31-2020)"
 edition = "2024"
 license = "Apache-2.0 OR MIT"

--- a/ccm/CHANGELOG.md
+++ b/ccm/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (206-08-21)
+### Changed
+- Replace `subtle` with `ctutils` ([#879])
+
+[#879]: https://github.com/RustCrypto/AEADs/pull/879
+
 ## 0.6.0 (2026-08-12)
 ### Added
 - `rand_core` feature ([#467])

--- a/ccm/Cargo.toml
+++ b/ccm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccm"
-version = "0.6.0"
+version = "0.6.1"
 description = "Generic implementation of the Counter with CBC-MAC (CCM) mode"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/deoxys/CHANGELOG.md
+++ b/deoxys/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2026-08-21)
+### Changed
+- Replace `subtle` with `ctutils` ([#879])
+
+[#879]: https://github.com/RustCrypto/AEADs/pull/879
+
 ## 0.2.0 (2026-08-12)
 ### Added
 - `rand_core` feature ([#467])

--- a/deoxys/Cargo.toml
+++ b/deoxys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deoxys"
-version = "0.2.0"
+version = "0.2.1"
 description = """
 Pure Rust implementation of the Deoxys Authenticated Encryption with Associated
 Data (AEAD) cipher, including the Deoxys-II variant which was selected by the

--- a/eax/CHANGELOG.md
+++ b/eax/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2026-08-21)
+### Changed
+- Replace `subtle` with `ctutils` ([#879])
+
+[#879]: https://github.com/RustCrypto/AEADs/pull/879
+
 ## 0.6.0 (2026-08-12)
 ### Added
 - `rand_core` feature ([#467])

--- a/eax/Cargo.toml
+++ b/eax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eax"
-version = "0.6.0"
+version = "0.6.1"
 description = """
 Pure Rust implementation of the EAX Authenticated Encryption with Associated Data (AEAD) Cipher with
 optional architecture-specific hardware acceleration. Implemented generically around block ciphers,


### PR DESCRIPTION
The initial `.0` releases of these crates still used `subtle` exclusively for the tag comparison and `ctutils` for everything else.

This cuts new releases with #879, a PR which switched from `subtle` to `ctutils`.

Releases the following:
- `aes-gcm` v0.11.1
- `aes-gcm-siv` v0.12.1
- `ascon-aead128` v0.1.1
- `belt-dwp` v0.1.1
- `ccm` v0.6.1
- `deoxys` v0.2.1
- `eax` v0.6.1